### PR TITLE
Update main with documentation in stable

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -1,4 +1,5 @@
 name: "docs-deploy"
+concurrency: "docs-deploy"
 
 on:
   push:
@@ -7,11 +8,17 @@ on:
     paths:
       - 'docs/**'
 
+  workflow_run:
+    branches: [ main ]
+    workflows: [ 'release' ]
+    types: [ completed ]
+
   workflow_dispatch:
 
 jobs:
   deploy:
     name: 📃 Deploy new version bunit.dev
+    if: github.ref == 'refs/heads/stable' || ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: windows-latest
     steps:
 


### PR DESCRIPTION
Hi @egil

This PR was created because the [docs-deploy](https://github.com/bUnit-dev/bUnit/actions/runs/799265259) failed to automatically merge stable into main.