### PR TITLE
Better error message from JSInterop when detecting an unconfigured module import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ List of added functionality in this release.
 
 List of fixes in this release.
 
+- Fixed JSInterop error message when trying to import an unconfigured module (#398).
+
 - Fixed issue where a registered fall-back service provider was not made available to resolve service dependencies of components under test. Thanks to [@dady8889](https://github.com/dady8889) for the reporting the issue.
 
 ## [1.1.5] - 2021-04-30

--- a/src/bunit.web/JSInterop/JSRuntimeUnhandledInvocationException.cs
+++ b/src/bunit.web/JSInterop/JSRuntimeUnhandledInvocationException.cs
@@ -53,22 +53,29 @@ namespace Bunit
 			sb.AppendLine("Configure bUnit's JSInterop to handle the call with following:");
 			sb.AppendLine();
 
-			if (invocation.IsVoidResultInvocation)
+			if (invocation.Identifier == "import")
 			{
-				sb.AppendLine($"    SetupVoid({GetArguments(invocation)})");
+				sb.AppendLine($"    SetupModule({GetArguments(invocation, includeIdentifier: false)})");
 			}
 			else
 			{
-				sb.AppendLine($"    Setup<{GetReturnTypeName(invocation.ResultType)}>({GetArguments(invocation)})");
-			}
-
-			if (invocation.Arguments.Any())
-			{
-				sb.AppendLine("or the following, to match any arguments:");
 				if (invocation.IsVoidResultInvocation)
-					sb.AppendLine($"    SetupVoid(\"{invocation.Identifier}\", _ => true)");
+				{
+					sb.AppendLine($"    SetupVoid({GetArguments(invocation)})");
+				}
 				else
-					sb.AppendLine($"    Setup<{GetReturnTypeName(invocation.ResultType)}>(\"{invocation.Identifier}\", _ => true)");
+				{
+					sb.AppendLine($"    Setup<{GetReturnTypeName(invocation.ResultType)}>({GetArguments(invocation)})");
+				}
+
+				if (invocation.Arguments.Any())
+				{
+					sb.AppendLine("or the following, to match any arguments:");
+					if (invocation.IsVoidResultInvocation)
+						sb.AppendLine($"    SetupVoid(\"{invocation.Identifier}\", _ => true)");
+					else
+						sb.AppendLine($"    Setup<{GetReturnTypeName(invocation.ResultType)}>(\"{invocation.Identifier}\", _ => true)");
+				}
 			}
 
 			sb.AppendLine();
@@ -113,11 +120,14 @@ namespace Bunit
 			}
 		}
 
-		private static string GetArguments(JSRuntimeInvocation invocation)
+		private static string GetArguments(JSRuntimeInvocation invocation, bool includeIdentifier = true)
 		{
 			var args = invocation.Arguments
-				.Select(x => x is string s ? $"\"{s}\"" : x?.ToString() ?? "null")
-				.Prepend($"\"{invocation.Identifier}\"");
+				.Select(x => x is string s ? $"\"{s}\"" : x?.ToString() ?? "null");
+			if (includeIdentifier)
+			{
+				args = args.Prepend($"\"{invocation.Identifier}\"");
+			}
 
 			return string.Join(", ", args);
 		}

--- a/src/bunit.web/JSInterop/JSRuntimeUnhandledInvocationException.cs
+++ b/src/bunit.web/JSInterop/JSRuntimeUnhandledInvocationException.cs
@@ -13,6 +13,8 @@ namespace Bunit
 	[Serializable]
 	public sealed class JSRuntimeUnhandledInvocationException : Exception
 	{
+		private const string DefaultImportIdentifier = "import";
+
 		/// <summary>
 		/// Gets the unplanned invocation.
 		/// </summary>
@@ -53,7 +55,7 @@ namespace Bunit
 			sb.AppendLine("Configure bUnit's JSInterop to handle the call with following:");
 			sb.AppendLine();
 
-			if (invocation.Identifier == "import")
+			if (invocation.Identifier == DefaultImportIdentifier)
 			{
 				sb.AppendLine($"    SetupModule({GetArguments(invocation, includeIdentifier: false)})");
 			}

--- a/tests/bunit.web.tests/JSInterop/JSRuntimeUnhandledInvocationExceptionTest.cs
+++ b/tests/bunit.web.tests/JSInterop/JSRuntimeUnhandledInvocationExceptionTest.cs
@@ -295,6 +295,22 @@ namespace Bunit.JSInterop
 			Assert.Equal(exectedErrorMessage, sut.Message);
 		}
 
+		[Theory(DisplayName = "Message prints prints correctly when trying to import an unconfigured module")]
+		[AutoData]
+		public void Test036(string moduleName)
+		{
+			var identifier = "import";
+			var returnType = typeof(void);
+			var invocationMethodName = "InvokeAsync";
+			var exectedErrorMessage = CreateExpectedErrorMessage(
+				$"{CodeIdent}{invocationMethodName}<{returnType.Name}>(\"{identifier}\", \"{moduleName}\")",
+				$"{CodeIdent}SetupModule(\"{moduleName}\")");
+
+			var sut = new JSRuntimeUnhandledInvocationException(new JSRuntimeInvocation(identifier, new object?[] { moduleName }, returnType, invocationMethodName));
+
+			Assert.Equal(exectedErrorMessage, sut.Message);
+		}
+
 		public class Dummy1 { }
 		public class Dummy2 { }
 		public class Dummy3 { }


### PR DESCRIPTION
## Pull request description
Fixes #398.
Personalize JSInterop error message when trying to import an unconfigured module.

### PR meta checklist
- [X] Pull request is targeted at `main` branch for code   
  or targeted at `stable` branch for documentation that is live on bunit.dev.
- [X] Pull request is linked to all related issues, if any.
- [X] I have read the _CONTRIBUTING.md_ document.

### Code PR specific checklist
- [X] My code follows the code style of this project and AspNetCore coding guidelines.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [X] I have updated the appropriate sub section in the _CHANGELOG.md_.
- [X] I have added, updated or removed tests to according to my changes.
  - [X] All tests passed.
