### PR TITLE
Markup matches combinations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ All notable changes to **bUnit** will be documented in this file. The project ad
 ### Added
 
 List of added functionality in this release.
+- Added more extensions methods to MarkupMatchesAssertExtensions to allow asserting on MarkupMatches from IEnumerable and IElement. By [@jgoday](https://github.com/jgoday).
+
 - Added `BunitErrorBoundaryLogger` impl of Microsoft.AspNetCore.Components.Web.IErrorBoundaryLogger` (needed for Blazor ErrorBoundary component, from net6.0). By [@jgoday](https://github.com/jgoday).
 
 - Added `ComponentFactories` property to the `TestContextBase` type. The `ComponentFactories` property is a `ComponentFactoryCollection` type that contains `IComponentFactory` types. These are used by bUnits component activator, whenever a component is created during testing. If no component factories is added to the collection, the standard component activator mechanism from Blazor is used. This feature makes it possible to control what components are created normally during a test, and which should be e.g. replaced by a test dummy. More info is available in issue [#388](https://github.com/bUnit-dev/bUnit/issues/388).  

--- a/src/bunit.web/Asserting/MarkupMatchesAssertExtensions.cs
+++ b/src/bunit.web/Asserting/MarkupMatchesAssertExtensions.cs
@@ -352,78 +352,83 @@ namespace Bunit
 		}
 
 		/// <summary>
-		/// Verifies that the rendered markup from the <paramref name="actualElements"/> elements
+		/// Verifies that the rendered markup from the <paramref name="actual"/> elements
 		/// the <paramref name="expected"/> markup fragment, using the <see cref="HtmlComparer"/> type.
 		/// </summary>
-		/// <exception cref="HtmlEqualException">Thrown when the <paramref name="actualElements"/> markup does not match the <paramref name="expected"/> markup.</exception>
-		/// <param name="actualElements">A enumerable of IElements to verifiy.</param>
+		/// <exception cref="HtmlEqualException">Thrown when the <paramref name="actual"/> markup does not match the <paramref name="expected"/> markup.</exception>
+		/// <param name="actual">A enumerable of IElements to verifiy.</param>
 		/// <param name="expected">The expected markup fragment.</param>
 		/// <param name="userMessage">A custom user message to display in case the verification fails.</param>
 		[AssertionMethod]
-		public static void MarkupMatches(this IEnumerable<IElement> actualElements, string expected, string? userMessage = null)
+		public static void MarkupMatches(this IEnumerable<IElement> actual, string expected, string? userMessage = null)
 		{
-			if (actualElements is null)
-				throw new ArgumentNullException(nameof(actualElements));
+			if (actual is null)
+				throw new ArgumentNullException(nameof(actual));
 			if (expected is null)
 				throw new ArgumentNullException(nameof(expected));
 
-			using var parser = new BunitHtmlParser();
-			var nodesStr = string.Join(
-				string.Empty,
-				actualElements.Select(s => s.OuterHtml));
-			var actualNodes = nodesStr.ToNodeList(parser);
-			var expectedNodes = parser.Parse(expected);
-			actualNodes.MarkupMatches(expectedNodes, userMessage);
+			MarkupMatches(actual.ToNodeList(), expected, userMessage);
 		}
 
 		/// <summary>
-		/// Verifies that the rendered markup from the <paramref name="actualElements"/> elements
-		/// the <paramref name="expected"/> markup fragment, using the <see cref="HtmlComparer"/> type.
+		/// Verifies that the rendered markup from the <paramref name="actual"/> element matches
+		/// the <paramref name="expected"/> fragments, using the <see cref="HtmlComparer"/> type.
 		/// </summary>
-		/// <exception cref="HtmlEqualException">Thrown when the <paramref name="actualElements"/> markup does not match the <paramref name="expected"/> markup.</exception>
-		/// <param name="actualElements">A enumerable of IElements to verifiy.</param>
-		/// <param name="expected">The render fragment whose output to compare against.</param>
+		/// <exception cref="HtmlEqualException">Thrown when the <paramref name="actual"/> element does not match the <paramref name="expected"/> fragments.</exception>
+		/// <param name="actual">An IElement to verifiy.</param>
+		/// <param name="expected">The expected markup fragments.</param>
 		/// <param name="userMessage">A custom user message to display in case the verification fails.</param>
 		[AssertionMethod]
-		public static void MarkupMatches(this IEnumerable<IElement> actualElements, IRenderedFragment expected, string? userMessage = null)
+		public static void MarkupMatches(this IElement actual, IEnumerable<IRenderedFragment> expected, string? userMessage = null)
 		{
-			if (actualElements is null)
-				throw new ArgumentNullException(nameof(actualElements));
+			if (actual is null)
+				throw new ArgumentNullException(nameof(actual));
 			if (expected is null)
 				throw new ArgumentNullException(nameof(expected));
 
-			using var parser = new BunitHtmlParser();
-			var nodesStr = string.Join(
-				string.Empty,
-				actualElements.Select(s => s.OuterHtml));
-			var actualNodes = nodesStr.ToNodeList(parser);
-			actualNodes.MarkupMatches(expected.Nodes, userMessage);
+			var expectedNodes = string.Join(string.Empty, expected.Select(e => e.Markup));
+
+			MarkupMatches(actual, expectedNodes, userMessage);
 		}
 
 		/// <summary>
-		/// Verifies that the rendered markup from the <paramref name="actualElements"/> elements
-		/// the <paramref name="expected"/> markup fragment, using the <see cref="HtmlComparer"/> type.
+		/// Verifies that the rendered markup from the <paramref name="actual"/> elements matches
+		/// the <paramref name="expected"/> fragment, using the <see cref="HtmlComparer"/> type.
 		/// </summary>
-		/// <exception cref="HtmlEqualException">Thrown when the <paramref name="actualElements"/> markup does not match the <paramref name="expected"/> markup.</exception>
-		/// <param name="actualElements">A enumerable of IElements to verifiy.</param>
-		/// <param name="expected">The render fragment whose output to compare against.</param>
+		/// <exception cref="HtmlEqualException">Thrown when the <paramref name="actual"/> element does not match the <paramref name="expected"/> fragments.</exception>
+		/// <param name="actual">A list of elements to verifiy.</param>
+		/// <param name="expected">The expected markup fragment.</param>
 		/// <param name="userMessage">A custom user message to display in case the verification fails.</param>
 		[AssertionMethod]
-		public static void MarkupMatches(this IEnumerable<IElement> actualElements, RenderFragment expected, string? userMessage = null)
+		public static void MarkupMatches(this IEnumerable<IElement> actual, IRenderedFragment expected, string? userMessage = null)
 		{
-			if (actualElements is null)
-				throw new ArgumentNullException(nameof(actualElements));
+			if (actual is null)
+				throw new ArgumentNullException(nameof(actual));
 			if (expected is null)
 				throw new ArgumentNullException(nameof(expected));
 
-			using var parser = new BunitHtmlParser();
-			var nodesStr = string.Join(
-				string.Empty,
-				actualElements.Select(s => s.OuterHtml));
-			var actualNodes = nodesStr.ToNodeList(parser);
-			var renderedFragment = actualNodes.GetTestContext()?.RenderInsideRenderTree(expected) as IRenderedFragment
-				?? AdhocRenderRenderFragment(expected);
-			actualNodes.MarkupMatches(renderedFragment, userMessage);
+			MarkupMatches(actual.ToNodeList(), expected, userMessage);
+		}
+
+		/// <summary>
+		/// Verifies that the rendered markup from the <paramref name="actual"/> elements matches
+		/// the <paramref name="expected"/> fragments, using the <see cref="HtmlComparer"/> type.
+		/// </summary>
+		/// <exception cref="HtmlEqualException">Thrown when the <paramref name="actual"/> elements does not match the <paramref name="expected"/> fragments.</exception>
+		/// <param name="actual">A list of elements to verify.</param>
+		/// <param name="expected">A list of fragments.</param>
+		/// <param name="userMessage">A custom user message to display in case the verification fails.</param>
+		[AssertionMethod]
+		public static void MarkupMatches(this IEnumerable<IElement> actual, IEnumerable<IRenderedFragment> expected, string? userMessage = null)
+		{
+			if (actual is null)
+				throw new ArgumentNullException(nameof(actual));
+			if (expected is null)
+				throw new ArgumentNullException(nameof(expected));
+
+			var expectedNodes = string.Join(string.Empty, expected.Select(e => e.Markup));
+
+			MarkupMatches(actual.ToNodeList(), expectedNodes, userMessage);
 		}
 
 		private static IRenderedFragment AdhocRenderRenderFragment(this RenderFragment renderFragment)
@@ -441,6 +446,21 @@ namespace Bunit
 			}
 
 			return htmlParser.Parse(markup);
+		}
+
+		private static INodeList ToNodeList(this IEnumerable<IElement> elements, BunitHtmlParser? htmlParser = null)
+		{
+			var nodesStr = string.Join(string.Empty, elements.Select(s => s.OuterHtml));
+
+			if (htmlParser is null)
+			{
+				using var parser = new BunitHtmlParser();
+				return nodesStr.ToNodeList(parser);
+			}
+			else
+			{
+				return nodesStr.ToNodeList(htmlParser);
+			}
 		}
 	}
 }

--- a/src/bunit.web/Asserting/MarkupMatchesAssertExtensions.cs
+++ b/src/bunit.web/Asserting/MarkupMatchesAssertExtensions.cs
@@ -393,9 +393,30 @@ namespace Bunit
 
 		/// <summary>
 		/// Verifies that the rendered markup from the <paramref name="actual"/> elements matches
+		/// the <paramref name="expected"/> elements, using the <see cref="HtmlComparer"/> type.
+		/// </summary>
+		/// <exception cref="HtmlEqualException">Thrown when the <paramref name="actual"/> element does not match the <paramref name="expected"/> elements.</exception>
+		/// <param name="actual">An element to verify.</param>
+		/// <param name="expected">A list of elements.</param>
+		/// <param name="userMessage">A custom user message to display in case the verification fails.</param>
+		[AssertionMethod]
+		public static void MarkupMatches(this IElement actual, IEnumerable<IElement> expected, string? userMessage = null)
+		{
+			if (actual is null)
+				throw new ArgumentNullException(nameof(actual));
+			if (expected is null)
+				throw new ArgumentNullException(nameof(expected));
+
+			var expectedNodes = expected.ToNodeList();
+
+			MarkupMatches(actual, expectedNodes, userMessage);
+		}
+
+		/// <summary>
+		/// Verifies that the rendered markup from the <paramref name="actual"/> elements matches
 		/// the <paramref name="expected"/> fragment, using the <see cref="HtmlComparer"/> type.
 		/// </summary>
-		/// <exception cref="HtmlEqualException">Thrown when the <paramref name="actual"/> element does not match the <paramref name="expected"/> fragments.</exception>
+		/// <exception cref="HtmlEqualException">Thrown when the <paramref name="actual"/> elements does not match the <paramref name="expected"/> fragment.</exception>
 		/// <param name="actual">A list of elements to verifiy.</param>
 		/// <param name="expected">The expected markup fragment.</param>
 		/// <param name="userMessage">A custom user message to display in case the verification fails.</param>

--- a/src/bunit.web/Asserting/MarkupMatchesAssertExtensions.cs
+++ b/src/bunit.web/Asserting/MarkupMatchesAssertExtensions.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using AngleSharp.Dom;
 using Bunit.Asserting;
 using Bunit.Diffing;
@@ -347,6 +349,81 @@ namespace Bunit
 			var renderedFragment = actual.GetTestContext()?.RenderInsideRenderTree(expected) as IRenderedFragment
 				?? AdhocRenderRenderFragment(expected);
 			MarkupMatches(actual, renderedFragment, userMessage);
+		}
+
+		/// <summary>
+		/// Verifies that the rendered markup from the <paramref name="actualElements"/> elements
+		/// the <paramref name="expected"/> markup fragment, using the <see cref="HtmlComparer"/> type.
+		/// </summary>
+		/// <exception cref="HtmlEqualException">Thrown when the <paramref name="actualElements"/> markup does not match the <paramref name="expected"/> markup.</exception>
+		/// <param name="actualElements">A enumerable of IElements to verifiy.</param>
+		/// <param name="expected">The expected markup fragment.</param>
+		/// <param name="userMessage">A custom user message to display in case the verification fails.</param>
+		[AssertionMethod]
+		public static void MarkupMatches(this IEnumerable<IElement> actualElements, string expected, string? userMessage = null)
+		{
+			if (actualElements is null)
+				throw new ArgumentNullException(nameof(actualElements));
+			if (expected is null)
+				throw new ArgumentNullException(nameof(expected));
+
+			using var parser = new BunitHtmlParser();
+			var nodesStr = string.Join(
+				string.Empty,
+				actualElements.Select(s => s.OuterHtml));
+			var actualNodes = nodesStr.ToNodeList(parser);
+			var expectedNodes = parser.Parse(expected);
+			actualNodes.MarkupMatches(expectedNodes, userMessage);
+		}
+
+		/// <summary>
+		/// Verifies that the rendered markup from the <paramref name="actualElements"/> elements
+		/// the <paramref name="expected"/> markup fragment, using the <see cref="HtmlComparer"/> type.
+		/// </summary>
+		/// <exception cref="HtmlEqualException">Thrown when the <paramref name="actualElements"/> markup does not match the <paramref name="expected"/> markup.</exception>
+		/// <param name="actualElements">A enumerable of IElements to verifiy.</param>
+		/// <param name="expected">The render fragment whose output to compare against.</param>
+		/// <param name="userMessage">A custom user message to display in case the verification fails.</param>
+		[AssertionMethod]
+		public static void MarkupMatches(this IEnumerable<IElement> actualElements, IRenderedFragment expected, string? userMessage = null)
+		{
+			if (actualElements is null)
+				throw new ArgumentNullException(nameof(actualElements));
+			if (expected is null)
+				throw new ArgumentNullException(nameof(expected));
+
+			using var parser = new BunitHtmlParser();
+			var nodesStr = string.Join(
+				string.Empty,
+				actualElements.Select(s => s.OuterHtml));
+			var actualNodes = nodesStr.ToNodeList(parser);
+			actualNodes.MarkupMatches(expected.Nodes, userMessage);
+		}
+
+		/// <summary>
+		/// Verifies that the rendered markup from the <paramref name="actualElements"/> elements
+		/// the <paramref name="expected"/> markup fragment, using the <see cref="HtmlComparer"/> type.
+		/// </summary>
+		/// <exception cref="HtmlEqualException">Thrown when the <paramref name="actualElements"/> markup does not match the <paramref name="expected"/> markup.</exception>
+		/// <param name="actualElements">A enumerable of IElements to verifiy.</param>
+		/// <param name="expected">The render fragment whose output to compare against.</param>
+		/// <param name="userMessage">A custom user message to display in case the verification fails.</param>
+		[AssertionMethod]
+		public static void MarkupMatches(this IEnumerable<IElement> actualElements, RenderFragment expected, string? userMessage = null)
+		{
+			if (actualElements is null)
+				throw new ArgumentNullException(nameof(actualElements));
+			if (expected is null)
+				throw new ArgumentNullException(nameof(expected));
+
+			using var parser = new BunitHtmlParser();
+			var nodesStr = string.Join(
+				string.Empty,
+				actualElements.Select(s => s.OuterHtml));
+			var actualNodes = nodesStr.ToNodeList(parser);
+			var renderedFragment = actualNodes.GetTestContext()?.RenderInsideRenderTree(expected) as IRenderedFragment
+				?? AdhocRenderRenderFragment(expected);
+			actualNodes.MarkupMatches(renderedFragment, userMessage);
 		}
 
 		private static IRenderedFragment AdhocRenderRenderFragment(this RenderFragment renderFragment)

--- a/tests/bunit.web.tests/Asserting/MarkupMatchesAssertExtensionsTest.cs
+++ b/tests/bunit.web.tests/Asserting/MarkupMatchesAssertExtensionsTest.cs
@@ -1,5 +1,6 @@
 using System;
 using AngleSharp.Dom;
+using Bunit.TestAssets.SampleComponents;
 using Microsoft.AspNetCore.Components;
 using Shouldly;
 using Xunit;
@@ -94,5 +95,22 @@ namespace Bunit.Asserting
 		[Fact(DisplayName = "MarkupMatches(INodeList, RenderFragment) correctly diffs markup")]
 		public void Test0010()
 			=> Should.Throw<HtmlEqualException>(() => ActualNodeList.MarkupMatches(ExpectedRenderFragment));
+
+		private IRenderedFragment FindAllRenderedFragment => Render(b => b.AddMarkupContent(0, "<div><p><strong>test</strong></p></div>"));
+		private string FindAllExpectedRenderFragment = "<p><strong>test</strong></p>";
+
+		[Fact(DisplayName = "MarkupMatches combination works with IRenderedFragment's FindAll extension method")]
+		public void Test011()
+		{
+			FindAllRenderedFragment.FindAll("p").MarkupMatches(FindAllExpectedRenderFragment);
+		}
+
+		[Fact(DisplayName = "MarkupMatches combination works with FindAll and FindComponents<T>")]
+		public void Test012()
+		{
+			var cut = RenderComponent<TwoChildren>();
+
+			cut.FindAll("p>*").MarkupMatches(cut.FindComponents<ClickCounter>());
+		}
 	}
 }

--- a/tests/bunit.web.tests/Asserting/MarkupMatchesAssertExtensionsTest.cs
+++ b/tests/bunit.web.tests/Asserting/MarkupMatchesAssertExtensionsTest.cs
@@ -108,9 +108,9 @@ namespace Bunit.Asserting
 		[Fact(DisplayName = "MarkupMatches combination works with FindAll and FindComponents<T>")]
 		public void Test012()
 		{
-			var cut = RenderComponent<TwoChildren>();
+			var cut = RenderComponent<RefToSimple1Child>();
 
-			cut.FindAll("p>*").MarkupMatches(cut.FindComponents<ClickCounter>());
+			cut.FindAll("h1").MarkupMatches(cut.FindComponents<Simple1>());
 		}
 	}
 }

--- a/tests/bunit.web.tests/Asserting/MarkupMatchesAssertExtensionsTest.cs
+++ b/tests/bunit.web.tests/Asserting/MarkupMatchesAssertExtensionsTest.cs
@@ -97,12 +97,12 @@ namespace Bunit.Asserting
 			=> Should.Throw<HtmlEqualException>(() => ActualNodeList.MarkupMatches(ExpectedRenderFragment));
 
 		private IRenderedFragment FindAllRenderedFragment => Render(b => b.AddMarkupContent(0, "<div><p><strong>test</strong></p></div>"));
-		private string FindAllExpectedRenderFragment = "<p><strong>test</strong></p>";
+		private readonly string findAllExpectedRenderFragment = "<p><strong>test</strong></p>";
 
 		[Fact(DisplayName = "MarkupMatches combination works with IRenderedFragment's FindAll extension method")]
 		public void Test011()
 		{
-			FindAllRenderedFragment.FindAll("p").MarkupMatches(FindAllExpectedRenderFragment);
+			FindAllRenderedFragment.FindAll("p").MarkupMatches(findAllExpectedRenderFragment);
 		}
 
 		[Fact(DisplayName = "MarkupMatches combination works with FindAll and FindComponents<T>")]

--- a/tests/bunit.web.tests/Asserting/MarkupMatchesAssertExtensionsTest.cs
+++ b/tests/bunit.web.tests/Asserting/MarkupMatchesAssertExtensionsTest.cs
@@ -112,5 +112,21 @@ namespace Bunit.Asserting
 
 			cut.FindAll("h1").MarkupMatches(cut.FindComponents<Simple1>());
 		}
+
+		[Fact(DisplayName = "MarkupMatches combination works with FindAll and a markup string")]
+		public void Test013()
+		{
+			var cut = RenderComponent<NoArgs>();
+
+			cut.FindAll("h1").MarkupMatches("<h1>Hello world</h1>");
+		}
+
+		[Fact(DisplayName = "MarkupMatches combination works with Find and FindAll")]
+		public void Test014()
+		{
+			var cut = RenderComponent<TwoChildren>();
+
+			cut.Find("div").MarkupMatches(cut.FindAll("div"));
+		}
 	}
 }


### PR DESCRIPTION
## Pull request description
Related to #422.
Add more extensions to MarkupMatchesAssertExtensions to allow asserting on MarkupMatches from IEnumerable<IElement> and IElement

### PR meta checklist
- [X] Pull request is targeted at `main` branch for code   
  or targeted at `stable` branch for documentation that is live on bunit.dev.
- [X] Pull request is linked to all related issues, if any.
- [X] I have read the _CONTRIBUTING.md_ document.

### Code PR specific checklist
- [X] My code follows the code style of this project and AspNetCore coding guidelines.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] I have updated the appropriate sub section in the _CHANGELOG.md_.
- [X] I have added, updated or removed tests to according to my changes.
  - [ ] All tests passed.
