### PR TITLE
Fix a typo about using incorrect component in the sample

### DIFF
--- a/docs/samples/tests/razor/RenderFragmentParams2Test.razor
+++ b/docs/samples/tests/razor/RenderFragmentParams2Test.razor
@@ -6,7 +6,7 @@
     using var ctx = new TestContext();
 
     var cut = ctx.Render(@<RenderFragmentParams>
-                            <Content><Alert /></Content>
+                            <Content><Counter /></Content>
                           </RenderFragmentParams>);
   }
 }


### PR DESCRIPTION
In the doc, it is clearly said that the child component is the Counter component, but in the .razor file sample, the child component used is the Alert component which is also different from the C# sample.