### PR TITLE
#361: Allow untyped JSInterop.Setup methods, that matches with any type

### DIFF
--- a/src/bunit.web/JSInterop/BunitJSInterop.cs
+++ b/src/bunit.web/JSInterop/BunitJSInterop.cs
@@ -16,7 +16,7 @@ namespace Bunit
 	public class BunitJSInterop
 	{
 		private readonly Dictionary<Type, List<object>> handlers = new();
-		private JSRuntimeInvocationHandler? genericHandler = null;
+		private JSRuntimeInvocationHandler? genericHandler;
 		private JSRuntimeMode mode;
 
 		/// <summary>
@@ -88,7 +88,7 @@ namespace Bunit
 
 			if (genericHandler != null && genericHandler.HandleAsync(invocation) is Task<object> res)
 			{
-				result = new ValueTask<TValue>(res.ContinueWith(r => (TValue) r.Result, TaskContinuationOptions.NotOnCanceled));
+				result = new ValueTask<TValue>(res.ContinueWith(r => (TValue) r.Result, System.Threading.CancellationToken.None, TaskContinuationOptions.NotOnCanceled, TaskScheduler.Default));
 			}
 			
 			return result;

--- a/src/bunit.web/JSInterop/BunitJSInteropSetupExtensions.cs
+++ b/src/bunit.web/JSInterop/BunitJSInteropSetupExtensions.cs
@@ -68,6 +68,40 @@ namespace Bunit
 			=> Setup<TResult>(jsInterop, _ => true, isCatchAllHandler: true);
 
 		/// <summary>
+		/// Configure an untyped JSInterop invocation handler passing the <paramref name="invocationMatcher"/> test.
+		/// </summary>
+		/// <param name="jsInterop">The bUnit JSInterop to setup the invocation handling with.</param>
+		/// <param name="invocationMatcher">A matcher that is passed an <see cref="JSRuntimeInvocation"/>. If it returns true the invocation is matched.</param>
+		/// <returns>A <see cref="UntypedJSRuntimeInvocationHandler"/>.</returns>
+		public static UntypedJSRuntimeInvocationHandler Setup(this BunitJSInterop jsInterop, InvocationMatcher invocationMatcher)
+		{
+			if (jsInterop is null)
+				throw new ArgumentNullException(nameof(jsInterop));
+			return new UntypedJSRuntimeInvocationHandler(jsInterop, invocationMatcher);
+		}
+
+		/// <summary>
+		/// Configure an untyped JSInterop invocation handler with the <paramref name="identifier"/> and arguments
+		/// passing the <paramref name="invocationMatcher"/> test.
+		/// </summary>
+		/// <param name="jsInterop">The bUnit JSInterop to setup the invocation handling with.</param>
+		/// <param name="identifier">The identifier to setup a response for.</param>
+		/// <param name="invocationMatcher">A matcher that is passed an <see cref="JSRuntimeInvocation"/> associated with  the<paramref name="identifier"/>. If it returns true the invocation is matched.</param>
+		/// <returns>A <see cref="UntypedJSRuntimeInvocationHandler"/>.</returns>
+		public static UntypedJSRuntimeInvocationHandler Setup(this BunitJSInterop jsInterop, string identifier, InvocationMatcher invocationMatcher)
+			=> Setup(jsInterop, inv => identifier.Equals(inv.Identifier, StringComparison.Ordinal) && invocationMatcher(inv));
+
+		/// <summary>
+		/// Configure an untyped JSInterop invocation handler with the <paramref name="identifier"/> and <paramref name="arguments"/>.
+		/// </summary>
+		/// <param name="jsInterop">The bUnit JSInterop to setup the invocation handling with.</param>
+		/// <param name="identifier">The identifier to setup a response for.</param>
+		/// <param name="arguments">The arguments that an invocation to <paramref name="identifier"/> should match.</param>
+		/// <returns>A <see cref="UntypedJSRuntimeInvocationHandler"/>.</returns>
+		public static UntypedJSRuntimeInvocationHandler Setup(this BunitJSInterop jsInterop, string identifier, params object?[]? arguments)
+			=> Setup(jsInterop, identifier, invocation => invocation.Arguments.SequenceEqual(arguments ?? Array.Empty<object?>()));
+
+		/// <summary>
 		/// Configure a JSInterop invocation handler for an <c>InvokeVoidAsync</c> call with arguments
 		/// passing the <paramref name="invocationMatcher"/> test, that should not receive any result.
 		/// </summary>

--- a/src/bunit.web/JSInterop/InvocationHandlers/JSRuntimeInvocationHandlerFactory.cs
+++ b/src/bunit.web/JSInterop/InvocationHandlers/JSRuntimeInvocationHandlerFactory.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Threading.Tasks;
+
+namespace Bunit.JSInterop.InvocationHandlers
+{
+    internal class JSRuntimeInvocationHandlerFactory<TResult, TException> : JSRuntimeInvocationHandler<TResult>
+        where TException : Exception
+    {
+        private readonly Func<JSRuntimeInvocation, TResult>? resultFactory;
+        private readonly Func<JSRuntimeInvocation, TException>? exceptionFactory;
+
+        public JSRuntimeInvocationHandlerFactory(Func<JSRuntimeInvocation, TResult>? rFactory, Func<JSRuntimeInvocation, TException>? eFactory, InvocationMatcher matcher, bool isCatchAllHandler) : base(matcher, isCatchAllHandler)
+        {
+            resultFactory = rFactory;
+            exceptionFactory = eFactory;
+        }
+
+        protected override internal Task<TResult> HandleAsync(JSRuntimeInvocation invocation)
+		{
+            if (exceptionFactory != null && exceptionFactory.Invoke(invocation) is TException t)
+            {
+                base.SetException<TException>(t);
+            }
+            else if (resultFactory != null && resultFactory.Invoke(invocation) is TResult res)
+            {
+                base.SetResult(res);
+            }
+            return base.HandleAsync(invocation);
+		}
+    }
+}

--- a/src/bunit.web/JSInterop/InvocationHandlers/JSRuntimeInvocationHandlerFactory.cs
+++ b/src/bunit.web/JSInterop/InvocationHandlers/JSRuntimeInvocationHandlerFactory.cs
@@ -3,29 +3,29 @@ using System.Threading.Tasks;
 
 namespace Bunit.JSInterop.InvocationHandlers
 {
-    internal class JSRuntimeInvocationHandlerFactory<TResult, TException> : JSRuntimeInvocationHandler<TResult>
-        where TException : Exception
-    {
-        private readonly Func<JSRuntimeInvocation, TResult>? resultFactory;
-        private readonly Func<JSRuntimeInvocation, TException>? exceptionFactory;
+	internal class JSRuntimeInvocationHandlerFactory<TResult, TException> : JSRuntimeInvocationHandler<TResult>
+		where TException : Exception
+	{
+		private readonly Func<JSRuntimeInvocation, TResult>? resultFactory;
+		private readonly Func<JSRuntimeInvocation, TException>? exceptionFactory;
 
-        public JSRuntimeInvocationHandlerFactory(Func<JSRuntimeInvocation, TResult>? rFactory, Func<JSRuntimeInvocation, TException>? eFactory, InvocationMatcher matcher, bool isCatchAllHandler) : base(matcher, isCatchAllHandler)
-        {
-            resultFactory = rFactory;
-            exceptionFactory = eFactory;
-        }
-
-        protected override internal Task<TResult> HandleAsync(JSRuntimeInvocation invocation)
+		public JSRuntimeInvocationHandlerFactory(Func<JSRuntimeInvocation, TResult>? rFactory, Func<JSRuntimeInvocation, TException>? eFactory, InvocationMatcher matcher, bool isCatchAllHandler) : base(matcher, isCatchAllHandler)
 		{
-            if (exceptionFactory != null && exceptionFactory.Invoke(invocation) is TException t)
-            {
-                base.SetException<TException>(t);
-            }
-            else if (resultFactory != null && resultFactory.Invoke(invocation) is TResult res)
-            {
-                base.SetResult(res);
-            }
-            return base.HandleAsync(invocation);
+			resultFactory = rFactory;
+			exceptionFactory = eFactory;
 		}
-    }
+
+		protected override internal Task<TResult> HandleAsync(JSRuntimeInvocation invocation)
+		{
+			if (exceptionFactory != null && exceptionFactory.Invoke(invocation) is TException t)
+			{
+				base.SetException<TException>(t);
+			}
+			else if (resultFactory != null && resultFactory.Invoke(invocation) is TResult res)
+			{
+				base.SetResult(res);
+			}
+			return base.HandleAsync(invocation);
+		}
+	}
 }

--- a/src/bunit.web/JSInterop/InvocationHandlers/UntypedJSRuntimeInvocationHandler.cs
+++ b/src/bunit.web/JSInterop/InvocationHandlers/UntypedJSRuntimeInvocationHandler.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Threading.Tasks;
+
+namespace Bunit.JSInterop.InvocationHandlers
+{
+    /// <summary>
+	/// Represents a handler for an invocation of a JavaScript function with specific arguments
+	/// that can return any type, depending on the SetResult/SetCancelled/SetException invocations.
+	/// </summary>
+    public class UntypedJSRuntimeInvocationHandler : JSRuntimeInvocationHandler
+    {
+        private readonly InvocationMatcher invocationMatcher;
+
+        private readonly BunitJSInterop jsInterop;
+
+        /// <summary>
+		/// Initializes a new instance of the <see cref="UntypedJSRuntimeInvocationHandler"/> class.
+		/// </summary>
+        /// <param name="interop">The bUnit JSInterop to setup the invocation handling with.</param>
+		/// <param name="matcher">An invocation matcher used to determine if the handler should handle an invocation.</param>
+		/// <param name="isCatchAllHandler">Set to true if this handler is a catch all handler, that should only be used if there are no other non-catch all handlers available.</param>
+        public UntypedJSRuntimeInvocationHandler(BunitJSInterop interop, InvocationMatcher matcher, bool isCatchAllHandler = true)
+            : base(matcher, isCatchAllHandler)
+        {
+            jsInterop = interop;
+            invocationMatcher = matcher ?? throw new ArgumentNullException(nameof(matcher));
+        }
+
+		/// <summary>
+		/// Sets the result factory function, that when invoked sets the <typeparamref name="TReturnType"/> result that invocations will receive.
+		/// </summary>
+		/// <param name="resultFactory">The result factory function that creates the handler result.</param>
+		/// <returns>This handler to allow calls to be chained.</returns>
+        public JSRuntimeInvocationHandler<TReturnType> SetResult<TReturnType>(Func<JSRuntimeInvocation, TReturnType> resultFactory)
+        {
+            var handler = new JSRuntimeInvocationHandlerFactory<TReturnType, Exception>(resultFactory, null, invocationMatcher, IsCatchAllHandler);
+
+            jsInterop.AddInvocationHandler<TReturnType>(handler);
+
+            return handler;
+        }
+
+		/// <summary>
+		/// Marks the <see cref="Task"/> that invocations will receive as canceled.
+		/// </summary>
+		/// <returns>This handler to allow calls to be chained.</returns>
+        public JSRuntimeInvocationHandler<TReturnType> SetCanceled<TReturnType>()
+        {
+            var handler = new JSRuntimeInvocationHandler<TReturnType>(invocationMatcher, IsCatchAllHandler);
+            handler.SetCanceled();
+
+            jsInterop.AddInvocationHandler<TReturnType>(handler);
+
+            return handler;
+        }
+
+		/// <summary>
+		/// Sets the exception factory, that when invoked determines the <typeparamref name="TException"/> exception that invocations will receive.
+		/// </summary>
+		/// <param name="exceptionFactory">The exception function factory to set.</param>
+		/// <returns>This handler to allow calls to be chained.</returns>
+        public JSRuntimeInvocationHandler<TReturnType> SetException<TReturnType, TException>(Func<JSRuntimeInvocation, TException> exceptionFactory) where TException : Exception
+        {
+            var handler = new JSRuntimeInvocationHandlerFactory<TReturnType, TException>(null, exceptionFactory, invocationMatcher, IsCatchAllHandler);
+
+            jsInterop.AddInvocationHandler<TReturnType>(handler);
+
+            return handler;
+        }
+    }
+}

--- a/src/bunit.web/JSInterop/InvocationHandlers/UntypedJSRuntimeInvocationHandler.cs
+++ b/src/bunit.web/JSInterop/InvocationHandlers/UntypedJSRuntimeInvocationHandler.cs
@@ -3,69 +3,69 @@ using System.Threading.Tasks;
 
 namespace Bunit.JSInterop.InvocationHandlers
 {
-    /// <summary>
+	/// <summary>
 	/// Represents a handler for an invocation of a JavaScript function with specific arguments
 	/// that can return any type, depending on the SetResult/SetCancelled/SetException invocations.
 	/// </summary>
-    public class UntypedJSRuntimeInvocationHandler : JSRuntimeInvocationHandler
-    {
-        private readonly InvocationMatcher invocationMatcher;
+	public class UntypedJSRuntimeInvocationHandler : JSRuntimeInvocationHandler
+	{
+		private readonly InvocationMatcher invocationMatcher;
 
-        private readonly BunitJSInterop jsInterop;
+		private readonly BunitJSInterop jsInterop;
 
-        /// <summary>
+		/// <summary>
 		/// Initializes a new instance of the <see cref="UntypedJSRuntimeInvocationHandler"/> class.
 		/// </summary>
-        /// <param name="interop">The bUnit JSInterop to setup the invocation handling with.</param>
+		/// <param name="interop">The bUnit JSInterop to setup the invocation handling with.</param>
 		/// <param name="matcher">An invocation matcher used to determine if the handler should handle an invocation.</param>
 		/// <param name="isCatchAllHandler">Set to true if this handler is a catch all handler, that should only be used if there are no other non-catch all handlers available.</param>
-        public UntypedJSRuntimeInvocationHandler(BunitJSInterop interop, InvocationMatcher matcher, bool isCatchAllHandler = true)
-            : base(matcher, isCatchAllHandler)
-        {
-            jsInterop = interop;
-            invocationMatcher = matcher ?? throw new ArgumentNullException(nameof(matcher));
-        }
+		public UntypedJSRuntimeInvocationHandler(BunitJSInterop interop, InvocationMatcher matcher, bool isCatchAllHandler = true)
+			: base(matcher, isCatchAllHandler)
+		{
+			jsInterop = interop;
+			invocationMatcher = matcher ?? throw new ArgumentNullException(nameof(matcher));
+		}
 
 		/// <summary>
 		/// Sets the result factory function, that when invoked sets the <typeparamref name="TReturnType"/> result that invocations will receive.
 		/// </summary>
 		/// <param name="resultFactory">The result factory function that creates the handler result.</param>
 		/// <returns>This handler to allow calls to be chained.</returns>
-        public JSRuntimeInvocationHandler<TReturnType> SetResult<TReturnType>(Func<JSRuntimeInvocation, TReturnType> resultFactory)
-        {
-            var handler = new JSRuntimeInvocationHandlerFactory<TReturnType, Exception>(resultFactory, null, invocationMatcher, IsCatchAllHandler);
+		public JSRuntimeInvocationHandler<TReturnType> SetResult<TReturnType>(Func<JSRuntimeInvocation, TReturnType> resultFactory)
+		{
+			var handler = new JSRuntimeInvocationHandlerFactory<TReturnType, Exception>(resultFactory, null, invocationMatcher, IsCatchAllHandler);
 
-            jsInterop.AddInvocationHandler<TReturnType>(handler);
+			jsInterop.AddInvocationHandler<TReturnType>(handler);
 
-            return handler;
-        }
+			return handler;
+		}
 
 		/// <summary>
 		/// Marks the <see cref="Task"/> that invocations will receive as canceled.
 		/// </summary>
 		/// <returns>This handler to allow calls to be chained.</returns>
-        public JSRuntimeInvocationHandler<TReturnType> SetCanceled<TReturnType>()
-        {
-            var handler = new JSRuntimeInvocationHandler<TReturnType>(invocationMatcher, IsCatchAllHandler);
-            handler.SetCanceled();
+		public JSRuntimeInvocationHandler<TReturnType> SetCanceled<TReturnType>()
+		{
+			var handler = new JSRuntimeInvocationHandler<TReturnType>(invocationMatcher, IsCatchAllHandler);
+			handler.SetCanceled();
 
-            jsInterop.AddInvocationHandler<TReturnType>(handler);
+			jsInterop.AddInvocationHandler<TReturnType>(handler);
 
-            return handler;
-        }
+			return handler;
+		}
 
 		/// <summary>
 		/// Sets the exception factory, that when invoked determines the <typeparamref name="TException"/> exception that invocations will receive.
 		/// </summary>
 		/// <param name="exceptionFactory">The exception function factory to set.</param>
 		/// <returns>This handler to allow calls to be chained.</returns>
-        public JSRuntimeInvocationHandler<TReturnType> SetException<TReturnType, TException>(Func<JSRuntimeInvocation, TException> exceptionFactory) where TException : Exception
-        {
-            var handler = new JSRuntimeInvocationHandlerFactory<TReturnType, TException>(null, exceptionFactory, invocationMatcher, IsCatchAllHandler);
+		public JSRuntimeInvocationHandler<TReturnType> SetException<TReturnType, TException>(Func<JSRuntimeInvocation, TException> exceptionFactory) where TException : Exception
+		{
+			var handler = new JSRuntimeInvocationHandlerFactory<TReturnType, TException>(null, exceptionFactory, invocationMatcher, IsCatchAllHandler);
 
-            jsInterop.AddInvocationHandler<TReturnType>(handler);
+			jsInterop.AddInvocationHandler<TReturnType>(handler);
 
-            return handler;
-        }
-    }
+			return handler;
+		}
+	}
 }

--- a/src/bunit.web/JSInterop/InvocationHandlers/UntypedJSRuntimeInvocationHandler.cs
+++ b/src/bunit.web/JSInterop/InvocationHandlers/UntypedJSRuntimeInvocationHandler.cs
@@ -13,7 +13,7 @@ namespace Bunit.JSInterop.InvocationHandlers
 
 		private readonly BunitJSInterop jsInterop;
 
-		private JSRuntimeInvocation? currentInvocation = null;
+		private JSRuntimeInvocation? currentInvocation;
 
 		/// <summary>
 		/// Initializes a new instance of the <see cref="UntypedJSRuntimeInvocationHandler"/> class.
@@ -37,6 +37,11 @@ namespace Bunit.JSInterop.InvocationHandlers
 		/// <returns>This handler to allow calls to be chained.</returns>
 		public JSRuntimeInvocationHandler SetResult<TReturnType>(Func<JSRuntimeInvocation, TReturnType> resultFactory)
 		{
+			if (resultFactory == null)
+			{
+				throw new ArgumentNullException(nameof(resultFactory));
+			}
+
 			if (currentInvocation != null && resultFactory.Invoke(currentInvocation.Value) is TReturnType res)
 			{
 				base.SetResultBase(res);
@@ -59,6 +64,11 @@ namespace Bunit.JSInterop.InvocationHandlers
 		/// <returns>This handler to allow calls to be chained.</returns>
 		public JSRuntimeInvocationHandler SetException<TReturnType, TException>(Func<JSRuntimeInvocation, TException> exceptionFactory) where TException : Exception
 		{
+			if (exceptionFactory == null)
+			{
+				throw new ArgumentNullException(nameof(exceptionFactory));
+			}
+
 			if (currentInvocation != null && exceptionFactory.Invoke(currentInvocation.Value) is TException excp)
 			{
 				base.SetException(excp);

--- a/tests/bunit.web.tests/JSInterop/BunitJSInteropTest.cs
+++ b/tests/bunit.web.tests/JSInterop/BunitJSInteropTest.cs
@@ -511,5 +511,49 @@ namespace Bunit.JSInterop
 			exception.Invocation.Identifier.ShouldBe(identifier);
 			exception.Invocation.Arguments.ShouldBe(args);
 		}
+
+		[Fact(DisplayName = "Untyped setup can return a typed result from a factory function")]
+		public async Task Test059()
+		{
+			var sut = CreateSut(JSRuntimeMode.Strict);
+			var identifier = "func";
+
+			var jsRuntime = sut.JSRuntime;
+
+			var handler = sut.Setup(i => i.Identifier == identifier);
+			handler.SetResult(_ => false);
+
+			var i1 = await jsRuntime.InvokeAsync<bool>(identifier);
+			i1.ShouldBe(false);
+		}
+
+		[Fact(DisplayName = "Untyped setup can throw an exception from a factory function")]
+		public void Test060()
+		{
+			var sut = CreateSut(JSRuntimeMode.Strict);
+			var identifier = "func";
+
+			var jsRuntime = sut.JSRuntime;
+
+			var handler = sut.Setup(i => i.Identifier == identifier);
+			handler.SetException<bool, NotImplementedException>(_ => throw new NotImplementedException());
+
+			Should.Throw<NotImplementedException>(async () => await jsRuntime.InvokeAsync<bool>(identifier));
+		}
+
+		[Fact(DisplayName = "An untyped invocation handler can be canceled")]
+		public void Test061()
+		{
+			var sut = CreateSut(JSRuntimeMode.Strict);
+			var identifier = "func";
+
+			var jsRuntime = sut.JSRuntime;
+
+			var handler = sut.Setup(i => i.Identifier == identifier);
+			handler.SetCanceled<bool>();
+
+			var res = jsRuntime.InvokeAsync<bool>(identifier);
+			res.IsCanceled.ShouldBeTrue();
+		}
 	}
 }

--- a/tests/bunit.web.tests/JSInterop/BunitJSInteropTest.cs
+++ b/tests/bunit.web.tests/JSInterop/BunitJSInteropTest.cs
@@ -550,10 +550,26 @@ namespace Bunit.JSInterop
 			var jsRuntime = sut.JSRuntime;
 
 			var handler = sut.Setup(i => i.Identifier == identifier);
-			handler.SetCanceled<bool>();
+			handler.SetCanceled();
 
 			var res = jsRuntime.InvokeAsync<bool>(identifier);
 			res.IsCanceled.ShouldBeTrue();
+		}
+
+		[Fact(DisplayName = "Untyped supports setting result after invocation")]
+		public async Task Test062()
+		{
+			var sut = CreateSut(JSRuntimeMode.Strict);
+			var identifier = "func";
+			var jsRuntime = sut.JSRuntime;
+
+			var handler = sut.Setup(i => i.Identifier == identifier);
+
+			var i1 = jsRuntime.InvokeAsync<bool>(identifier);
+
+			handler.SetResult(_ => false);
+
+			(await i1).ShouldBe(false);
 		}
 	}
 }


### PR DESCRIPTION
## Pull request description
<!--- 
    Describe the changes and motivation behind them here, if it is not obvious
    from the related issues. Does it have new features, breaking changes, etc. 
-->
Fixes #361.

It defines new non-generic **Setup** methods on _BunitJSInteropSetupExtensions_, that returns an _UntypedJSRuntimeInvocationHandler_, who is responsible to create typed _JSRuntimeInvocationHandler_ (JSRuntimeInvocationHandlerFactory) from factory functions (SetResult/SetException/SetCanceled).

Factory functions are defined as _Func<JSRuntimeInvocation, T>_.

A review of _UntypedJSruntimeInvocationHandler_/_JSRuntimeInvocationHandlerFactory_ correct names would be necessary.

* Would it be correct to create a _JSRuntimeFactoryFunction_ delegate instead of 'Func<JSruntimeInvocation, T> ?
```csharp
public delegate T JSRuntimeFunctionFactory<T>(JSRuntimeInvocation invocation);
```
**UntypedJSruntimeInvocationHandler** is created from the non-generic setup extension method,
and allow us to return a typed handler from a factory function.

**JSRuntimeInvocationHandlerFactory** is based on _JSRuntimeInvocationHandler<T>_,
is created from _UntypedJSRuntimeInvocationHandler.SetResult(FactoryFunction)_ or _UntypedJSRuntimeInvocationHandler.SetException(FactoryFunction),_
his only responsibility is handling a js invocation and set the specific result or exception on the base class.


### PR meta checklist
- [X] Pull request is targeted at `main` branch for code   
  or targeted at `stable` branch for documentation that is live on bunit.dev.
- [X] Pull request is linked to all related issues, if any.
- [X] I have read the _CONTRIBUTING.md_ document.

### Code PR specific checklist
- [X] My code follows the code style of this project and AspNetCore coding guidelines.
- [X] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] I have updated the appropriate sub section in the _CHANGELOG.md_.
- [X] I have added, updated or removed tests to according to my changes.
  - [X] All tests passed.
