### PR TITLE
Use AbsoluteUri in FakeNavigationManager to preserve escpaed uri's

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ List of fixes in this release.
 
 - Fixed issue where a registered fall-back service provider was not made available to resolve service dependencies of components under test. Thanks to [@dady8889](https://github.com/dady8889) for the reporting the issue.
 
+- Fixed handling of escaped uri's in FakeNavigationManager. By [@linkdotnet](https://github.com/linkdotnet) in [#460](https://github.com/bUnit-dev/bUnit/pull/460)
+
 ## [1.1.5] - 2021-04-30
 
 ### Added

--- a/src/bunit.web/TestDoubles/NavigationManager/FakeNavigationManager.cs
+++ b/src/bunit.web/TestDoubles/NavigationManager/FakeNavigationManager.cs
@@ -26,7 +26,7 @@ namespace Bunit.TestDoubles
 		/// <inheritdoc/>
 		protected override void NavigateToCore(string uri, bool forceLoad)
 		{
-			Uri = ToAbsoluteUri(uri).AbsoluteUri;
+			Uri = ToAbsoluteUri(uri).OriginalString;
 
 			renderer.Dispatcher.InvokeAsync(
 				() => NotifyLocationChanged(isInterceptedLink: false));

--- a/src/bunit.web/TestDoubles/NavigationManager/FakeNavigationManager.cs
+++ b/src/bunit.web/TestDoubles/NavigationManager/FakeNavigationManager.cs
@@ -26,7 +26,7 @@ namespace Bunit.TestDoubles
 		/// <inheritdoc/>
 		protected override void NavigateToCore(string uri, bool forceLoad)
 		{
-			Uri = ToAbsoluteUri(uri).ToString();
+			Uri = ToAbsoluteUri(uri).AbsoluteUri;
 
 			renderer.Dispatcher.InvokeAsync(
 				() => NotifyLocationChanged(isInterceptedLink: false));

--- a/tests/bunit.web.tests/TestDoubles/NavigationManager/FakeNavigationManagerTest.cs
+++ b/tests/bunit.web.tests/TestDoubles/NavigationManager/FakeNavigationManagerTest.cs
@@ -43,7 +43,7 @@ namespace Bunit.TestDoubles
 			sut.Uri.ShouldBe(expectedUri.ToString());
 		}
 
-		[Theory(DisplayName = "NavigateTo with absolute URI sets the Uri property ")]
+		[Theory(DisplayName = "NavigateTo with absolute URI sets the Uri property")]
 		[InlineData("http://localhost")]
 		[InlineData("http://localhost/")]
 		[InlineData("http://localhost/foo")]
@@ -54,7 +54,7 @@ namespace Bunit.TestDoubles
 
 			sut.NavigateTo(uri);
 
-			sut.Uri.ShouldBe(expectedUri.ToString());
+			sut.Uri.ShouldBe(expectedUri.OriginalString);
 		}
 
 		[Fact(DisplayName = "NavigateTo raises the NotifyLocationChanged")]

--- a/tests/bunit.web.tests/TestDoubles/NavigationManager/FakeNavigationManagerTest.cs
+++ b/tests/bunit.web.tests/TestDoubles/NavigationManager/FakeNavigationManagerTest.cs
@@ -91,5 +91,15 @@ namespace Bunit.TestDoubles
 
 			cut.Markup.ShouldBe($"{sut.BaseUri}foo");
 		}
+
+		[Fact(DisplayName = "Uri should not be unescaped")]
+		public void Test007()
+		{
+			var sut = CreateFakeNavigationMananger();
+
+			sut.NavigateTo("/with%20whitespace");
+
+			sut.Uri.ShouldEndWith("with%20whitespace");
+		}
 	}
 }


### PR DESCRIPTION
## Pull request description
Fixes #458 

In theory this is a API breaking change as Uri is different before than after the change.