### PR TITLE
feat: Added additional introduced flags in MouseEventArgs (net5 or higher)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to **bUnit** will be documented in this file. The project ad
 
 - Added `FakeSignOutSessionStateManage` type in Blazor, that makes it it easy to test components that use the `SignOutSessionStateManage` type. By [@linkdotnet](https://github.com/linkdotnet).
 
+- Added more optional arguments for `Click` and `DoubleClick` extensions which were introduced in NET5 and NET6. Reported by [@egil](https://github.com/egil). Implemented by [@linkdotnet](https://github.com/linkdotnet).
 ## [1.4.15] - 2021-12-18
 
 This release reintroduces `Stub<TComponent>` and related back into the main library, so the "preview" library `bunit.web.mock` is already obsolete. 

--- a/src/bunit.web/EventDispatchExtensions/MouseEventDispatchExtensions.cs
+++ b/src/bunit.web/EventDispatchExtensions/MouseEventDispatchExtensions.cs
@@ -252,7 +252,76 @@ public static class MouseEventDispatchExtensions
 	/// <returns>A task that completes when the event handler is done.</returns>
 	public static Task MouseUpAsync(this IElement element, MouseEventArgs eventArgs) => element.TriggerEventAsync("onmouseup", eventArgs);
 
+#if NET6_0_OR_GREATER
 	/// <summary>
+	/// Raises the <c>@onclick</c> event on <paramref name="element"/>,  passing the provided
+	/// properties to the event handler via a <see cref="MouseEventArgs"/> object.
+	/// </summary>
+	/// <param name="element">The element to raise the event on.</param>
+	/// <param name="detail">A count of consecutive clicks that happened in a short amount of time, incremented by one.</param>
+	/// <param name="screenX">The X coordinate of the mouse pointer in global (screen) coordinates.</param>
+	/// <param name="screenY">The Y coordinate of the mouse pointer in global (screen) coordinates.</param>
+	/// <param name="clientX">The X coordinate of the mouse pointer in local (DOM content) coordinates.</param>
+	/// <param name="clientY">The Y coordinate of the mouse pointer in local (DOM content) coordinates.</param>
+	/// <param name="pageX">The X coordinate of the mouse pointer relative to the whole document.</param>
+	/// <param name="pageY">The Y coordinate of the mouse pointer relative to the whole document.</param>
+	/// <param name="offsetX">The X coordinate of the mouse pointer in relative (Target Element) coordinates.</param>
+	/// <param name="offsetY">The Y coordinate of the mouse pointer in relative (Target Element) coordinates.</param>
+	/// <param name="button">
+	///     The button number that was pressed when the mouse event was fired: Left button=0,
+	///     middle button=1 (if present), right button=2. For mice configured for left handed
+	///     use in which the button actions are reversed the values are instead read from
+	///     right to left.
+	/// </param>
+	/// <param name="buttons">
+	///     The buttons being pressed when the mouse event was fired: Left button=1, Right
+	///     button=2, Middle (wheel) button=4, 4th button (typically, "Browser Back" button)=8,
+	///     5th button (typically, "Browser Forward" button)=16. If two or more buttons are
+	///     pressed, returns the logical sum of the values. E.g., if Left button and Right
+	///     button are pressed, returns 3 (=1 | 2).
+	/// </param>
+	/// <param name="ctrlKey">true if the control key was down when the event was fired. false otherwise.</param>
+	/// <param name="shiftKey">true if the shift key was down when the event was fired. false otherwise.</param>
+	/// <param name="altKey">true if the alt key was down when the event was fired. false otherwise.</param>
+	/// <param name="metaKey">true if the meta key was down when the event was fired. false otherwise.</param>
+	/// <param name="type">Gets or sets the type of the event.</param>
+	public static void Click(this IElement element, long detail = 1, double screenX = default, double screenY = default, double clientX = default, double clientY = default, double pageX = 0, double pageY = 0, double offsetX = 0, double offsetY = 0, long button = default, long buttons = default, bool ctrlKey = default, bool shiftKey = default, bool altKey = default, bool metaKey = default, string? type = default)
+		=> _ = ClickAsync(element, new MouseEventArgs { Detail = detail, ScreenX = screenX, ScreenY = screenY, ClientX = clientX, PageX = pageX, PageY = pageY, OffsetX = offsetX, OffsetY = offsetY, ClientY = clientY, Button = button, Buttons = buttons, CtrlKey = ctrlKey, ShiftKey = shiftKey, AltKey = altKey, MetaKey = metaKey, Type = type! });
+#elif NET5_0
+	/// <summary>
+	/// Raises the <c>@onclick</c> event on <paramref name="element"/>,  passing the provided
+	/// properties to the event handler via a <see cref="MouseEventArgs"/> object.
+	/// </summary>
+	/// <param name="element">The element to raise the event on.</param>
+	/// <param name="detail">A count of consecutive clicks that happened in a short amount of time, incremented by one.</param>
+	/// <param name="screenX">The X coordinate of the mouse pointer in global (screen) coordinates.</param>
+	/// <param name="screenY">The Y coordinate of the mouse pointer in global (screen) coordinates.</param>
+	/// <param name="clientX">The X coordinate of the mouse pointer in local (DOM content) coordinates.</param>
+	/// <param name="clientY">The Y coordinate of the mouse pointer in local (DOM content) coordinates.</param>
+	/// <param name="offsetX">The X coordinate of the mouse pointer in relative (Target Element) coordinates.</param>
+	/// <param name="offsetY">The Y coordinate of the mouse pointer in relative (Target Element) coordinates.</param>
+	/// <param name="button">
+	///     The button number that was pressed when the mouse event was fired: Left button=0,
+	///     middle button=1 (if present), right button=2. For mice configured for left handed
+	///     use in which the button actions are reversed the values are instead read from
+	///     right to left.
+	/// </param>
+	/// <param name="buttons">
+	///     The buttons being pressed when the mouse event was fired: Left button=1, Right
+	///     button=2, Middle (wheel) button=4, 4th button (typically, "Browser Back" button)=8,
+	///     5th button (typically, "Browser Forward" button)=16. If two or more buttons are
+	///     pressed, returns the logical sum of the values. E.g., if Left button and Right
+	///     button are pressed, returns 3 (=1 | 2).
+	/// </param>
+	/// <param name="ctrlKey">true if the control key was down when the event was fired. false otherwise.</param>
+	/// <param name="shiftKey">true if the shift key was down when the event was fired. false otherwise.</param>
+	/// <param name="altKey">true if the alt key was down when the event was fired. false otherwise.</param>
+	/// <param name="metaKey">true if the meta key was down when the event was fired. false otherwise.</param>
+	/// <param name="type">Gets or sets the type of the event.</param>
+	public static void Click(this IElement element, long detail = 1, double screenX = default, double screenY = default, double clientX = default, double clientY = default, double offsetX = 0, double offsetY = 0, long button = default, long buttons = default, bool ctrlKey = default, bool shiftKey = default, bool altKey = default, bool metaKey = default, string? type = default)
+		=> _ = ClickAsync(element, new MouseEventArgs { Detail = detail, ScreenX = screenX, ScreenY = screenY, ClientX = clientX, OffsetX = offsetX, OffsetY = offsetY, ClientY = clientY, Button = button, Buttons = buttons, CtrlKey = ctrlKey, ShiftKey = shiftKey, AltKey = altKey, MetaKey = metaKey, Type = type! });
+#else
+		/// <summary>
 	/// Raises the <c>@onclick</c> event on <paramref name="element"/>,  passing the provided
 	/// properties to the event handler via a <see cref="MouseEventArgs"/> object.
 	/// </summary>
@@ -282,6 +351,8 @@ public static class MouseEventDispatchExtensions
 	/// <param name="type">Gets or sets the type of the event.</param>
 	public static void Click(this IElement element, long detail = 1, double screenX = default, double screenY = default, double clientX = default, double clientY = default, long button = default, long buttons = default, bool ctrlKey = default, bool shiftKey = default, bool altKey = default, bool metaKey = default, string? type = default)
 		=> _ = ClickAsync(element, new MouseEventArgs { Detail = detail, ScreenX = screenX, ScreenY = screenY, ClientX = clientX, ClientY = clientY, Button = button, Buttons = buttons, CtrlKey = ctrlKey, ShiftKey = shiftKey, AltKey = altKey, MetaKey = metaKey, Type = type! });
+#endif
+
 
 	/// <summary>
 	/// Raises the <c>@onclick</c> event on <paramref name="element"/>, passing the provided <paramref name="eventArgs"/>
@@ -300,6 +371,76 @@ public static class MouseEventDispatchExtensions
 	/// <param name="eventArgs">The event arguments to pass to the event handler.</param>
 	/// <returns>A task that completes when the event handler is done.</returns>
 	public static Task ClickAsync(this IElement element, MouseEventArgs eventArgs) => element.TriggerEventAsync("onclick", eventArgs);
+
+#if NET6_0_OR_GREATER
+	/// <summary>
+	/// Raises the <c>@ondblclick</c> event on <paramref name="element"/>,  passing the provided
+	/// properties to the event handler via a <see cref="MouseEventArgs"/> object.
+	/// </summary>
+	/// <param name="element">The element to raise the event on.</param>
+	/// <param name="detail">A count of consecutive clicks that happened in a short amount of time, incremented by one.</param>
+	/// <param name="screenX">The X coordinate of the mouse pointer in global (screen) coordinates.</param>
+	/// <param name="screenY">The Y coordinate of the mouse pointer in global (screen) coordinates.</param>
+	/// <param name="clientX">The X coordinate of the mouse pointer in local (DOM content) coordinates.</param>
+	/// <param name="clientY">The Y coordinate of the mouse pointer in local (DOM content) coordinates.</param>
+	/// <param name="pageX">The X coordinate of the mouse pointer relative to the whole document.</param>
+	/// <param name="pageY">The Y coordinate of the mouse pointer relative to the whole document.</param>
+	/// <param name="offsetX">The X coordinate of the mouse pointer in relative (Target Element) coordinates.</param>
+	/// <param name="offsetY">The Y coordinate of the mouse pointer in relative (Target Element) coordinates.</param>
+	/// <param name="button">
+	///     The button number that was pressed when the mouse event was fired: Left button=0,
+	///     middle button=1 (if present), right button=2. For mice configured for left handed
+	///     use in which the button actions are reversed the values are instead read from
+	///     right to left.
+	/// </param>
+	/// <param name="buttons">
+	///     The buttons being pressed when the mouse event was fired: Left button=1, Right
+	///     button=2, Middle (wheel) button=4, 4th button (typically, "Browser Back" button)=8,
+	///     5th button (typically, "Browser Forward" button)=16. If two or more buttons are
+	///     pressed, returns the logical sum of the values. E.g., if Left button and Right
+	///     button are pressed, returns 3 (=1 | 2).
+	/// </param>
+	/// <param name="ctrlKey">true if the control key was down when the event was fired. false otherwise.</param>
+	/// <param name="shiftKey">true if the shift key was down when the event was fired. false otherwise.</param>
+	/// <param name="altKey">true if the alt key was down when the event was fired. false otherwise.</param>
+	/// <param name="metaKey">true if the meta key was down when the event was fired. false otherwise.</param>
+	/// <param name="type">Gets or sets the type of the event.</param>
+	public static void DoubleClick(this IElement element, long detail = 2, double screenX = default, double screenY = default, double clientX = default, double clientY = default, double pageX = 0, double pageY = 0, double offsetX = 0, double offsetY = 0, long button = default, long buttons = default, bool ctrlKey = default, bool shiftKey = default, bool altKey = default, bool metaKey = default, string? type = default)
+		=> _ = DoubleClickAsync(element, new MouseEventArgs { Detail = detail, ScreenX = screenX, ScreenY = screenY, ClientX = clientX, ClientY = clientY, PageX = pageX, PageY = pageY, OffsetX = offsetX, OffsetY = offsetY, Button = button, Buttons = buttons, CtrlKey = ctrlKey, ShiftKey = shiftKey, AltKey = altKey, MetaKey = metaKey, Type = type! });
+#elif NET5_0
+	/// <summary>
+	/// Raises the <c>@ondblclick</c> event on <paramref name="element"/>,  passing the provided
+	/// properties to the event handler via a <see cref="MouseEventArgs"/> object.
+	/// </summary>
+	/// <param name="element">The element to raise the event on.</param>
+	/// <param name="detail">A count of consecutive clicks that happened in a short amount of time, incremented by one.</param>
+	/// <param name="screenX">The X coordinate of the mouse pointer in global (screen) coordinates.</param>
+	/// <param name="screenY">The Y coordinate of the mouse pointer in global (screen) coordinates.</param>
+	/// <param name="clientX">The X coordinate of the mouse pointer in local (DOM content) coordinates.</param>
+	/// <param name="clientY">The Y coordinate of the mouse pointer in local (DOM content) coordinates.</param>
+	/// <param name="offsetX">The X coordinate of the mouse pointer in relative (Target Element) coordinates.</param>
+	/// <param name="offsetY">The Y coordinate of the mouse pointer in relative (Target Element) coordinates.</param>
+	/// <param name="button">
+	///     The button number that was pressed when the mouse event was fired: Left button=0,
+	///     middle button=1 (if present), right button=2. For mice configured for left handed
+	///     use in which the button actions are reversed the values are instead read from
+	///     right to left.
+	/// </param>
+	/// <param name="buttons">
+	///     The buttons being pressed when the mouse event was fired: Left button=1, Right
+	///     button=2, Middle (wheel) button=4, 4th button (typically, "Browser Back" button)=8,
+	///     5th button (typically, "Browser Forward" button)=16. If two or more buttons are
+	///     pressed, returns the logical sum of the values. E.g., if Left button and Right
+	///     button are pressed, returns 3 (=1 | 2).
+	/// </param>
+	/// <param name="ctrlKey">true if the control key was down when the event was fired. false otherwise.</param>
+	/// <param name="shiftKey">true if the shift key was down when the event was fired. false otherwise.</param>
+	/// <param name="altKey">true if the alt key was down when the event was fired. false otherwise.</param>
+	/// <param name="metaKey">true if the meta key was down when the event was fired. false otherwise.</param>
+	/// <param name="type">Gets or sets the type of the event.</param>
+	public static void DoubleClick(this IElement element, long detail = 2, double screenX = default, double screenY = default, double clientX = default, double clientY = default, double offsetX = 0, double offsetY = 0, long button = default, long buttons = default, bool ctrlKey = default, bool shiftKey = default, bool altKey = default, bool metaKey = default, string? type = default)
+		=> _ = DoubleClickAsync(element, new MouseEventArgs { Detail = detail, ScreenX = screenX, ScreenY = screenY, ClientX = clientX, ClientY = clientY, OffsetX = offsetX, OffsetY = offsetY, Button = button, Buttons = buttons, CtrlKey = ctrlKey, ShiftKey = shiftKey, AltKey = altKey, MetaKey = metaKey, Type = type! });
+#else
 
 	/// <summary>
 	/// Raises the <c>@ondblclick</c> event on <paramref name="element"/>,  passing the provided
@@ -331,7 +472,7 @@ public static class MouseEventDispatchExtensions
 	/// <param name="type">Gets or sets the type of the event.</param>
 	public static void DoubleClick(this IElement element, long detail = 2, double screenX = default, double screenY = default, double clientX = default, double clientY = default, long button = default, long buttons = default, bool ctrlKey = default, bool shiftKey = default, bool altKey = default, bool metaKey = default, string? type = default)
 		=> _ = DoubleClickAsync(element, new MouseEventArgs { Detail = detail, ScreenX = screenX, ScreenY = screenY, ClientX = clientX, ClientY = clientY, Button = button, Buttons = buttons, CtrlKey = ctrlKey, ShiftKey = shiftKey, AltKey = altKey, MetaKey = metaKey, Type = type! });
-
+#endif
 	/// <summary>
 	/// Raises the <c>@ondblclick</c> event on <paramref name="element"/>, passing the provided <paramref name="eventArgs"/>
 	/// to the event handler.


### PR DESCRIPTION
This PR adds the following new properties to the `Click` and `DoubleClick` extension method:
 * `OffsetX` and `OffsetY` for net5 and net6
 * `PageX` and `PageY` for net6

If targeted against netstandard2.1there is no difference.

## Pull request description
<!--- 
    Describe the changes and motivation behind them here, if it is not obvious
    from the related issues. Does it have new features, breaking changes, etc. 
-->

### PR meta checklist
- [x] Pull request is targeted at `main` branch for code   
  or targeted at `stable` branch for documentation that is live on bunit.dev.
- [x] Pull request is linked to all related issues, if any.
- [x] I have read the _CONTRIBUTING.md_ document.

### Code PR specific checklist
- [x] My code follows the code style of this project and AspNetCore coding guidelines.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] I have updated the appropriate sub section in the _CHANGELOG.md_.
- [ ] I have added, updated or removed tests to according to my changes.
  - [ ] All tests passed.
