### PR TITLE
feat: Support multiple test frameworks in bUnit test template (#129)

### DIFF
--- a/.github/workflows/verification.yml
+++ b/.github/workflows/verification.yml
@@ -73,11 +73,15 @@ jobs:
           dotnet pack src/bunit/ -c release -o ${GITHUB_WORKSPACE}/packages -p:ContinuousIntegrationBuild=true
           dotnet pack src/bunit.template/ -c release -o ${GITHUB_WORKSPACE}/packages -p:ContinuousIntegrationBuild=true
 
+      - name: ✳ Install bUnit template
+        if: matrix.os != 'windows-latest'
+        run: |
+          dotnet new --install bunit.template::${NBGV_NuGetPackageVersion} --nuget-source ${GITHUB_WORKSPACE}/packages
+          
       # Excluding windows because the restore step doesnt seem to work correct.
       - name: ✔ Verify xUnit template
         if: matrix.os != 'windows-latest'
         run: |
-          dotnet new --install bunit.template::${NBGV_NuGetPackageVersion} --nuget-source ${GITHUB_WORKSPACE}/packages
           dotnet new bunit --no-restore -o ${GITHUB_WORKSPACE}/TemplateTestXunit
           echo '<?xml version="1.0" encoding="utf-8"?><Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003"></Project>' >> ${GITHUB_WORKSPACE}/TemplateTestXunit/Directory.Build.props
           dotnet restore ${GITHUB_WORKSPACE}/TemplateTestXunit --source ${GITHUB_WORKSPACE}/packages --source https://api.nuget.org/v3/index.json
@@ -86,7 +90,6 @@ jobs:
       - name: ✔ Verify NUnit template
         if: matrix.os != 'windows-latest'
         run: |
-          dotnet new --install bunit.template::${NBGV_NuGetPackageVersion} --nuget-source ${GITHUB_WORKSPACE}/packages
           dotnet new bunit --framework nunit --no-restore -o ${GITHUB_WORKSPACE}/TemplateTestNunit
           echo '<?xml version="1.0" encoding="utf-8"?><Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003"></Project>' >> ${GITHUB_WORKSPACE}/TemplateTestNunit/Directory.Build.props
           dotnet restore ${GITHUB_WORKSPACE}/TemplateTestNunit --source ${GITHUB_WORKSPACE}/packages --source https://api.nuget.org/v3/index.json
@@ -95,7 +98,6 @@ jobs:
       - name: ✔ Verify MSTest template
         if: matrix.os != 'windows-latest'
         run: |
-          dotnet new --install bunit.template::${NBGV_NuGetPackageVersion} --nuget-source ${GITHUB_WORKSPACE}/packages
           dotnet new bunit --framework mstest --no-restore -o ${GITHUB_WORKSPACE}/TemplateTestMstest
           echo '<?xml version="1.0" encoding="utf-8"?><Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003"></Project>' >> ${GITHUB_WORKSPACE}/TemplateTestMstest/Directory.Build.props
           dotnet restore ${GITHUB_WORKSPACE}/TemplateTestMstest --source ${GITHUB_WORKSPACE}/packages --source https://api.nuget.org/v3/index.json

--- a/.github/workflows/verification.yml
+++ b/.github/workflows/verification.yml
@@ -74,14 +74,32 @@ jobs:
           dotnet pack src/bunit.template/ -c release -o ${GITHUB_WORKSPACE}/packages -p:ContinuousIntegrationBuild=true
 
       # Excluding windows because the restore step doesnt seem to work correct.
-      - name: ✔ Verify template
+      - name: ✔ Verify xUnit template
         if: matrix.os != 'windows-latest'
         run: |
           dotnet new --install bunit.template::${NBGV_NuGetPackageVersion} --nuget-source ${GITHUB_WORKSPACE}/packages
-          dotnet new bunit --no-restore -o ${GITHUB_WORKSPACE}/TemplateTest
-          echo '<?xml version="1.0" encoding="utf-8"?><Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003"></Project>' >> ${GITHUB_WORKSPACE}/TemplateTest/Directory.Build.props
-          dotnet restore ${GITHUB_WORKSPACE}/TemplateTest --source ${GITHUB_WORKSPACE}/packages --source https://api.nuget.org/v3/index.json
-          dotnet test ${GITHUB_WORKSPACE}/TemplateTest --blame-hang --blame-hang-timeout 1m --blame-hang-dump-type none
+          dotnet new bunit --no-restore -o ${GITHUB_WORKSPACE}/TemplateTestXunit
+          echo '<?xml version="1.0" encoding="utf-8"?><Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003"></Project>' >> ${GITHUB_WORKSPACE}/TemplateTestXunit/Directory.Build.props
+          dotnet restore ${GITHUB_WORKSPACE}/TemplateTestXunit --source ${GITHUB_WORKSPACE}/packages --source https://api.nuget.org/v3/index.json
+          dotnet test ${GITHUB_WORKSPACE}/TemplateTestXunit --blame-hang --blame-hang-timeout 1m --blame-hang-dump-type none
+
+      - name: ✔ Verify NUnit template
+        if: matrix.os != 'windows-latest'
+        run: |
+          dotnet new --install bunit.template::${NBGV_NuGetPackageVersion} --nuget-source ${GITHUB_WORKSPACE}/packages
+          dotnet new bunit --framework nunit --no-restore -o ${GITHUB_WORKSPACE}/TemplateTestNunit
+          echo '<?xml version="1.0" encoding="utf-8"?><Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003"></Project>' >> ${GITHUB_WORKSPACE}/TemplateTestNunit/Directory.Build.props
+          dotnet restore ${GITHUB_WORKSPACE}/TemplateTestNunit --source ${GITHUB_WORKSPACE}/packages --source https://api.nuget.org/v3/index.json
+          dotnet test ${GITHUB_WORKSPACE}/TemplateTestNunit --blame-hang --blame-hang-timeout 1m --blame-hang-dump-type none
+
+      - name: ✔ Verify MSTest template
+        if: matrix.os != 'windows-latest'
+        run: |
+          dotnet new --install bunit.template::${NBGV_NuGetPackageVersion} --nuget-source ${GITHUB_WORKSPACE}/packages
+          dotnet new bunit --framework mstest --no-restore -o ${GITHUB_WORKSPACE}/TemplateTestMstest
+          echo '<?xml version="1.0" encoding="utf-8"?><Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003"></Project>' >> ${GITHUB_WORKSPACE}/TemplateTestMstest/Directory.Build.props
+          dotnet restore ${GITHUB_WORKSPACE}/TemplateTestMstest --source ${GITHUB_WORKSPACE}/packages --source https://api.nuget.org/v3/index.json
+          dotnet test ${GITHUB_WORKSPACE}/TemplateTestMstest --blame-hang --blame-hang-timeout 1m --blame-hang-dump-type none
 
       # DocFx only works well on Windows currently
       - name: 📄 Build documentation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to **bUnit** will be documented in this file. The project ad
 - Added `FakeSignOutSessionStateManage` type in Blazor, that makes it easy to test components that use the `SignOutSessionStateManage` type. By [@linkdotnet](https://github.com/linkdotnet).
 - Added a validation to `AddChildContent` method in `ComponentParameterCollectionBuilder` that will throw an exception if the component's `ChildContent` is a generic type. By [@denisekart](https://github.com/denisekart).
 - Added more optional arguments for `Click` and `DoubleClick` extensions which were introduced in .NET 5 and .NET 6. By [@linkdotnet](https://github.com/linkdotnet).
+- Added template support for `Nunit` and `MSTest` unit test frameworks. By [@denisekart](https://github.com/denisekart).
 
 ### Fixed
 

--- a/src/bunit.template/template/.template.config/dotnetcli.host.json
+++ b/src/bunit.template/template/.template.config/dotnetcli.host.json
@@ -3,6 +3,15 @@
 		"skipRestore": {
 			"longName": "no-restore",
 			"shortName": ""
+		},
+		"UnitTestFramework": {
+			"longName": "framework",
+			"shortName": ""
 		}
-	}
+	},
+	"usageExamples": [
+		"--framework xunit",
+		"--framework nunit",
+		"--framework mstest"
+	]
 }

--- a/src/bunit.template/template/.template.config/template.json
+++ b/src/bunit.template/template/.template.config/template.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "$schema": "http://json.schemastore.org/template",
   "author": "Egil Hansen",
   "classifications": [
@@ -19,29 +19,66 @@
   "sourceName": "Company.BlazorTests1",
   "defaultName": "BlazorTestProject1",
   "preferNameDirectory": true,
-  "symbols": {
-    "HostIdentifier": {
-      "type": "bind",
-      "binding": "HostIdentifier"
-    },
-    "skipRestore": {
-      "type": "parameter",
-      "datatype": "bool",
-      "description": "If specified, skips the automatic restore of the project on create.",
-      "defaultValue": "false"
-    }
-  },
+	"symbols": {
+		"HostIdentifier": {
+			"type": "bind",
+			"binding": "HostIdentifier"
+		},
+		"skipRestore": {
+			"type": "parameter",
+			"datatype": "bool",
+			"description": "If specified, skips the automatic restore of the project on create.",
+			"defaultValue": "false"
+		},
+		"UnitTestFramework": {
+			"type": "parameter",
+			"description": "The target unit testing framework for the project.",
+			"displayName": "Unit test framework",
+			"datatype": "choice",
+			"defaultValue": "xunit",
+			"replaces": "UnitTestFramework",
+			"choices": [
+				{
+					"choice": "nunit",
+					"description": "NUnit unit testing framework",
+					"displayName": "NUnit"
+				},
+				{
+					"choice": "xunit",
+					"description": "xUnit unit testing framework",
+					"displayName": "xUnit"
+				},
+				{
+					"choice": "mstest",
+					"description": "MSTest unit testing framework",
+					"displayName": "MSTest"
+				}
+			]
+		},
+		"testFramework_nunit": {
+			"type": "computed",
+			"value": "UnitTestFramework == \"nunit\""
+		},
+		"testFramework_xunit": {
+			"type": "computed",
+			"value": "UnitTestFramework == \"xunit\""
+		},
+		"testFramework_mstest": {
+			"type": "computed",
+			"value": "UnitTestFramework == \"mstest\""
+		}
+	},
   "primaryOutputs": [
     { "path": "Company.BlazorTests1.csproj" }
   ],
   "postActions": [
-    {
-      "condition": "(!skipRestore)",
-      "description": "Restore NuGet packages required by this project.",
-      "manualInstructions": [ { "text": "Run 'dotnet restore'" } ],
-      "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
-      "continueOnError": true
-    }
+		{
+			"condition": "(!skipRestore)",
+			"description": "Restore NuGet packages required by this project.",
+			"manualInstructions": [ { "text": "Run 'dotnet restore'" } ],
+			"actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+			"continueOnError": true
+		}
     //},
     //{
     //  "description": "Adding latests bUnit.Core reference",

--- a/src/bunit.template/template/.template.config/template.json
+++ b/src/bunit.template/template/.template.config/template.json
@@ -18,7 +18,17 @@
   },
   "sourceName": "Company.BlazorTests1",
   "defaultName": "BlazorTestProject1",
-  "preferNameDirectory": true,
+	"preferNameDirectory": true,
+	"sources": [
+		{
+			"modifiers": [
+				{
+					"exclude": [ "BunitTestContext.cs" ],
+					"condition": "(testFramework_xunit)"
+				}
+			]
+		}
+	],
 	"symbols": {
 		"HostIdentifier": {
 			"type": "bind",
@@ -79,51 +89,5 @@
 			"actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
 			"continueOnError": true
 		}
-    //},
-    //{
-    //  "description": "Adding latests bUnit.Core reference",
-    //  "actionId": "B17581D1-C5C9-4489-8F0A-004BE667B814",
-    //  "continueOnError": true,
-    //  "manualInstructions": [
-    //    {
-    //      "text": "Manually add the 'bunit.core' reference to your project file"
-    //    }
-    //  ],
-    //  "args": {
-    //    "referenceType": "package",
-    //    "reference": "bunit.core",
-    //    "projectFileExtensions": ".csproj"
-    //  }
-    //},
-    //{
-    //  "description": "Adding latests bUnit.Web reference",
-    //  "actionId": "B17581D1-C5C9-4489-8F0A-004BE667B814",
-    //  "continueOnError": true,
-    //  "manualInstructions": [
-    //    {
-    //      "text": "Manually add the 'bunit.web' reference to your project file"
-    //    }
-    //  ],
-    //  "args": {
-    //    "referenceType": "package",
-    //    "reference": "bunit.web",
-    //    "projectFileExtensions": ".csproj"
-    //  }
-    //},
-    //{
-    //  "description": "Adding latests bUnit.xUnit reference",
-    //  "actionId": "B17581D1-C5C9-4489-8F0A-004BE667B814",
-    //  "continueOnError": true,
-    //  "manualInstructions": [
-    //    {
-    //      "text": "Manually add the 'bunit.xunit' reference to your project file"
-    //    }
-    //  ],
-    //  "args": {
-    //    "referenceType": "package",
-    //    "reference": "bunit.xunit",
-    //    "projectFileExtensions": ".csproj"
-    //  }
-    //}
   ]
 }

--- a/src/bunit.template/template/BunitTestContext.cs
+++ b/src/bunit.template/template/BunitTestContext.cs
@@ -1,0 +1,29 @@
+using Bunit;
+#if (testFramework_nunit)
+using NUnit.Framework;
+#elif (testFramework_mstest)
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+#endif
+
+namespace Company.BlazorTests1;
+
+/// <summary>
+/// Test context wrapper for bUnit.
+/// Read more about using <see cref="BunitTestContext"/> <seealso href="https://bunit.dev/docs/getting-started/writing-tests.html#remove-boilerplate-code-from-tests">here</seealso>.
+/// </summary>
+public abstract class BunitTestContext : TestContextWrapper
+{
+#if (testFramework_nunit)
+	[SetUp]
+#elif (testFramework_mstest)
+	[TestInitialize]
+#endif
+	public void Setup() => TestContext = new Bunit.TestContext();
+
+#if (testFramework_nunit)
+	[TearDown]
+#elif (testFramework_mstest)
+	[TestCleanup]
+#endif
+	public void TearDown() => TestContext?.Dispose();
+}

--- a/src/bunit.template/template/Company.BlazorTests1.csproj
+++ b/src/bunit.template/template/Company.BlazorTests1.csproj
@@ -9,22 +9,39 @@
 	<ItemGroup>
 		<Using Include="Bunit" />
 		<Using Include="Bunit.TestDoubles" />
-		<Using Include="Xunit" />
 		<Using Include="Microsoft.Extensions.DependencyInjection" />
+		<Using Include="Xunit" Condition="'$(testFramework_xunit)' == 'true'"/>
+		<Using Include="NUnit.Framework" Condition="'$(testFramework_nunit)' == 'true'"/>
+		<Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" Condition="'$(testFramework_mstest)' == 'true'"/>
+
+		<Using Include="Bunit.TestContext" Alias="TestContext" />
 	</ItemGroup>
 
 	<ItemGroup>
-    <PackageReference Include="bunit" Version="#{NBGV_NuGetPackageVersion}#" />
+		<PackageReference Include="bunit" Version="#{NBGV_NuGetPackageVersion}#" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+		<PackageReference Include="coverlet.collector" Version="3.1.0">
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+	</ItemGroup>
+
+	<ItemGroup Condition="'$(testFramework_xunit)' == 'true'">
 		<PackageReference Include="xunit" Version="2.4.1" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
-		<PackageReference Include="coverlet.collector" Version="3.1.0">
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-			<PrivateAssets>all</PrivateAssets>
-		</PackageReference>
-  </ItemGroup>
+	</ItemGroup>
+
+	<ItemGroup Condition="'$(testFramework_nunit)' == 'true'">
+		<PackageReference Include="NUnit" Version="3.13.2" />
+		<PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
+	</ItemGroup>
+
+	<ItemGroup Condition="'$(testFramework_mstest)' == 'true'">
+		<PackageReference Include="MSTest.TestAdapter" Version="2.2.7" />
+		<PackageReference Include="MSTest.TestFramework" Version="2.2.7" />
+	</ItemGroup>
 
 </Project>

--- a/src/bunit.template/template/Company.BlazorTests1.csproj
+++ b/src/bunit.template/template/Company.BlazorTests1.csproj
@@ -13,8 +13,6 @@
 		<Using Include="Xunit" Condition="'$(testFramework_xunit)' == 'true'"/>
 		<Using Include="NUnit.Framework" Condition="'$(testFramework_nunit)' == 'true'"/>
 		<Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" Condition="'$(testFramework_mstest)' == 'true'"/>
-
-		<Using Include="Bunit.TestContext" Alias="TestContext" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/bunit.template/template/CounterCSharpTests.cs
+++ b/src/bunit.template/template/CounterCSharpTests.cs
@@ -4,9 +4,19 @@ namespace Company.BlazorTests1;
 /// These tests are written entirely in C#.
 /// Learn more at https://bunit.dev/docs/getting-started/writing-tests.html#creating-basic-tests-in-cs-files
 /// </summary>
+#if (testFramework_mstest)
+[TestClass]
+#endif
 public class CounterCSharpTests : TestContext
+
 {
+#if (testFramework_xunit)
 	[Fact]
+#elif (testFramework_nunit)
+	[Test]
+#elif (testFramework_mstest)
+	[TestMethod]
+#endif
 	public void CounterStartsAtZero()
 	{
 		// Arrange
@@ -16,7 +26,13 @@ public class CounterCSharpTests : TestContext
 		cut.Find("p").MarkupMatches("<p>Current count: 0</p>");
 	}
 
+#if (testFramework_xunit)
 	[Fact]
+#elif (testFramework_nunit)
+	[Test]
+#elif (testFramework_mstest)
+	[TestMethod]
+#endif
 	public void ClickingButtonIncrementsCounter()
 	{
 		// Arrange

--- a/src/bunit.template/template/CounterCSharpTests.cs
+++ b/src/bunit.template/template/CounterCSharpTests.cs
@@ -4,11 +4,14 @@ namespace Company.BlazorTests1;
 /// These tests are written entirely in C#.
 /// Learn more at https://bunit.dev/docs/getting-started/writing-tests.html#creating-basic-tests-in-cs-files
 /// </summary>
-#if (testFramework_mstest)
-[TestClass]
-#endif
+#if (testFramework_xunit)
 public class CounterCSharpTests : TestContext
-
+#elif (testFramework_nunit)
+public class CounterCSharpTests : BunitTestContext
+#elif (testFramework_mstest)
+[TestClass]
+public class CounterCSharpTests : BunitTestContext
+#endif
 {
 #if (testFramework_xunit)
 	[Fact]

--- a/src/bunit.template/template/CounterRazorTests.razor
+++ b/src/bunit.template/template/CounterRazorTests.razor
@@ -1,3 +1,6 @@
+@*#if (testFramework_mstest)*@
+@attribute [TestClass]
+@*#endif*@
 @inherits TestContext
 
 These tests are written entirely in razor and C# syntax.
@@ -5,7 +8,13 @@ These tests are written entirely in razor and C# syntax.
 Learn more at https://bunit.dev/docs/getting-started/writing-tests.html#creating-basic-tests-in-razor-files
 
 @code {
-	[Fact]
+@*#if (testFramework_xunit)*@
+    [Fact]
+@*#elif (testFramework_nunit)*@
+    [Test]
+@*#elif (testFramework_mstest)*@
+    [TestMethod]
+@*#endif*@
 	public void CounterStartsAtZero()
 	{
 		// Arrange
@@ -14,8 +23,13 @@ Learn more at https://bunit.dev/docs/getting-started/writing-tests.html#creating
 		// Assert that content of the paragraph shows counter at zero
 		cut.Find("p").MarkupMatches(@<p>Current count: 0</p>);
 	}
-
-	[Fact]
+@*#if (testFramework_xunit)*@
+    [Fact]
+@*#elif (testFramework_nunit)*@
+    [Test]
+@*#elif (testFramework_mstest)*@
+    [TestMethod]
+@*#endif*@
 	public void ClickingButtonIncrementsCounter()
 	{
 		// Arrange

--- a/src/bunit.template/template/CounterRazorTests.razor
+++ b/src/bunit.template/template/CounterRazorTests.razor
@@ -1,7 +1,11 @@
-@*#if (testFramework_mstest)*@
-@attribute [TestClass]
-@*#endif*@
+@*#if (testFramework_xunit)*@
 @inherits TestContext
+@*#elif (testFramework_nunit)*@
+@inherits BunitTestContext
+@*#elif (testFramework_mstest)*@
+@attribute [TestClass]
+@inherits BunitTestContext
+@*#endif*@
 
 These tests are written entirely in razor and C# syntax.
 

--- a/src/bunit.template/template/_Imports.razor
+++ b/src/bunit.template/template/_Imports.razor
@@ -3,4 +3,3 @@
 @using Microsoft.Extensions.DependencyInjection
 @using Bunit
 @using Bunit.TestDoubles
-@using Xunit

--- a/src/bunit.template/template/_Imports.razor
+++ b/src/bunit.template/template/_Imports.razor
@@ -3,3 +3,10 @@
 @using Microsoft.Extensions.DependencyInjection
 @using Bunit
 @using Bunit.TestDoubles
+@*#if (testFramework_xunit)*@
+@using Xunit
+@*#elif (testFramework_nunit)*@
+@using NUnit.Framework
+@*#elif (testFramework_mstest)*@
+@using Microsoft.VisualStudio.TestTools.UnitTesting
+@*#endif*@


### PR DESCRIPTION
## Pull request description

Add support for MSTest and NUnit test framweworks in bUnit test template

refs: #129

![bunit-multiple-test-fws-2](https://user-images.githubusercontent.com/6152001/152314517-b852f8da-5a09-4b97-b350-67ad7c01de7c.gif)


### PR meta checklist
- [x] Pull request is targeted at `main` branch for code   
  or targeted at `stable` branch for documentation that is live on bunit.dev.
- [x] Pull request is linked to all related issues, if any.
- [x] I have read the _CONTRIBUTING.md_ document.

### Code PR specific checklist
- [x] My code follows the code style of this project and AspNetCore coding guidelines.
- [x] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly. (in a separate PR)
- [x] I have updated the appropriate sub section in the _CHANGELOG.md_.
- [x] I have added, updated or removed tests to according to my changes.
  - [x] All tests passed.

### Considerations/questions:

- Please pay extra attention to the changes in `verification.yml` since I didn't have the chance to actually run the workflow (and am not too familiar with it).
- The documentation relies on using the `TestContextWrapper` to initialize the test classes in NUnit and MSTest frameworks. I've found a different way of achieving the goal by using global usings in combination with an alias. My reasons for doing this are the following:
  - Templates are identical (except specific test attributes) across different test frameworks
  - Test setup is (arguably) cleaner
  That being said, if you believe this should be reverted, I have no issues with that and will modify my contribution to fit the documentation.
- It appears that global usings may be an alternative to razor `_Imports` - to that end, I've removed test framework specific usings from the `_imports.razor` file. The `Bunit` and `Bunit.TestDoubles` could therefore be removed as well (to consider).
- Documentation will be updated in a separate PR