### PR TITLE
Bugfix/nonbubbling events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to **bUnit** will be documented in this file. The project ad
 
 ## [Unreleased]
 
+### Added
+-   Added more non bubbling events to bUnit so it behaves closer to the HTML specification. [@linkdotnet](https://github.com/linkdotnet). 
+
 ### Fixed
 
 -   `ClickAsync` could lead to bubbling exceptions from `GetDispatchEventTasks` even though they should be handled. Reported by [@aguacongas](aguacongas). Fixed by [@linkdotnet](https://github.com/linkdotnet).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,10 @@ All notable changes to **bUnit** will be documented in this file. The project ad
 
 ## [Unreleased]
 
-### Added
--   Added more non bubbling events to bUnit so it behaves closer to the HTML specification. [@linkdotnet](https://github.com/linkdotnet). 
-
 ### Fixed
 
 -   `ClickAsync` could lead to bubbling exceptions from `GetDispatchEventTasks` even though they should be handled. Reported by [@aguacongas](aguacongas). Fixed by [@linkdotnet](https://github.com/linkdotnet).
-  
+-   Added more non bubbling events to bUnit so it behaves closer to the HTML specification. [@linkdotnet](https://github.com/linkdotnet).
 
 ## [1.5.12] - 2022-02-15
 

--- a/src/bunit.web/EventDispatchExtensions/TriggerEventDispatchExtensions.cs
+++ b/src/bunit.web/EventDispatchExtensions/TriggerEventDispatchExtensions.cs
@@ -11,7 +11,31 @@ namespace Bunit;
 /// </summary>
 public static class TriggerEventDispatchExtensions
 {
-	private static readonly HashSet<string> NonBubblingEvents = new(StringComparer.Ordinal) { "onabort", "onblur", "onchange", "onerror", "onfocus", "onload", "onloadend", "onloadstart", "onmouseenter", "onmouseleave", "onprogress", "onreset", "onscroll", "onsubmit", "onunload", "ontoggle", "ondomnodeinsertedintodocument", "ondomnoderemovedfromdocument" };
+	private static readonly HashSet<string> NonBubblingEvents = new(StringComparer.Ordinal)
+	{
+		"onabort",
+		"onblur",
+		"onchange",
+		"onerror",
+		"onfocus",
+		"onload",
+		"onloadend",
+		"onloadstart",
+		"onmouseenter",
+		"onmouseleave",
+		"onprogress",
+		"onreset",
+		"onscroll",
+		"onsubmit",
+		"onunload",
+		"ontoggle",
+		"ondomnodeinsertedintodocument",
+		"ondomnoderemovedfromdocument",
+		"oninvalid",
+		"onpointerleave",
+		"onpointerenter",
+		"onselectionchange",
+	};
 	private static readonly HashSet<string> DisabledEventNames = new(StringComparer.Ordinal) { "onclick", "ondblclick", "onmousedown", "onmousemove", "onmouseup" };
 
 	/// <summary>

--- a/tests/bunit.web.tests/EventDispatchExtensions/GeneralEventDispatchExtensionsTest.cs
+++ b/tests/bunit.web.tests/EventDispatchExtensions/GeneralEventDispatchExtensionsTest.cs
@@ -94,6 +94,10 @@ namespace Bunit
 		[InlineData("ontoggle")]
 		[InlineData("onDOMNodeInsertedIntoDocument")]
 		[InlineData("onDOMNodeRemovedFromDocument")]
+		[InlineData("oninvalid")]
+		[InlineData("onpointerleave")]
+		[InlineData("onpointerenter")]
+		[InlineData("onselectionchange")]
 		public async Task Test110(string eventName)
 		{
 			var cut = RenderComponent<EventBubbles>(ps => ps.Add(p => p.EventName, eventName));


### PR DESCRIPTION
## Pull request description
I recently had a test with the `oninvalid` event. I quick check in the specification revealed that this event should not bubble. Therefore I added this and some more events to the list of non bubbling events in bUnit.

 * `invalid` - see [here](https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/invalid_event)
 * `pointerenter` - see [here](https://developer.mozilla.org/en-US/docs/Web/API/Document/pointerenter_event)
 * `pointerleave` - see [here](https://developer.mozilla.org/en-US/docs/Web/API/Document/pointerleave_event)
 * `selectionchange` - see [here](https://developer.mozilla.org/en-US/docs/Web/API/Document/selectionchange_event)

With this PR bUnit behaves closer to the HTML specification. I don't consider a big impact with that.

### PR meta checklist
- [x] Pull request is targeted at `main` branch for code   
  or targeted at `stable` branch for documentation that is live on bunit.dev.
- [x] Pull request is linked to all related issues, if any.
- [x] I have read the _CONTRIBUTING.md_ document.

### Code PR specific checklist
- [x] My code follows the code style of this project and AspNetCore coding guidelines.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] I have updated the appropriate sub section in the _CHANGELOG.md_.
- [x] I have added, updated or removed tests to according to my changes.
  - [x] All tests passed.
