### PR TITLE
fix: FakeNavigationManager doesn't throw exception when navigating to…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ All notable changes to **bUnit** will be documented in this file. The project ad
 
 - Fixed step by step guide for building and viewing the documentation locally. By [@linkdotnet](https://github.com/linkdotnet).
 
+- `FakeNavigationManager.NavigateTo` could lead to exceptions when navigating to external url's. Reported by (@TDroogers)[https://github.com/TDroogers]. Fixed by [@linkdotnet](https://github.com/linkdotnet).
+
 ## [1.6.4] - 2022-02-22
 
 A quick minor release that primiarily fixes a regression in 1.5.12.

--- a/src/bunit.web/TestDoubles/NavigationManager/FakeNavigationManager.cs
+++ b/src/bunit.web/TestDoubles/NavigationManager/FakeNavigationManager.cs
@@ -49,11 +49,19 @@ public sealed class FakeNavigationManager : NavigationManager
 
 		renderer.Dispatcher.InvokeAsync(() =>
 		{
-			Uri = ToAbsoluteUri(uri).OriginalString;
+			Uri = absoluteUri.OriginalString;
 
+			// Only notify of changes if user navigates within the same
+			// base url (domain). Otherwise, the user navigated away
+			// from the app, and Blazor's NavigationManager would
+			// not notify of location changes.
 			if (!changedBaseUri)
 			{
 				NotifyLocationChanged(isInterceptedLink: false);
+			}
+			else
+			{
+				BaseUri = GetBaseUri(absoluteUri);
 			}
 		});
 	}
@@ -81,11 +89,19 @@ public sealed class FakeNavigationManager : NavigationManager
 
 			renderer.Dispatcher.InvokeAsync(() =>
 			{
-				Uri = ToAbsoluteUri(uri).OriginalString;
+				Uri = absoluteUri.OriginalString;
 
+				// Only notify of changes if user navigates within the same
+				// base url (domain). Otherwise, the user navigated away
+				// from the app, and Blazor's NavigationManager would
+				// not notify of location changes.
 				if (!changedBaseUri)
 				{
 					NotifyLocationChanged(isInterceptedLink: false);
+				}
+				else
+				{
+					BaseUri = GetBaseUri(absoluteUri);
 				}
 			});
 		}

--- a/src/bunit.web/TestDoubles/NavigationManager/FakeNavigationManager.cs
+++ b/src/bunit.web/TestDoubles/NavigationManager/FakeNavigationManager.cs
@@ -109,7 +109,7 @@ public sealed class FakeNavigationManager : NavigationManager
 
 	private URI GetNewAbsoluteUri(string uri)
 		=> URI.IsWellFormedUriString(uri, UriKind.Relative)
-			? base.ToAbsoluteUri(uri)
+			? ToAbsoluteUri(uri)
 			: new URI(uri, UriKind.Absolute);
 
 	private bool HasDifferentBaseUri(URI absoluteUri)

--- a/tests/bunit.web.tests/TestDoubles/NavigationManager/FakeNavigationManagerTest.cs
+++ b/tests/bunit.web.tests/TestDoubles/NavigationManager/FakeNavigationManagerTest.cs
@@ -138,5 +138,30 @@ namespace Bunit.TestDoubles
 				.ShouldBeEquivalentTo(new NavigationHistory("/secondUrl", new NavigationOptions() { ReplaceHistoryEntry = true }));
 		}
 #endif
+
+		[Fact(DisplayName = "Navigate to an external url should set BaseUri")]
+		public void Test008()
+		{
+			const string externalUri = "https://bunit.dev/docs/getting-started/index.html";
+			var sut = CreateFakeNavigationMananger();
+
+			sut.NavigateTo(externalUri);
+
+			sut.BaseUri.ShouldBe("https://bunit.dev/");
+			sut.Uri.ShouldBe(externalUri);
+		}
+
+		[Fact(DisplayName = "Navigate to external url should not invoke LocationChanged event")]
+		public void Test009()
+		{
+			var locationChangedInvoked = false;
+			const string externalUri = "https://bunit.dev/docs/getting-started/index.html";
+			var sut = CreateFakeNavigationMananger();
+			sut.LocationChanged += (s, e) => locationChangedInvoked = true;
+
+			sut.NavigateTo(externalUri);
+
+			locationChangedInvoked.ShouldBeFalse();
+		}
 	}
 }


### PR DESCRIPTION

## Pull request description
Fixes #665 

The basic idea is to check if we want to go to an external url. If so we will set the `BaseUri` to the new base uri.
Also we do **not** invoke the `LocationChanged` event when navigating away from the Blazor page.

### PR meta checklist
- [x] Pull request is targeted at `main` branch for code   
  or targeted at `stable` branch for documentation that is live on bunit.dev.
- [x] Pull request is linked to all related issues, if any.
- [x] I have read the _CONTRIBUTING.md_ document.

### Code PR specific checklist
- [x] My code follows the code style of this project and AspNetCore coding guidelines.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] I have updated the appropriate sub section in the _CHANGELOG.md_.
- [x] I have added, updated or removed tests to according to my changes.
  - [x] All tests passed.
