### PR TITLE
Feature/async exc

### DIFF
--- a/.github/workflows/verification.yml
+++ b/.github/workflows/verification.yml
@@ -63,7 +63,7 @@ jobs:
 
       - name: 🧪 Run unit tests
         run: |
-          dotnet test ./tests/bunit.core.tests/bunit.core.tests.csproj -c release --logger:"console;verbosity=normal" --blame-hang --blame-hang-timeout 1m --blame-hang-dump-type none
+          dotnet test ./tests/bunit.core.tests/bunit.core.tests.csproj -c release --logger:"console;verbosity=diagnostic" --blame-hang --blame-hang-timeout 1m --blame-hang-dump-type none
           dotnet test ./tests/bunit.web.tests/bunit.web.tests.csproj -c release --logger:"console;verbosity=normal" --blame-hang --blame-hang-timeout 1m --blame-hang-dump-type none
           dotnet test ./tests/bunit.web.testcomponents.tests/bunit.web.testcomponents.tests.csproj -c release --logger:"console;verbosity=normal" --blame-hang --blame-hang-timeout 1m --blame-hang-dump-type none
 

--- a/.github/workflows/verification.yml
+++ b/.github/workflows/verification.yml
@@ -63,7 +63,7 @@ jobs:
 
       - name: 🧪 Run unit tests
         run: |
-          dotnet test ./tests/bunit.core.tests/bunit.core.tests.csproj -c release --logger:"console;verbosity=diagnostic" --blame-hang --blame-hang-timeout 1m --blame-hang-dump-type none
+          dotnet test ./tests/bunit.core.tests/bunit.core.tests.csproj -c release --logger:"console;verbosity=diagnostic" --blame --blame-hang --blame-hang-timeout 1m --blame-hang-dump-type none
           dotnet test ./tests/bunit.web.tests/bunit.web.tests.csproj -c release --logger:"console;verbosity=normal" --blame-hang --blame-hang-timeout 1m --blame-hang-dump-type none
           dotnet test ./tests/bunit.web.testcomponents.tests/bunit.web.testcomponents.tests.csproj -c release --logger:"console;verbosity=normal" --blame-hang --blame-hang-timeout 1m --blame-hang-dump-type none
 

--- a/tests/bunit.core.tests/xunit.runner.json
+++ b/tests/bunit.core.tests/xunit.runner.json
@@ -1,4 +1,5 @@
 {
 	"$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
-	"diagnosticMessages": false
+	"diagnosticMessages": false,
+	"longRunningTestSeconds": 30
 }

--- a/tests/bunit.core.tests/xunit.runner.json
+++ b/tests/bunit.core.tests/xunit.runner.json
@@ -1,5 +1,5 @@
 {
 	"$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
-	"diagnosticMessages": false,
+	"diagnosticMessages": true,
 	"longRunningTestSeconds": 30
 }

--- a/tests/bunit.web.tests/JSInterop/BunitJSInteropTest.cs
+++ b/tests/bunit.web.tests/JSInterop/BunitJSInteropTest.cs
@@ -238,8 +238,10 @@ public partial class BunitJSInteropTest
 	{
 		var sut = CreateSut(JSRuntimeMode.Strict);
 		var planned = sut.SetupVoid("foo", "bar", 42);
-		// If we await here we run into a deadlock
+#pragma warning disable CS4014
+		//  If we await here we run into a deadlock
 		sut.JSRuntime.InvokeVoidAsync("foo", "bar", 42);
+#pragma warning restore CS4014
 
 		await Should.ThrowAsync<JSRuntimeUnhandledInvocationException>(async () => await sut.JSRuntime.InvokeVoidAsync("foo", "bar", 41));
 
@@ -255,8 +257,10 @@ public partial class BunitJSInteropTest
 	{
 		var sut = CreateSut(JSRuntimeMode.Strict);
 		var planned = sut.SetupVoid("foo", x => x.Arguments.Count == 2);
+#pragma warning disable CS4014
 		// If we await here we run into a deadlock
 		sut.JSRuntime.InvokeVoidAsync("foo", "bar", 42);
+#pragma warning restore CS4014
 
 		await Should.ThrowAsync<JSRuntimeUnhandledInvocationException>(async () => await sut.JSRuntime.InvokeVoidAsync("foo", 42));
 		await Should.ThrowAsync<JSRuntimeUnhandledInvocationException>(async () => await sut.JSRuntime.InvokeVoidAsync("foo"));


### PR DESCRIPTION
Use `await Should.ThrowAsync` for async operation.

Unfortunately this alone was not enough to make the "blame-hang-timeout" obsolete. It might still run until eternity and further.

Even [that very run crashed.](https://github.com/bUnit-dev/bUnit/pull/695/checks#step:8:959)