### PR TITLE
refactor: GitVersion in Directory.Build.props

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -44,5 +44,9 @@
 	<ItemGroup>
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
 	</ItemGroup>
+
+	<ItemGroup Label="Git versioning">
+		<PackageReference Include="Nerdbank.GitVersioning" Version="3.5.103" PrivateAssets="All" />
+	</ItemGroup>
 	
 </Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -43,10 +43,8 @@
 	
 	<ItemGroup>
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
-	</ItemGroup>
-
-	<ItemGroup Label="Git versioning">
 		<PackageReference Include="Nerdbank.GitVersioning" Version="3.5.103" PrivateAssets="All" />
+		
 	</ItemGroup>
 	
 </Project>

--- a/src/bunit.core/bunit.core.csproj
+++ b/src/bunit.core/bunit.core.csproj
@@ -14,10 +14,6 @@
 		</Description>
 	</PropertyGroup>
 
-	<ItemGroup>
-		<PackageReference Include="Nerdbank.GitVersioning" Version="3.4.255" PrivateAssets="All" />
-	</ItemGroup>
-	
 	<ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
 		<PackageReference Include="Microsoft.Extensions.Logging" Version="$(DotNet3Version)" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(DotNet3Version)" />

--- a/src/bunit.template/bunit.template.csproj
+++ b/src/bunit.template/bunit.template.csproj
@@ -22,10 +22,6 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Nerdbank.GitVersioning" Version="3.4.255" PrivateAssets="All" />
-	</ItemGroup>
-	
-	<ItemGroup>
 		<Content Include="template\**\*" Exclude="template\**\bin\**;template\**\obj\**;template\**\.vs\**" />
 		<Compile Remove="**\*" />
 		<Compile Remove="template\obj\**" />

--- a/src/bunit.web.testcomponents/bunit.web.testcomponents.csproj
+++ b/src/bunit.web.testcomponents/bunit.web.testcomponents.csproj
@@ -24,7 +24,6 @@ NOTE: This package represents experimental features of bUnit that has been super
 		<PackageReference Include="xunit.assert" Version="2.4.1" />
 		<PackageReference Include="xunit.extensibility.core" Version="2.4.1" />
 		<PackageReference Include="xunit.extensibility.execution" Version="2.4.1" />
-		<PackageReference Include="Nerdbank.GitVersioning" Version="3.4.255" PrivateAssets="All" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">

--- a/src/bunit.web/bunit.web.csproj
+++ b/src/bunit.web/bunit.web.csproj
@@ -19,7 +19,6 @@
 		<PackageReference Include="AngleSharp.Css" Version="0.16.4" />
 		<PackageReference Include="AngleSharp.Diffing" Version="0.17.0" />
 		<PackageReference Include="AngleSharp.Wrappers" Version="2.0.0" />
-		<PackageReference Include="Nerdbank.GitVersioning" Version="3.4.255" PrivateAssets="All" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">

--- a/src/bunit/bunit.csproj
+++ b/src/bunit/bunit.csproj
@@ -25,8 +25,4 @@
 	  <ProjectReference Include="..\bunit.web\bunit.web.csproj" />
 	</ItemGroup>
 
-	<ItemGroup>
-		<PackageReference Include="Nerdbank.GitVersioning" Version="3.4.255" PrivateAssets="All" />
-	</ItemGroup>
-
 </Project>


### PR DESCRIPTION
Just a smaller quality of life PR:
GitVersion nuget package was used in every src project so it made sense to move it up to the `Directory.Builds.props`.

If merged, closes #699 as I already use the new version.