### PR TITLE
refactor: use StringBuilder instead of List

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to **bUnit** will be documented in this file. The project ad
 
 ## [Unreleased]
 
+### Changed
+ -   `Htmlizer` uses `StringBuilder` instead of `List<string>` to reduce allocations and improve render speed. By [@linkdotnet](https://github.com/linkdotnet).
+
 ## [1.7.7] - 2022-04-29
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to **bUnit** will be documented in this file. The project ad
 ## [Unreleased]
 
 ### Changed
- -   `Htmlizer` uses `StringBuilder` instead of `List<string>` to reduce allocations and improve render speed. By [@linkdotnet](https://github.com/linkdotnet).
+ - `Htmlizer` uses `StringBuilder` instead of `List<string>` to reduce allocations and improve render speed. By [@linkdotnet](https://github.com/linkdotnet).
 
 ## [1.7.7] - 2022-04-29
 

--- a/src/bunit.web/Rendering/Internal/Htmlizer.cs
+++ b/src/bunit.web/Rendering/Internal/Htmlizer.cs
@@ -4,6 +4,7 @@
 // of the license from the aspnetcore repository.
 using System.Diagnostics;
 using System.Globalization;
+using System.Text;
 using System.Text.Encodings.Web;
 using Bunit.Rendering;
 
@@ -59,7 +60,7 @@ internal static class Htmlizer
 		var frames = context.GetRenderTreeFrames(componentId);
 		var newPosition = RenderFrames(context, frames, 0, frames.Count);
 		Debug.Assert(newPosition == frames.Count, $"frames.Count = {frames.Count}. newPosition = {newPosition}");
-		return string.Join(string.Empty, context.Result);
+		return context.Result.ToString();
 	}
 
 	private static int RenderFrames(HtmlRenderingContext context, ArrayRange<RenderTreeFrame> frames, int position, int maxElements)
@@ -94,10 +95,10 @@ internal static class Htmlizer
 			case RenderTreeFrameType.Attribute:
 				throw new InvalidOperationException($"Attributes should only be encountered within {nameof(RenderElement)}");
 			case RenderTreeFrameType.Text:
-				context.Result.Add(HtmlEncoder.Encode(frame.TextContent));
+				context.Result.Append(HtmlEncoder.Encode(frame.TextContent));
 				return position + 1;
 			case RenderTreeFrameType.Markup:
-				context.Result.Add(frame.MarkupContent);
+				context.Result.Append(frame.MarkupContent);
 				return position + 1;
 			case RenderTreeFrameType.Component:
 				return RenderChildComponent(context, frames, position);
@@ -129,8 +130,8 @@ internal static class Htmlizer
 	{
 		ref var frame = ref frames.Array[position];
 		var result = context.Result;
-		result.Add("<");
-		result.Add(frame.ElementName);
+		result.Append('<');
+		result.Append(frame.ElementName);
 		var afterAttributes = RenderAttributes(context, frames, position + 1, frame.ElementSubtreeLength - 1, out var capturedValueAttribute);
 
 		// When we see an <option> as a descendant of a <select>, and the option's "value" attribute matches the
@@ -140,13 +141,13 @@ internal static class Htmlizer
 			&& string.Equals(frame.ElementName, "option", StringComparison.OrdinalIgnoreCase)
 			&& string.Equals(capturedValueAttribute, context.ClosestSelectValueAsString, StringComparison.Ordinal))
 		{
-			result.Add(" selected");
+			result.Append(" selected");
 		}
 
 		var remainingElements = frame.ElementSubtreeLength + position - afterAttributes;
 		if (remainingElements > 0)
 		{
-			result.Add(">");
+			result.Append('>');
 
 			var isSelect = string.Equals(frame.ElementName, "select", StringComparison.OrdinalIgnoreCase);
 			if (isSelect)
@@ -163,22 +164,22 @@ internal static class Htmlizer
 				context.ClosestSelectValueAsString = null;
 			}
 
-			result.Add("</");
-			result.Add(frame.ElementName);
-			result.Add(">");
+			result.Append("</");
+			result.Append(frame.ElementName);
+			result.Append('>');
 			return afterElement;
 		}
 
 		if (SelfClosingElements.Contains(frame.ElementName))
 		{
-			result.Add(" />");
+			result.Append(" />");
 		}
 		else
 		{
-			result.Add(">");
-			result.Add("</");
-			result.Add(frame.ElementName);
-			result.Add(">");
+			result.Append('>');
+			result.Append("</");
+			result.Append(frame.ElementName);
+			result.Append('>');
 		}
 
 		Debug.Assert(afterAttributes == position + frame.ElementSubtreeLength, $"afterAttributes = {afterAttributes}. position = {position}. frame.ElementSubtreeLength = {frame.ElementSubtreeLength}");
@@ -220,7 +221,8 @@ internal static class Htmlizer
 			// Added to write ElementReferenceCaptureId to DOM
 			if (frame.FrameType == RenderTreeFrameType.ElementReferenceCapture)
 			{
-				result.Add($" {ElementReferenceAttrName}=\"{frame.ElementReferenceCaptureId}\"");
+				var value = $" {ElementReferenceAttrName}=\"{frame.ElementReferenceCaptureId}\"";
+				result.Append(value);
 			}
 
 			if (frame.FrameType != RenderTreeFrameType.Attribute)
@@ -238,13 +240,13 @@ internal static class Htmlizer
 				// NOTE: this was changed to make it more obvious
 				//       that this is a generated/special blazor attribute
 				//       used for tracking event handler id's
-				result.Add(" ");
-				result.Add(BlazorAttrPrefix);
-				result.Add(frame.AttributeName);
-				result.Add("=");
-				result.Add("\"");
-				result.Add(frame.AttributeEventHandlerId.ToString(CultureInfo.InvariantCulture));
-				result.Add("\"");
+				result.Append(' ');
+				result.Append(BlazorAttrPrefix);
+				result.Append(frame.AttributeName);
+				result.Append('=');
+				result.Append('"');
+				result.Append(frame.AttributeEventHandlerId.ToString(CultureInfo.InvariantCulture));
+				result.Append('"');
 				continue;
 			}
 
@@ -255,23 +257,23 @@ internal static class Htmlizer
 					// that this is a generated/special blazor attribute
 					// for internal usage
 					var nameParts = frame.AttributeName.Split('_', StringSplitOptions.RemoveEmptyEntries);
-					result.Add(" ");
-					result.Add(BlazorAttrPrefix);
-					result.Add(nameParts[2]);
-					result.Add(":");
-					result.Add(nameParts[1]);
+					result.Append(' ');
+					result.Append(BlazorAttrPrefix);
+					result.Append(nameParts[2]);
+					result.Append(':');
+					result.Append(nameParts[1]);
 					break;
-				case bool flag when flag:
-					result.Add(" ");
-					result.Add(frame.AttributeName);
+				case bool flag and true:
+					result.Append(' ');
+					result.Append(frame.AttributeName);
 					break;
 				case string value:
-					result.Add(" ");
-					result.Add(frame.AttributeName);
-					result.Add("=");
-					result.Add("\"");
-					result.Add(HtmlEncoder.Encode(value));
-					result.Add("\"");
+					result.Append(' ');
+					result.Append(frame.AttributeName);
+					result.Append('=');
+					result.Append('"');
+					result.Append(HtmlEncoder.Encode(value));
+					result.Append('"');
 					break;
 				default:
 					break;
@@ -293,7 +295,7 @@ internal static class Htmlizer
 		public ArrayRange<RenderTreeFrame> GetRenderTreeFrames(int componentId)
 			=> frames[componentId];
 
-		public List<string> Result { get; } = new List<string>();
+		public StringBuilder Result { get; } = new ();
 
 		public string? ClosestSelectValueAsString { get; set; }
 	}


### PR DESCRIPTION
# Replace `List<string>` with `StringBuilder` in `Htmlizer`
The PR replaces the current `List<string>` with a `StringBuilder`.  This brings mainly 3 advantages:
 * Make the intent better visible
 * Less allocations
 * Better performance

I know the original implementation comes from @SteveSandersonMS, but not sure what the motivation was.
Anyway I thought I take the lead and propose a different approach with the given advantages on the top.
Feedback very welcome.

# Rendering a sample component
The test just renders a rather small component. The results will be even better when we render bigger components.
For the test I used the `MultipleChildContent` as reference. 

## Old
```csharp
|          Method |     Mean |   Error |   StdDev |   Gen 0 |   Gen 1 | Allocated |
|---------------- |---------:|--------:|---------:|--------:|--------:|----------:|
| RenderComponent | 388.9 us | 7.72 us | 19.07 us | 42.9688 | 14.1602 |    179 KB |
```

## New
```csharp
|          Method |     Mean |   Error |   StdDev |   Gen 0 |   Gen 1 | Allocated |
|---------------- |---------:|--------:|---------:|--------:|--------:|----------:|
| RenderComponent | 368.3 us | 7.77 us | 22.03 us | 41.0156 | 13.6719 |    170 KB |
```

# General
In general `StringBuilder` is faster and uses less allocations than a `List<string>`.
I built a small [sample benchmark](https://gist.github.com/linkdotnet/fc8ef970b504a6c69f633053383c8084) with the following results:
```csharp
|          Method |       Mean |    Error |   StdDev |     Median | Ratio | RatioSD |  Gen 0 | Allocated |
|---------------- |-----------:|---------:|---------:|-----------:|------:|--------:|-------:|----------:|
|          ByList | 1,993.5 ns | 58.49 ns | 167.8 ns | 1,988.0 ns |  1.00 |    0.00 | 0.7744 |      3 KB |
| ByStringBuilder |   896.6 ns | 78.55 ns | 231.6 ns |   811.9 ns |  0.45 |    0.12 | 0.5980 |      2 KB |

```