### PR TITLE
refactor: use ReadOnlySpan<char> in htmlparser

### DIFF
--- a/src/bunit.web/Rendering/BunitHtmlParser.cs
+++ b/src/bunit.web/Rendering/BunitHtmlParser.cs
@@ -61,8 +61,10 @@ public sealed class BunitHtmlParser : IDisposable
 	{
 		if (markup is null)
 			throw new ArgumentNullException(nameof(markup));
+			
+		var document = GetNewDocumentAsync().GetAwaiter().GetResult();
 
-		var (ctx, matchedElement) = GetParseContextAsync(markup).GetAwaiter().GetResult();
+		var (ctx, matchedElement) = GetParseContext(markup, document);
 
 		return ctx is null && matchedElement is not null
 			? ParseSpecial(markup, matchedElement)
@@ -82,9 +84,10 @@ public sealed class BunitHtmlParser : IDisposable
 		};
 	}
 
-	private async Task<(IElement? Context, string? MatchedElement)> GetParseContextAsync(string markup)
+	private static (IElement? Context, string? MatchedElement) GetParseContext(
+		ReadOnlySpan<char> markup, 
+		IDocument document)
 	{
-		var document = await GetNewDocumentAsync().ConfigureAwait(false);
 		var startIndex = markup.IndexOfFirstNonWhitespaceChar();
 
 		// verify that first non-whitespace characters is a '<'
@@ -96,7 +99,10 @@ public sealed class BunitHtmlParser : IDisposable
 		return (Context: document.Body, MatchedElement: null);
 	}
 
-	private static (IElement? Context, string? MatchedElement) GetParseContextFromTag(string markup, int startIndex, IDocument document)
+	private static (IElement? Context, string? MatchedElement) GetParseContextFromTag(
+		ReadOnlySpan<char> markup,
+		int startIndex,
+		IDocument document)
 	{
 		Debug.Assert(document.Body is not null, "Body of the document should never be null at this point.");
 

--- a/src/bunit.web/Rendering/Internal/BunitHtmlParserHelpers.cs
+++ b/src/bunit.web/Rendering/Internal/BunitHtmlParserHelpers.cs
@@ -2,7 +2,11 @@ namespace Bunit.Rendering;
 
 internal static class BunitHtmlParserHelpers
 {
-	internal static bool StartsWithElements(this string markup, string[] tags, int startIndex, [NotNullWhen(true)] out string? matchedElement)
+	internal static bool StartsWithElements(
+		this ReadOnlySpan<char> markup,
+		string[] tags,
+		int startIndex,
+		[NotNullWhen(true)] out string? matchedElement)
 	{
 		matchedElement = null;
 
@@ -18,7 +22,7 @@ internal static class BunitHtmlParserHelpers
 		return false;
 	}
 
-	internal static bool StartsWithElement(this string markup, string tag, int startIndex)
+	internal static bool StartsWithElement(this ReadOnlySpan<char> markup, string tag, int startIndex)
 	{
 		var matchesTag = tag.Length + 1 < markup.Length - startIndex;
 		var charIndexAfterTag = tag.Length + startIndex + 1;
@@ -49,11 +53,11 @@ internal static class BunitHtmlParserHelpers
 
 	internal static bool IsTagStart(this char c) => c == '<';
 
-	internal static int IndexOfFirstNonWhitespaceChar(this string markup)
+	internal static int IndexOfFirstNonWhitespaceChar(this ReadOnlySpan<char> markup)
 	{
 		for (int i = 0; i < markup.Length; i++)
 		{
-			if (!char.IsWhiteSpace(markup, i))
+			if (!char.IsWhiteSpace(markup[i]))
 				return i;
 		}
 


### PR DESCRIPTION
# Using `ReadOnlySpan<char>` instead of string - Motivation
`ReadOnlySpan<char>` has some advantages over `string` especially when slicing the string (allocation - free) as well as faster iteration through the code.
We can leverage the second behavior in our `BunitHtmlParser` without adopting much of the code. The only passage which had to be changed is the async retrieval of the document.
As `ref struct`s live only on the stack, they don't work well with `async` in the first place.

Here the test setup I used:
<details>
<summary>Benchmark</summary>

```csharp
using AngleSharp.Dom;
using BenchmarkDotNet.Attributes;
using Bunit.Rendering;

namespace Bunit;

[MemoryDiagnoser]
public class Benchmark
{
    private const string Markup = @"
<html>
  <head>
    <title>Href Attribute Example</title>
  </head>
  <body>
    <div>
        <p class=""some-class"">Divs are always code</p>
    </div>
    <h1>Href Attribute Example</h1>
    <p>
      <a href=""https://www.freecodecamp.org/contribute/"">The freeCodeCamp Contribution Page</a> shows you how and where you can contribute to freeCodeCamp's community and growth.
    </p>
    </body>
    </html>
";
    private BunitHtmlParser parser = default!;

    [Benchmark]
    public INodeList RenderCounter() => parser.Parse(Markup);

    [GlobalSetup]
    public void Setup() => parser = new BunitHtmlParser();

    [GlobalCleanup]
    public void Cleanup() => parser.Dispose();
}
```

</details>

## Reference: Old Version string 
```csharp
|   Method |     Mean |    Error |   StdDev |  Gen 0 |  Gen 1 | Allocated |
|--------- |---------:|---------:|---------:|-------:|-------:|----------:|
| GetNodes | 97.61 us | 4.203 us | 12.33 us | 6.4697 | 1.8311 |     40 KB |
```

## New Version: `ReadOnlySpan<char>`
```csharp
|   Method |     Mean |    Error |   StdDev |  Gen 0 |  Gen 1 | Allocated |
|--------- |---------:|---------:|---------:|-------:|-------:|----------:|
| GetNodes | 75.10 us | 1.496 us | 1.723 us | 6.4697 | 1.8311 |     40 KB |

```

## Risks
The API is still the same as the public method still retrieves a `string` but every subsequent private method, which "really" does something with the string takes the `ReadOnlySpan<char>`.
Code-wise not much had to be changed.

## Outlook
With C#11 and bUnit v2.0 we could even go further. If we have the chance to change the public API we could use `ReadOnlySpan<char>` more aggressive (see motivation above). C# 11 allows switch expression on `ReadOnlySpan<char>` which we could use in some cases as well. 