### PR TITLE
refactor: check if main branch

### DIFF
--- a/.github/workflows/release-preview.yml
+++ b/.github/workflows/release-preview.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   release-preview:
-    if: github.event_name == 'workflow_dispatch' || ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: github.event_name == 'workflow_dispatch' || (github.ref == 'refs/heads/main' && ${{ github.event.workflow_run.conclusion == 'success' }})
     runs-on: ubuntu-latest
     steps:
     


### PR DESCRIPTION
Only run `release-preview` when triggered from `main`.