### PR TITLE
fix: Benchmarks are not packable

### DIFF
--- a/benchmark/Directory.Build.props
+++ b/benchmark/Directory.Build.props
@@ -5,6 +5,7 @@
 		<LangVersion>10.0</LangVersion>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<NoWarn>CA1014,NU5104</NoWarn>
+	        <IsPackable>false</IsPackable>
 
 		<!-- Used by code coverage -->
 		<DebugType>full</DebugType>


### PR DESCRIPTION
The benchmark project should not be published as separate nuget package.