### PR TITLE
fix: dont support net7 for deprecated testcomponents

### DIFF
--- a/src/bunit.web.testcomponents/bunit.web.testcomponents.csproj
+++ b/src/bunit.web.testcomponents/bunit.web.testcomponents.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>netstandard2.1;net5.0;net6.0;net7.0</TargetFrameworks>
+		<TargetFrameworks>netstandard2.1;net5.0;net6.0</TargetFrameworks>
 		<RootNamespace>Bunit</RootNamespace>
 		<AssemblyName>Bunit.Web.TestComponents</AssemblyName>
 	</PropertyGroup>
@@ -12,38 +12,29 @@
 		<Description>
 			bUnit.web.testcomponents enables writing tests using the &lt;Fixture&gt; and &lt;SnapshotTest&gt; components in .razor files.
 
-This package only works with xUnit.
+			This package only works with xUnit.
 
-NOTE: This package represents experimental features of bUnit that has been superseded by better ones. It is provided to avoid breaking existing test suites but is unlikely to see improvements or updates in the future.
+			NOTE: This package represents experimental features of bUnit that has been superseded by better ones. It is provided to avoid breaking existing test suites but is unlikely to see improvements or updates in the future.
 		</Description>
 	</PropertyGroup>
 
 	<ItemGroup>
 		<PackageReference Include="SourceFileFinder" Version="1.1.0" />
-		<PackageReference Include="System.Reflection.Metadata" Version="$(DotNet5Version)" />
 		<PackageReference Include="xunit.assert" Version="2.4.1" />
 		<PackageReference Include="xunit.extensibility.core" Version="2.4.1" />
 		<PackageReference Include="xunit.extensibility.execution" Version="2.4.1" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
-		<PackageReference Include="Microsoft.AspNetCore.Components" Version="$(DotNet3Version)" />
-		<PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="$(DotNet3Version)" />
+		<PackageReference Include="System.Reflection.Metadata" Version="$(DotNet5Version)" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
-		<PackageReference Include="Microsoft.AspNetCore.Components" Version="$(DotNet5Version)" />
-		<PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="$(DotNet5Version)" />
+		<PackageReference Include="System.Reflection.Metadata" Version="$(DotNet5Version)" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-		<PackageReference Include="Microsoft.AspNetCore.Components" Version="$(DotNet6Version)" />
-		<PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="$(DotNet6Version)" />
-	</ItemGroup>
-
-	<ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
-		<PackageReference Include="Microsoft.AspNetCore.Components" Version="$(DotNet7Version)" />
-		<PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="$(DotNet7Version)" />
+		<PackageReference Include="System.Reflection.Metadata" Version="$(DotNet6Version)" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/bunit.web.testcomponents/bunit.web.testcomponents.csproj
+++ b/src/bunit.web.testcomponents/bunit.web.testcomponents.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>netstandard2.1;net5.0;net6.0</TargetFrameworks>
+		<TargetFrameworks>netstandard2.1;net5.0</TargetFrameworks>
 		<RootNamespace>Bunit</RootNamespace>
 		<AssemblyName>Bunit.Web.TestComponents</AssemblyName>
 	</PropertyGroup>

--- a/tests/bunit.web.testcomponents.tests/RazorTesting/RazorTestDiscovererTest.cs
+++ b/tests/bunit.web.testcomponents.tests/RazorTesting/RazorTestDiscovererTest.cs
@@ -1,6 +1,8 @@
 using Bunit.SampleComponents;
 using Xunit.Abstractions;
+using Xunit;
 using Xunit.Sdk;
+using Xunit.Runners;
 
 namespace Bunit.RazorTesting;
 

--- a/tests/bunit.web.testcomponents.tests/RazorTesting/RazorTestSourceInformationProviderTest.cs
+++ b/tests/bunit.web.testcomponents.tests/RazorTesting/RazorTestSourceInformationProviderTest.cs
@@ -16,14 +16,15 @@ public sealed class RazorTestSourceInformationProviderTest : IDisposable
 		return tests[testIndex - 1];
 	}
 
-	// Ignored because file doesnt seem to be compile on Linux [InlineData(typeof(MixedCaseComponent), 1, 2)]
+	// Ignored because file doesnt seem to be compile on Linux
+	// [InlineData(typeof(MixedCaseComponent), 1, 2)]
+	// [InlineData(typeof(TestCasesWithWeirdLineBreaks), 1, 2)]
+	// [InlineData(typeof(TestCasesWithWeirdLineBreaks), 2, 7)]
 	[Theory(DisplayName = "Can find source info")]
 	[InlineData(typeof(ComponentWithoutMethods), 1, 2)]
 	[InlineData(typeof(ComponentWithMethod), 1, 2)]
 	[InlineData(typeof(ComponentWithTwoTests), 1, 3)]
 	[InlineData(typeof(ComponentWithTwoTests), 2, 8)]
-	[InlineData(typeof(TestCasesWithWeirdLineBreaks), 1, 2)]
-	[InlineData(typeof(TestCasesWithWeirdLineBreaks), 2, 7)]
 	public void Test001(Type target, int testNumber, int expectedLineNumber)
 	{
 		using var sut = new RazorTestSourceInformationProvider(messageBus);

--- a/tests/bunit.web.testcomponents.tests/RazorTesting/RazorTestSourceInformationProviderTest.cs
+++ b/tests/bunit.web.testcomponents.tests/RazorTesting/RazorTestSourceInformationProviderTest.cs
@@ -18,13 +18,13 @@ public sealed class RazorTestSourceInformationProviderTest : IDisposable
 
 	// Ignored because file doesnt seem to be compile on Linux
 	// [InlineData(typeof(MixedCaseComponent), 1, 2)]
-	// [InlineData(typeof(TestCasesWithWeirdLineBreaks), 1, 2)]
-	// [InlineData(typeof(TestCasesWithWeirdLineBreaks), 2, 7)]
 	[Theory(DisplayName = "Can find source info")]
 	[InlineData(typeof(ComponentWithoutMethods), 1, 2)]
 	[InlineData(typeof(ComponentWithMethod), 1, 2)]
 	[InlineData(typeof(ComponentWithTwoTests), 1, 3)]
 	[InlineData(typeof(ComponentWithTwoTests), 2, 8)]
+	[InlineData(typeof(TestCasesWithWeirdLineBreaks), 1, 2)]
+	[InlineData(typeof(TestCasesWithWeirdLineBreaks), 2, 7)]
 	public void Test001(Type target, int testNumber, int expectedLineNumber)
 	{
 		using var sut = new RazorTestSourceInformationProvider(messageBus);

--- a/tests/bunit.web.testcomponents.tests/SampleComponents/MixedCaseComponent.rAzOr
+++ b/tests/bunit.web.testcomponents.tests/SampleComponents/MixedCaseComponent.rAzOr
@@ -1,2 +1,0 @@
-@inherits TestComponentBase
-<SnapshotTest><TestInput></TestInput><ExpectedOutput></ExpectedOutput></SnapshotTest>

--- a/tests/bunit.web.testcomponents.tests/bunit.web.testcomponents.tests.csproj
+++ b/tests/bunit.web.testcomponents.tests/bunit.web.testcomponents.tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
 	<PropertyGroup>
-		<TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+		<TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
 		<RootNamespace>Bunit</RootNamespace>
 		<AssemblyName>Bunit.Web.TestComponents.Tests</AssemblyName>
 		<EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>

--- a/tests/bunit.web.testcomponents.tests/bunit.web.testcomponents.tests.csproj
+++ b/tests/bunit.web.testcomponents.tests/bunit.web.testcomponents.tests.csproj
@@ -1,21 +1,21 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
 	<PropertyGroup>
-		<TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+		<TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
 		<RootNamespace>Bunit</RootNamespace>
 		<AssemblyName>Bunit.Web.TestComponents.Tests</AssemblyName>
+		<EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="System.Reflection.Metadata" Version="5.0.0" />
 		<PackageReference Include="xunit.extensibility.core" Version="2.4.1" />
 		<PackageReference Include="xunit.extensibility.execution" Version="2.4.1" />
 		<PackageReference Include="xunit.runner.utility" Version="2.4.1" />
 	</ItemGroup>
 
 	<ItemGroup>
-		<ProjectReference Include="..\..\src\bunit.web\bunit.web.csproj" />
 		<ProjectReference Include="..\..\src\bunit.web.testcomponents\bunit.web.testcomponents.csproj" />
+		<ProjectReference Include="..\..\src\bunit.web\bunit.web.csproj" />
 		<ProjectReference Include="..\bunit.testassets\bunit.testassets.csproj" />
 	</ItemGroup>
 


### PR DESCRIPTION
## Pull request description

I dont want to support net7 for test components, so that is removed. Unfortunately they are on nuget with .net6 target framework, so I updated the test project to also test for .net6.

This should also fix the failing nightly-builds with net7.

### PR meta checklist
- [x] Pull request is targeted at `main` branch for code   
  or targeted at `stable` branch for documentation that is live on bunit.dev.
- [ ] Pull request is linked to all related issues, if any.
- [ ] I have read the _CONTRIBUTING.md_ document.

### Code PR specific checklist
- [x] My code follows the code style of this project and AspNetCore coding guidelines.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] I have updated the appropriate sub section in the _CHANGELOG.md_.
- [x] I have added, updated or removed tests to according to my changes.
  - [x] All tests passed.
