### PR TITLE
fix: deadlock between FindComponents and updates of rendered components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to **bUnit** will be documented in this file. The project ad
 
 ## [Unreleased]
 
+### Fixes
+
+- A race condition existed between `WaitForState` / `WaitForAssertion` and `FindComponents`, if the first used the latter. Reported by [@rmihael](https://github.com/rmihael), [@SviatoslavK](https://github.com/SviatoslavK), and [@RaphaelMarcouxCTRL](https://github.com/RaphaelMarcouxCTRL). Fixed by [@egil](https://github.com/egil) and [@linkdotnet](https://github.com/linkdotnet).
+
 ## [1.8.15] - 2022-05-19
 
 ### Added

--- a/src/bunit.core/Extensions/WaitForHelpers/WaitForHelperLoggerExtensions.cs
+++ b/src/bunit.core/Extensions/WaitForHelpers/WaitForHelperLoggerExtensions.cs
@@ -23,20 +23,50 @@ internal static class WaitForHelperLoggerExtensions
 		= LoggerMessage.Define<int>(LogLevel.Debug, new EventId(20, "OnTimeout"), "The waiter for component {Id} disposed.");
 
 	internal static void LogCheckingWaitCondition<T>(this ILogger<WaitForHelper<T>> logger, int componentId)
-		=> CheckingWaitCondition(logger, componentId, null);
+	{
+		if (logger.IsEnabled(LogLevel.Debug))
+		{
+			CheckingWaitCondition(logger, componentId, null);
+		}
+	}
 
 	internal static void LogCheckCompleted<T>(this ILogger<WaitForHelper<T>> logger, int componentId)
-		=> CheckCompleted(logger, componentId, null);
+	{
+		if (logger.IsEnabled(LogLevel.Debug))
+		{
+			CheckCompleted(logger, componentId, null);
+		}
+	}
 
 	internal static void LogCheckFailed<T>(this ILogger<WaitForHelper<T>> logger, int componentId)
-		=> CheckFailed(logger, componentId, null);
+	{
+		if (logger.IsEnabled(LogLevel.Debug))
+		{
+			CheckFailed(logger, componentId, null);
+		}
+	}
 
 	internal static void LogCheckThrow<T>(this ILogger<WaitForHelper<T>> logger, int componentId, Exception exception)
-		=> CheckThrow(logger, componentId, exception);
+	{
+		if (logger.IsEnabled(LogLevel.Debug))
+		{
+			CheckThrow(logger, componentId, exception);
+		}
+	}
 
 	internal static void LogWaiterTimedOut<T>(this ILogger<WaitForHelper<T>> logger, int componentId)
-		=> WaiterTimedOut(logger, componentId, null);
+	{
+		if (logger.IsEnabled(LogLevel.Debug))
+		{
+			WaiterTimedOut(logger, componentId, null);
+		}
+	}
 
 	internal static void LogWaiterDisposed<T>(this ILogger<WaitForHelper<T>> logger, int componentId)
-		=> WaiterDisposed(logger, componentId, null);
+	{
+		if (logger.IsEnabled(LogLevel.Debug))
+		{
+			WaiterDisposed(logger, componentId, null);
+		}
+	}
 }

--- a/tests/bunit.core.tests/Extensions/WaitForHelpers/RenderedFragmentWaitForHelperExtensionsTest.cs
+++ b/tests/bunit.core.tests/Extensions/WaitForHelpers/RenderedFragmentWaitForHelperExtensionsTest.cs
@@ -37,7 +37,6 @@ public class RenderedFragmentWaitForHelperExtensionsTest : TestContext
 			cut.WaitForAssertion(() => cut.Markup.ShouldBeEmpty(), TimeSpan.FromMilliseconds(10)));
 
 		expected.Message.ShouldBe(WaitForAssertionHelper.TimeoutMessage);
-		expected.InnerException.ShouldBeOfType<ShouldAssertException>();
 	}
 
 	[Fact(DisplayName = "WaitForState throws exception after timeout")]

--- a/tests/bunit.testassets/AssertExtensions/TaskAssertionExtensions.cs
+++ b/tests/bunit.testassets/AssertExtensions/TaskAssertionExtensions.cs
@@ -1,0 +1,10 @@
+namespace Bunit;
+
+public static class TaskAssertionExtensions
+{
+	public static async Task ShouldCompleteWithin(this Task task, TimeSpan timeout)
+	{
+		if (task != await Task.WhenAny(task, Task.Delay(timeout)))
+			throw new TimeoutException();
+	}
+}

--- a/tests/bunit.web.tests/BlazorE2E/ComponentRenderingTest.cs
+++ b/tests/bunit.web.tests/BlazorE2E/ComponentRenderingTest.cs
@@ -529,7 +529,7 @@ public class ComponentRenderingTest : TestContext
 			timeout: TimeSpan.FromMilliseconds(2000));
 	}
 
-	[Fact(Skip = "Fails on Linux from time to time. Disabled for now.")]
+	[Fact]
 	public void CanDispatchRenderToSyncContext()
 	{
 		var cut = RenderComponent<DispatchingComponent>();
@@ -540,7 +540,7 @@ public class ComponentRenderingTest : TestContext
 		cut.WaitForAssertion(() => Assert.Equal("Success (completed synchronously)", result.TextContent.Trim()));
 	}
 
-	[Fact(Skip = "Fails on Linux from time to time. Disabled for now.")]
+	[Fact]
 	public void CanDoubleDispatchRenderToSyncContext()
 	{
 		var cut = RenderComponent<DispatchingComponent>();

--- a/tests/bunit.web.tests/Extensions/WaitForHelpers/RenderedFragmentWaitForElementsHelperExtensionsTest.cs
+++ b/tests/bunit.web.tests/Extensions/WaitForHelpers/RenderedFragmentWaitForElementsHelperExtensionsTest.cs
@@ -30,7 +30,6 @@ public class RenderedFragmentWaitForElementsHelperExtensionsTest : TestContext
 			cut.WaitForElement("#notHereElm", TimeSpan.FromMilliseconds(10)));
 
 		expected.Message.ShouldBe(WaitForElementHelper.TimeoutBeforeFoundMessage);
-		expected.InnerException.ShouldBeOfType<ElementNotFoundException>();
 	}
 
 	[Fact(DisplayName = "WaitForElements waits until cssSelector returns at least one element")]


### PR DESCRIPTION
Fixed #577.

THIS is experimental.

My idea was to, instead of using a lock around the the render tree getting build and find component's traversing the render tree to find components, is to just run the find component logic inside the dispatcher for the renderer. That should ensure that only at the time is allowed to happen.

## Pull request description
<!--- 
    Describe the changes and motivation behind them here, if it is not obvious
    from the related issues. Does it have new features, breaking changes, etc. 
-->

### PR meta checklist
- [x] Pull request is targeted at `main` branch for code   
  or targeted at `stable` branch for documentation that is live on bunit.dev.
- [x] Pull request is linked to all related issues, if any.
- [x] I have read the _CONTRIBUTING.md_ document.

### Code PR specific checklist
- [x] My code follows the code style of this project and AspNetCore coding guidelines.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] I have updated the appropriate sub section in the _CHANGELOG.md_.
- [x] I have added, updated or removed tests to according to my changes.
  - [x] All tests passed.
