### PR TITLE
build: enable osx, run template tests on windows also

### DIFF
--- a/.github/workflows/verification.yml
+++ b/.github/workflows/verification.yml
@@ -60,16 +60,21 @@ jobs:
         with:
           files: '["docs/site/*.md", "docs/**/*.md", "docs/**/*.tmpl.partial", "*.csproj", "**/*.csproj"]'
 
-      - name: 🐜 Ensure nuget.org source on Windows
-        if: matrix.os == 'windows-latest'
-        run: dotnet nuget add source https://api.nuget.org/v3/index.json -n nuget.org --configfile $env:APPDATA\NuGet\NuGet.Config
-        continue-on-error: true
-
       - name: 🧪 Run unit tests
         run: |
-          dotnet test ./tests/bunit.core.tests/bunit.core.tests.csproj -c release --blame-hang --blame-hang-timeout 1m --blame-hang-dump-type full
-          dotnet test ./tests/bunit.web.tests/bunit.web.tests.csproj -c release --blame-hang --blame-hang-timeout 1m --blame-hang-dump-type full
-          dotnet test ./tests/bunit.web.testcomponents.tests/bunit.web.testcomponents.tests.csproj -c release --blame-hang --blame-hang-timeout 1m --blame-hang-dump-type full
+          dotnet test ./tests/bunit.core.tests/bunit.core.tests.csproj -c release --blame-hang-timeout 15s --blame-hang-dump-type full --blame-crash-dump-type full
+          dotnet test ./tests/bunit.web.tests/bunit.web.tests.csproj -c release --blame-hang-timeout 15s --blame-hang-dump-type full --blame-crash-dump-type full
+          dotnet test ./tests/bunit.web.testcomponents.tests/bunit.web.testcomponents.tests.csproj -c release --blame-hang-timeout 15s --blame-hang-dump-type full --blame-crash-dump-type full
+
+      - name: 📛 Upload hang- and crash-dumps on test failure
+        if: failure()
+        uses: actions/upload-artifact@v3
+        with:
+          if-no-files-found: ignore
+          name: test-dumps
+          path: |
+            **/*hangdump.dmp
+            **/*crashdump.dmp
 
       - name: 🗳️ Pack library
         run: |

--- a/.github/workflows/verification.yml
+++ b/.github/workflows/verification.yml
@@ -15,6 +15,10 @@ on:
       - reopened
 
   workflow_dispatch:
+  
+concurrency:
+  group: verification-${{ github.ref }}-1
+  cancel-in-progress: true  
 
 jobs:
   verify-bunit:

--- a/.github/workflows/verification.yml
+++ b/.github/workflows/verification.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest] # macos-latest removed due to env error
+        os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -63,45 +63,37 @@ jobs:
 
       - name: 🧪 Run unit tests
         run: |
-          dotnet test ./tests/bunit.core.tests/bunit.core.tests.csproj -c release --blame-hang --blame-hang-timeout 1m --blame-hang-dump-type none
-          dotnet test ./tests/bunit.web.tests/bunit.web.tests.csproj -c release --blame-hang --blame-hang-timeout 1m --blame-hang-dump-type none
-          dotnet test ./tests/bunit.web.testcomponents.tests/bunit.web.testcomponents.tests.csproj -c release --blame-hang --blame-hang-timeout 1m --blame-hang-dump-type none
+          dotnet test ./tests/bunit.core.tests/bunit.core.tests.csproj -c release --blame-hang --blame-hang-timeout 1m --blame-hang-dump-type full
+          dotnet test ./tests/bunit.web.tests/bunit.web.tests.csproj -c release --blame-hang --blame-hang-timeout 1m --blame-hang-dump-type full
+          dotnet test ./tests/bunit.web.testcomponents.tests/bunit.web.testcomponents.tests.csproj -c release --blame-hang --blame-hang-timeout 1m --blame-hang-dump-type full
 
       - name: 🗳️ Pack library
         run: |
           dotnet pack -c release -o ${GITHUB_WORKSPACE}/packages -p:ContinuousIntegrationBuild=true
           dotnet pack src/bunit/ -c release -o ${GITHUB_WORKSPACE}/packages -p:ContinuousIntegrationBuild=true
           dotnet pack src/bunit.template/ -c release -o ${GITHUB_WORKSPACE}/packages -p:ContinuousIntegrationBuild=true
-
-      - name: ✳ Install bUnit template
-        if: matrix.os != 'windows-latest'
-        run: |
-          dotnet new --install bunit.template::${NBGV_NuGetPackageVersion} --nuget-source ${GITHUB_WORKSPACE}/packages
           
       # Excluding windows because the restore step doesnt seem to work correct.
       - name: ✔ Verify xUnit template
-        if: matrix.os != 'windows-latest'
         run: |
           dotnet new bunit --no-restore -o ${GITHUB_WORKSPACE}/TemplateTestXunit
           echo '<?xml version="1.0" encoding="utf-8"?><Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003"></Project>' >> ${GITHUB_WORKSPACE}/TemplateTestXunit/Directory.Build.props
           dotnet restore ${GITHUB_WORKSPACE}/TemplateTestXunit --source ${GITHUB_WORKSPACE}/packages --source https://api.nuget.org/v3/index.json
-          dotnet test ${GITHUB_WORKSPACE}/TemplateTestXunit --blame-hang --blame-hang-timeout 1m --blame-hang-dump-type none
+          dotnet test ${GITHUB_WORKSPACE}/TemplateTestXunit --blame-hang --blame-hang-timeout 1m --blame-hang-dump-type full
 
       - name: ✔ Verify NUnit template
-        if: matrix.os != 'windows-latest'
         run: |
           dotnet new bunit --framework nunit --no-restore -o ${GITHUB_WORKSPACE}/TemplateTestNunit
           echo '<?xml version="1.0" encoding="utf-8"?><Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003"></Project>' >> ${GITHUB_WORKSPACE}/TemplateTestNunit/Directory.Build.props
           dotnet restore ${GITHUB_WORKSPACE}/TemplateTestNunit --source ${GITHUB_WORKSPACE}/packages --source https://api.nuget.org/v3/index.json
-          dotnet test ${GITHUB_WORKSPACE}/TemplateTestNunit --blame-hang --blame-hang-timeout 1m --blame-hang-dump-type none
+          dotnet test ${GITHUB_WORKSPACE}/TemplateTestNunit --blame-hang --blame-hang-timeout 1m --blame-hang-dump-type full
 
       - name: ✔ Verify MSTest template
-        if: matrix.os != 'windows-latest'
         run: |
           dotnet new bunit --framework mstest --no-restore -o ${GITHUB_WORKSPACE}/TemplateTestMstest
           echo '<?xml version="1.0" encoding="utf-8"?><Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003"></Project>' >> ${GITHUB_WORKSPACE}/TemplateTestMstest/Directory.Build.props
           dotnet restore ${GITHUB_WORKSPACE}/TemplateTestMstest --source ${GITHUB_WORKSPACE}/packages --source https://api.nuget.org/v3/index.json
-          dotnet test ${GITHUB_WORKSPACE}/TemplateTestMstest --blame-hang --blame-hang-timeout 1m --blame-hang-dump-type none
+          dotnet test ${GITHUB_WORKSPACE}/TemplateTestMstest --blame-hang --blame-hang-timeout 1m --blame-hang-dump-type full
 
       # DocFx only works well on Windows currently
       - name: 📄 Build documentation

--- a/.github/workflows/verification.yml
+++ b/.github/workflows/verification.yml
@@ -73,31 +73,34 @@ jobs:
 
       - name: 🗳️ Pack library
         run: |
-          dotnet pack -c release -o ${GITHUB_WORKSPACE}/packages -p:ContinuousIntegrationBuild=true
-          dotnet pack src/bunit/ -c release -o ${GITHUB_WORKSPACE}/packages -p:ContinuousIntegrationBuild=true
-          dotnet pack src/bunit.template/ -c release -o ${GITHUB_WORKSPACE}/packages -p:ContinuousIntegrationBuild=true
-          
-      # Excluding windows because the restore step doesnt seem to work correct.
+          dotnet pack -c release -o ${{ github.workspace }}/packages -p:ContinuousIntegrationBuild=true
+          dotnet pack src/bunit/ -c release -o ${{ github.workspace }}/packages -p:ContinuousIntegrationBuild=true
+          dotnet pack src/bunit.template/ -c release -o ${{ github.workspace }}/packages -p:ContinuousIntegrationBuild=true
+
+      - name: ✳ Install bUnit template
+        run: |
+          dotnet new --install bunit.template::${NBGV_NuGetPackageVersion} --nuget-source ${{ github.workspace }}/packages
+
       - name: ✔ Verify xUnit template
         run: |
-          dotnet new bunit --no-restore -o ${GITHUB_WORKSPACE}/TemplateTestXunit
-          echo '<?xml version="1.0" encoding="utf-8"?><Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003"></Project>' >> ${GITHUB_WORKSPACE}/TemplateTestXunit/Directory.Build.props
-          dotnet restore ${GITHUB_WORKSPACE}/TemplateTestXunit --source ${GITHUB_WORKSPACE}/packages --source https://api.nuget.org/v3/index.json
-          dotnet test ${GITHUB_WORKSPACE}/TemplateTestXunit --blame-hang --blame-hang-timeout 1m --blame-hang-dump-type full
+          dotnet new bunit --no-restore -o ${{ github.workspace }}/TemplateTestXunit
+          echo '<?xml version="1.0" encoding="utf-8"?><Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003"></Project>' >> ${{ github.workspace }}/TemplateTestXunit/Directory.Build.props
+          dotnet restore ${{ github.workspace }}/TemplateTestXunit --source https://api.nuget.org/v3/index.json --source ${{ github.workspace }}/packages
+          dotnet test ${{ github.workspace }}/TemplateTestXunit
 
       - name: ✔ Verify NUnit template
         run: |
-          dotnet new bunit --framework nunit --no-restore -o ${GITHUB_WORKSPACE}/TemplateTestNunit
-          echo '<?xml version="1.0" encoding="utf-8"?><Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003"></Project>' >> ${GITHUB_WORKSPACE}/TemplateTestNunit/Directory.Build.props
-          dotnet restore ${GITHUB_WORKSPACE}/TemplateTestNunit --source ${GITHUB_WORKSPACE}/packages --source https://api.nuget.org/v3/index.json
-          dotnet test ${GITHUB_WORKSPACE}/TemplateTestNunit --blame-hang --blame-hang-timeout 1m --blame-hang-dump-type full
+          dotnet new bunit --framework nunit --no-restore -o ${{ github.workspace }}/TemplateTestNunit
+          echo '<?xml version="1.0" encoding="utf-8"?><Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003"></Project>' >> ${{ github.workspace }}/TemplateTestNunit/Directory.Build.props
+          dotnet restore ${{ github.workspace }}/TemplateTestNunit --source https://api.nuget.org/v3/index.json --source ${{ github.workspace }}/packages
+          dotnet test ${{ github.workspace }}/TemplateTestNunit
 
       - name: ✔ Verify MSTest template
         run: |
-          dotnet new bunit --framework mstest --no-restore -o ${GITHUB_WORKSPACE}/TemplateTestMstest
-          echo '<?xml version="1.0" encoding="utf-8"?><Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003"></Project>' >> ${GITHUB_WORKSPACE}/TemplateTestMstest/Directory.Build.props
-          dotnet restore ${GITHUB_WORKSPACE}/TemplateTestMstest --source ${GITHUB_WORKSPACE}/packages --source https://api.nuget.org/v3/index.json
-          dotnet test ${GITHUB_WORKSPACE}/TemplateTestMstest --blame-hang --blame-hang-timeout 1m --blame-hang-dump-type full
+          dotnet new bunit --framework mstest --no-restore -o ${{ github.workspace }}/TemplateTestMstest
+          echo '<?xml version="1.0" encoding="utf-8"?><Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003"></Project>' >> ${{ github.workspace }}/TemplateTestMstest/Directory.Build.props
+          dotnet restore ${{ github.workspace }}/TemplateTestMstest --source https://api.nuget.org/v3/index.json --source ${{ github.workspace }}/packages
+          dotnet test ${{ github.workspace }}/TemplateTestMstest
 
       # DocFx only works well on Windows currently
       - name: 📄 Build documentation


### PR DESCRIPTION
updates to verification workflow with dump collection, targeting os x as well, and include ability to cancel previous runs when new commits are pushed.

fixes #733

Todo:

- [x] upload dumps, if any: https://github.com/actions/upload-artifact
- [x] fix template check on windows
- [ ] create separate job for template verification
- [ ] create separate job for docs verification
- [ ] use cache to share build artifacts between jobs

Inspiration: https://yonatankra.com/7-github-actions-tricks-i-wish-i-knew-before-i-started/