### PR TITLE
Expose the ReferenceCaptureId nulled out issue

### DIFF
--- a/tests/bunit.testassets/SampleComponents/DynamicComponents/ComponentA.razor
+++ b/tests/bunit.testassets/SampleComponents/DynamicComponents/ComponentA.razor
@@ -1,0 +1,4 @@
+CommponentA
+@code {
+
+}

--- a/tests/bunit.testassets/SampleComponents/DynamicComponents/ComponentB.razor
+++ b/tests/bunit.testassets/SampleComponents/DynamicComponents/ComponentB.razor
@@ -1,0 +1,4 @@
+CommponentB
+@code {
+
+}

--- a/tests/bunit.testassets/SampleComponents/DynamicComponents/DynamicContainer.razor
+++ b/tests/bunit.testassets/SampleComponents/DynamicComponents/DynamicContainer.razor
@@ -1,0 +1,14 @@
+@page "/dynamic"
+<h3 @ref="title">DynamicContainer</h3>
+<DynamicComponent Type="@pageType"></DynamicComponent>
+<button @onclick="@ChangeDynamic" @ref="button" id="button">ChangeDynamic</button>
+@code {
+    private Type pageType = typeof(ComponentA);
+    public ElementReference title;
+    public ElementReference button;
+
+    private void ChangeDynamic()
+    {
+        pageType = (pageType == typeof(ComponentA)) ? typeof(ComponentB) : typeof(ComponentA);
+    }
+}

--- a/tests/bunit.web.tests/Rendering/ReferenceCaptureIdTest.cs
+++ b/tests/bunit.web.tests/Rendering/ReferenceCaptureIdTest.cs
@@ -1,0 +1,41 @@
+using Bunit.Rendering;
+using Bunit.TestAssets.SampleComponents.DynamicComponents;
+using System.Text.RegularExpressions;
+using Xunit.Abstractions;
+
+namespace Bunit;
+
+public class ReferenceCaptureIdTest : TestContext
+{
+	private readonly ITestOutputHelper output;
+
+	public ReferenceCaptureIdTest(ITestOutputHelper output)
+	{
+		this.output = output;
+	}
+
+	[Fact(DisplayName = "Changing a DynamicComponent type should not null out the ReferenceCaptureId of other elements")]
+	public void Test001()
+	{
+		var cut = RenderComponent<DynamicContainer>();
+		output.WriteLine($"Before changing DynamicComponent: {cut.Markup}");
+		// All @ref elements have a blazor:elementReference GUID
+		Guid.Parse(GetRefRerenceCaptureId(cut.Markup, "h3"));
+		Guid.Parse(GetRefRerenceCaptureId(cut.Markup, "button"));
+
+		cut.Find("#button").Click();
+
+		output.WriteLine($"After changing DynamicComponent: {cut.Markup}");
+		// Issue: The @ref elements have an empty blazor:elementReference, thus this throws now:
+		Guid.Parse(GetRefRerenceCaptureId(cut.Markup, "h3"));
+		Guid.Parse(GetRefRerenceCaptureId(cut.Markup, "button"));
+	}
+
+	// Extract the blazor:elementReference Id string for a HTML element
+	private string GetRefRerenceCaptureId(string markup, string element)
+	{
+		var re = new Regex($"<{element}.*blazor:elementReference=\"([^\"]+).*");
+		var match = re.Match(markup);
+		return match.Groups[1].Value;
+	}
+}


### PR DESCRIPTION
Add ReferenceCaptureIdTest: "Changing a DynamicComponent type should not
null out the ReferenceCaptureId of other elements"

Add SampleComponents/DynamicComponents which can also be run in a
Blazor Server app and rendered in the browser unter the path /dynamic

## Pull request description
<!--- 
    Describe the changes and motivation behind them here, if it is not obvious
    from the related issues. Does it have new features, breaking changes, etc. 
-->

### PR meta checklist
- [x] Pull request is targeted at `main` branch for code   
  or targeted at `stable` branch for documentation that is live on bunit.dev.
- [ ] Pull request is linked to all related issues, if any.
- [ ] I have read the _CONTRIBUTING.md_ document.

### Code PR specific checklist
- [x] My code follows the code style of this project and AspNetCore coding guidelines.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] I have updated the appropriate sub section in the _CHANGELOG.md_.
- [x] I have added, updated or removed tests to according to my changes.
  - [ ] All tests passed.
