### PR TITLE
add: Automatically backmerge to v2 on push to main

### DIFF
--- a/.github/backmerge_failed.md
+++ b/.github/backmerge_failed.md
@@ -1,0 +1,6 @@
+---
+title: Back merge from main to v2 failed
+labels: input needed
+---
+
+The back merge from main to v2 failed. Please investigate the GitHub Action and resolve the conflict manually.

--- a/.github/workflows/backmerge-to-v2.yml
+++ b/.github/workflows/backmerge-to-v2.yml
@@ -1,0 +1,44 @@
+name: Back merge to v2
+on: 
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  backmerge:
+    timeout-minutes: 2
+    runs-on: ubuntu-latest
+    steps:
+      - name: 🛒 Checkout repository
+        uses: actions/checkout@v2
+
+      - name: ⚙️ Import GPG key
+        id: import_gpg
+        uses: crazy-max/ghaction-import-gpg@v3
+        with:
+          gpg-private-key: ${{ secrets.BUNIT_BOT_GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.BUNIT_BOT_GPG_KEY_PASSPHRASE }}
+      
+      - name: ⚙️ Setup CI GIT
+        run: |
+          git config user.name "${{ steps.import_gpg.outputs.name }}"
+          git config user.email ${{ steps.import_gpg.outputs.email }}
+          git config --global user.signingkey ${{ steps.import_gpg.outputs.keyid }}
+          git config --global commit.gpgsign true
+
+      - name: 🤹‍♀️ Merge main to v2
+        run: |
+          git fetch --unshallow
+          git checkout v2
+          git pull
+          git rebase origin/main && git push --force-with-lease
+
+      - name: Create issue if failed
+        if: failure()
+        uses: JasonEtco/create-an-issue@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          filename: .github/backmerge-failed.md
+          update_existing: true


### PR DESCRIPTION
This PR adds a GitHub workflow which automatically merges changes from `main` to `v2` when there are changes on `main`.
If the merge is not successful an issue is created. 