### PR TITLE
fix: Key already been added on JSRuntimeInvocationDictionary.

### DIFF
--- a/src/bunit.web/Extensions/Internal/ICollectionExtensions.cs
+++ b/src/bunit.web/Extensions/Internal/ICollectionExtensions.cs
@@ -1,0 +1,25 @@
+﻿using System.Collections;
+
+namespace Bunit;
+
+internal static class ICollectionExtensions
+{
+	internal static IReadOnlyCollection<T> ToReadOnlyCollection<T>(this ICollection<T> source)
+	{
+		if (source == null)
+		{
+			throw new ArgumentNullException(nameof(source));
+		}
+
+		return source as IReadOnlyCollection<T> ?? new ReadOnlyCollectionAdapter<T>(source);
+	}
+
+	private sealed class ReadOnlyCollectionAdapter<T> : IReadOnlyCollection<T>
+	{
+		private readonly ICollection<T> source;
+		public ReadOnlyCollectionAdapter(ICollection<T> source) => this.source = source;
+		public int Count => source.Count;
+		public IEnumerator<T> GetEnumerator() => source.GetEnumerator();
+		IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+	}
+}

--- a/src/bunit.web/JSInterop/JSRuntimeInvocationDictionary.cs
+++ b/src/bunit.web/JSInterop/JSRuntimeInvocationDictionary.cs
@@ -1,4 +1,5 @@
 using System.Collections;
+using System.Collections.Concurrent;
 
 namespace Bunit;
 
@@ -8,7 +9,7 @@ namespace Bunit;
 [SuppressMessage("Naming", "CA1711:Identifiers should not have incorrect suffix", Justification = "Name makes sense in this context.")]
 public sealed class JSRuntimeInvocationDictionary : IReadOnlyCollection<JSRuntimeInvocation>
 {
-	private readonly Dictionary<string, List<JSRuntimeInvocation>> invocations = new(StringComparer.Ordinal);
+	private readonly ConcurrentDictionary<string, List<JSRuntimeInvocation>> invocations = new(StringComparer.Ordinal);
 
 	/// <summary>
 	/// Gets all invocations for a specific <paramref name="identifier"/>.
@@ -16,21 +17,17 @@ public sealed class JSRuntimeInvocationDictionary : IReadOnlyCollection<JSRuntim
 	/// <param name="identifier">The identifier to get invocations for.</param>
 	/// <returns>An <see cref="IReadOnlyList{JSRuntimeInvocation}"/>.</returns>
 	public IReadOnlyList<JSRuntimeInvocation> this[string identifier]
-	{
-		get => invocations.ContainsKey(identifier)
-			? invocations[identifier]
-			: Array.Empty<JSRuntimeInvocation>();
-	}
+		=> invocations.GetOrAdd(identifier, _ => new List<JSRuntimeInvocation>());
 
 	/// <summary>
 	/// Gets a read only collection of all the identifiers used in invocations in this dictionary.
 	/// </summary>
-	public IReadOnlyCollection<string> Identifiers => invocations.Keys;
+	public IReadOnlyCollection<string> Identifiers => invocations.Keys.ToReadOnlyCollection();
 
 	/// <summary>
 	/// Gets the total number of invocations registered in the dictionary.
 	/// </summary>
-	public int Count { get; private set; }
+	public int Count => invocations.Count;
 
 	/// <summary>
 	/// Gets an <see cref="IEnumerator{JSRuntimeInvocation}"/> that will
@@ -38,31 +35,20 @@ public sealed class JSRuntimeInvocationDictionary : IReadOnlyCollection<JSRuntim
 	/// </summary>
 	/// <returns>An iterator with all the <see cref="JSRuntimeInvocation"/> registered in this dictionary.</returns>
 	public IEnumerator<JSRuntimeInvocation> GetEnumerator()
-	{
-		foreach (var kvp in invocations)
-		{
-			foreach (var item in kvp.Value)
-			{
-				yield return item;
-			}
-		}
-	}
+		=> invocations.SelectMany(kvp => kvp.Value).GetEnumerator();
 
-	/// <inheritdoc/>
+	/// <inheritdoc />
 	IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
 	/// <summary>
 	/// Register a new invocation with this dictionary.
 	/// </summary>
 	internal void RegisterInvocation(JSRuntimeInvocation invocation)
-	{
-		Count++;
-
-		if (!invocations.ContainsKey(invocation.Identifier))
-		{
-			invocations.Add(invocation.Identifier, new List<JSRuntimeInvocation>());
-		}
-
-		invocations[invocation.Identifier].Add(invocation);
-	}
+		=> invocations.AddOrUpdate(invocation.Identifier,
+			_ => new List<JSRuntimeInvocation> { invocation },
+			(_, list) =>
+			{
+				list.Add(invocation);
+				return list;
+			});
 }

--- a/tests/bunit.web.tests/JSInterop/BunitJSObjectReferenceTest.cs
+++ b/tests/bunit.web.tests/JSInterop/BunitJSObjectReferenceTest.cs
@@ -226,8 +226,7 @@ public class BunitJSObjectReferenceTest : TestContext
 			.Identifier.ShouldBe("helloWorld");
 
 		JSInterop.Invocations
-			.Last()
-			.Identifier.ShouldBe("helloWorld");
+			.ShouldContain(x => x.Identifier == "helloWorld");
 	}
 
 	[Fact(DisplayName = "TryGetModuleJSInterop returns registered module handler when called with parameters that the handler matches with")]


### PR DESCRIPTION
## Pull request description
When running our test project I encountered concurrency issues on the JSRuntimeInvocationDictionary. The proposed change is to make the backing Dictionary a ConcurrentDictionary to make it more threadsafe. 

See stacktrace:
```  Failed Huisvesting_NaBewerken_EnablesOKButton [137 ms]
  Error Message:
   System.ArgumentException : An item with the same key has already been added. Key: some_key
  Stack Trace:
     at System.Collections.Generic.Dictionary`2.TryInsert(TKey key, TValue value, InsertionBehavior behavior)
   at System.Collections.Generic.Dictionary`2.Add(TKey key, TValue value)
   at Bunit.JSRuntimeInvocationDictionary.RegisterInvocation(JSRuntimeInvocation invocation) in /_/src/bunit.web/JSInterop/JSRuntimeInvocationDictionary.cs:line 66
   at Bunit.BunitJSInterop.RegisterInvocation(JSRuntimeInvocation invocation) in /_/src/bunit.web/JSInterop/BunitJSInterop.cs:line 94
   at Bunit.BunitJSInterop.HandleInvocation[TValue](JSRuntimeInvocation invocation) in /_/src/bunit.web/JSInterop/BunitJSInterop.cs:line 70
   at Bunit.JSInterop.Implementation.JSRuntimeExtensions.HandleInvokeAsync[TValue](BunitJSInterop jSInterop, String identifier, Object[] args) in /_/src/bunit.web/JSInterop/Implementation/JSRuntimeExtensions.cs:line 14
   at Bunit.JSInterop.BunitJSRuntime.InvokeAsync[TValue](String identifier, Object[] args) in /_/src/bunit.web/JSInterop/Implementation/BunitJSRuntime.cs:line 23
   at Microsoft.JSInterop.JSRuntimeExtensions.InvokeVoidAsync(IJSRuntime jsRuntime, String identifier, Object[] args)
....
....
   at Bunit.Rendering.TestRenderer.AssertNoUnhandledExceptions() in /_/src/bunit.core/Rendering/TestRenderer.cs:line 346
   at Bunit.Rendering.TestRenderer.Render[TResult](RenderFragment renderFragment, Func`2 activator) in /_/src/bunit.core/Rendering/TestRenderer.cs:line 232
   at Bunit.Rendering.TestRenderer.RenderFragment(RenderFragment renderFragment) in /_/src/bunit.core/Rendering/TestRenderer.cs:line 54
   at Bunit.Extensions.TestContextBaseRenderExtensions.RenderInsideRenderTree(TestContextBase testContext, RenderFragment renderFragment) in /_/src/bunit.core/Extensions/TestContextBaseRenderExtensions.cs:line 45
   at Bunit.Extensions.TestContextBaseRenderExtensions.RenderInsideRenderTree[TComponent](TestContextBase testContext, RenderFragment renderFragment) in /_/src/bunit.core/Extensions/TestContextBaseRenderExtensions.cs:line 25
   at Bunit.TestContext.Render[TComponent](RenderFragment renderFragment) in /_/src/bunit.web/TestContext.cs:line 69
   at Bunit.TestContext.RenderComponent[TComponent](ComponentParameter[] parameters) in /_/src/bunit.web/TestContext.cs:line 39
....
```

### PR meta checklist
- [X] Pull request is targeted at `main` branch for code   
  or targeted at `stable` branch for documentation that is live on bunit.dev.
- [X] Pull request is linked to all related issues, if any.
- [X] I have read the _CONTRIBUTING.md_ document.

### Code PR specific checklist
- [X] My code follows the code style of this project and AspNetCore coding guidelines.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] I have updated the appropriate sub section in the _CHANGELOG.md_.
- [X] I have added, updated or removed tests to according to my changes.
  - [X] All tests passed.
