### PR TITLE
fix: Fixed sample in docs and added more details

### DIFF
--- a/docs/samples/tests/razor/TwoWayBindingTest.razor
+++ b/docs/samples/tests/razor/TwoWayBindingTest.razor
@@ -1,10 +1,11 @@
-﻿@code {
+﻿@inherits TestContext
+
+@code {
   [Fact]
   public void Test()
   {
-    using var ctx = new TestContext();
     var currentValue = string.Empty;
 
-    var cut = ctx.Render(@<TwoWayBinding @bind-Value="currentValue"></TwoWayBinding>);
+    var cut = Render(@<TwoWayBinding @bind-Value="currentValue"></TwoWayBinding>);
   }
 }

--- a/docs/site/docs/providing-input/passing-parameters-to-components.md
+++ b/docs/site/docs/providing-input/passing-parameters-to-components.md
@@ -404,6 +404,9 @@ The example uses the `Bind` method to setup two-way binding between the `Value` 
 [!code-cshtml[TwoWayBindingTest.razor](../../../samples/tests/razor/TwoWayBindingTest.razor)]
 
 The example uses the standard `@bind-Value` directive in Blazor to set up two way binding between the `Value` parameter and `ValueChanged` parameter and the local variable in the test method (`currentValue`).
+
+> [!WARNING]
+> When using `@bind` in conjunction with razor test-files the razor component should **not** inherit from `ComponentBase` (which is the default). The simplest solution would be to inherit from `TestContext` (as seen in the example above) which also brings the benefits as described on top of this page. For **NUnit** and **MSTest** check out the section "Remove boilerplate code from tests" on the <xref:writing-tests> page.
 ***
 
 ## Further Reading


### PR DESCRIPTION
This is a small follow-up to #750 and addresses partially #761.
Basically our shown example derived directly from `ComponentBase` which would lead to errors for the user.

The updated documentation will show a warning when checking the razor file for `@bind`.

![image](https://user-images.githubusercontent.com/26365461/175578985-6adf2d9a-28dd-4f09-8fe5-5cbffe5d09f3.png)
