### PR TITLE
Windows runner

### DIFF
--- a/.github/workflows/verification-dotnet-nightly.yml
+++ b/.github/workflows/verification-dotnet-nightly.yml
@@ -33,10 +33,7 @@ jobs:
 
       - name: 🧪 Run unit tests
         run: |
-          dotnet test ./tests/bunit.core.tests/bunit.core.tests.csproj -c release --no-restore -f net7.0 --logger:"console;verbosity=normal" --blame-hang-timeout 15s --blame-hang-dump-type full --blame-crash-dump-type full
-          dotnet test ./tests/bunit.web.tests/bunit.web.tests.csproj -c release --no-restore -f net7.0 --logger:"console;verbosity=normal" --blame-hang-timeout 15s --blame-hang-dump-type full --blame-crash-dump-type full
-          dotnet test ./tests/AngleSharpWrappers.Tests/AngleSharpWrappers.Tests.csproj -c release --no-restore -f net7.0 --logger:"console;verbosity=normal" --blame-hang-timeout 15s --blame-hang-dump-type full --blame-crash-dump-type full
-
+          dotnet test -c release --no-restore -f net7.0 --logger:"console;verbosity=normal" --blame-hang-timeout 15s --blame-hang-dump-type full --blame-crash-dump-type full
       - name: 📛 Upload hang- and crash-dumps on test failure
         if: failure()
         uses: actions/upload-artifact@v3

--- a/.github/workflows/verification.yml
+++ b/.github/workflows/verification.yml
@@ -47,6 +47,7 @@ jobs:
           include-prerelease: true
 
       - name: 🎨 Setup color
+        if: matrix.os != 'windows-latest'
         run: |
           echo "DOTNET_SYSTEM_CONSOLE_ALLOW_ANSI_COLOR_REDIRECTION=1" >> $GITHUB_ENV
           echo "TERM=xterm" >> $GITHUB_ENV
@@ -63,11 +64,7 @@ jobs:
 
       - name: 🧪 Run unit tests
         run: |
-          dotnet test ./tests/bunit.core.tests/bunit.core.tests.csproj -c release --blame-hang-timeout 15s --blame-hang-dump-type full --blame-crash-dump-type full
-          dotnet test ./tests/bunit.web.tests/bunit.web.tests.csproj -c release --blame-hang-timeout 15s --blame-hang-dump-type full --blame-crash-dump-type full
-          dotnet test ./tests/bunit.web.testcomponents.tests/bunit.web.testcomponents.tests.csproj -c release --blame-hang-timeout 15s --blame-hang-dump-type full --blame-crash-dump-type full
-          dotnet test ./tests/AngleSharpWrappers.Tests/AngleSharpWrappers.Tests.csproj -c release --blame-hang-timeout 15s --blame-hang-dump-type full --blame-crash-dump-type full
-
+          dotnet test -c release --blame-hang-timeout 15s --blame-hang-dump-type full --blame-crash-dump-type full
       - name: 📛 Upload hang- and crash-dumps on test failure
         if: failure()
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
Found the issue with the workflow:
```yml
- name: Run unit tests
run: |
  dotnet test ./tests/ProjectA/ProjectA.csproj -c release
  dotnet test ./tests/ProjectB/ProjectB.csproj -c release
  dotnet test ./tests/ProjectC/ProjectC.csproj -c release
```

Let's assume ProjectA or ProjectB do have a test, which fails. Therefore the exit code is non-zero but ProjectC is successful the whole result code (in powershell) is for some weird reason 0 instead of non-zero.

So this is a temporary fix. Disadvantage right now is that we stop on the first failing test-suite **but** at least we have an indication whether or not windows is breaking.