### PR TITLE
fix: Reverted change for net7.0 nightly verification

### DIFF
--- a/.github/workflows/verification-dotnet-nightly.yml
+++ b/.github/workflows/verification-dotnet-nightly.yml
@@ -33,7 +33,10 @@ jobs:
 
       - name: 🧪 Run unit tests
         run: |
-          dotnet test -c release --no-restore -f net7.0 --logger:"console;verbosity=normal" --blame-hang-timeout 15s --blame-hang-dump-type full --blame-crash-dump-type full
+                    dotnet test ./tests/bunit.core.tests/bunit.core.tests.csproj -c release --no-restore -f net7.0 --logger:"console;verbosity=normal" --blame-hang-timeout 15s --blame-hang-dump-type full --blame-crash-dump-type full
+          dotnet test ./tests/bunit.web.tests/bunit.web.tests.csproj -c release --no-restore -f net7.0 --logger:"console;verbosity=normal" --blame-hang-timeout 15s --blame-hang-dump-type full --blame-crash-dump-type full
+          dotnet test ./tests/AngleSharpWrappers.Tests/AngleSharpWrappers.Tests.csproj -c release --no-restore -f net7.0 --logger:"console;verbosity=normal" --blame-hang-timeout 15s --blame-hang-dump-type full --blame-crash-dump-type full
+      
       - name: 📛 Upload hang- and crash-dumps on test failure
         if: failure()
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
The night-verification forces net7.0 as target configuration. On `main` we unfortunately have projects which don't support `net7.0` as configuration and are therefore failing.
I reverted the nightly verification back to "normal". 

As it is running on a ubuntu machine we shouldn't expect that windows error anyway.
Once we go "live" with `v2` we can simplify this again.