### PR TITLE
refactor: use nullable type instead of annotation

### DIFF
--- a/src/bunit.core/ComponentParameterCollectionBuilder.cs
+++ b/src/bunit.core/ComponentParameterCollectionBuilder.cs
@@ -46,7 +46,7 @@ public sealed class ComponentParameterCollectionBuilder<TComponent>
 	/// <param name="parameterSelector">A lambda function that selects the parameter.</param>
 	/// <param name="value">The value to pass to <typeparamref name="TComponent"/>.</param>
 	/// <returns>This <see cref="ComponentParameterCollectionBuilder{TComponent}"/>.</returns>
-	public ComponentParameterCollectionBuilder<TComponent> Add<TValue>(Expression<Func<TComponent, TValue>> parameterSelector, [AllowNull] TValue value)
+	public ComponentParameterCollectionBuilder<TComponent> Add<TValue>(Expression<Func<TComponent, TValue>> parameterSelector, TValue? value)
 	{
 		var (name, cascadingValueName, isCascading) = GetParameterInfo(parameterSelector);
 		return isCascading
@@ -400,7 +400,7 @@ public sealed class ComponentParameterCollectionBuilder<TComponent>
 	/// <param name="name">Name of the property for the parameter.</param>
 	/// <param name="value">Value to assign to the parameter.</param>
 	/// <returns>True if parameter with the name exists and value was set, false otherwise.</returns>
-	public bool TryAdd<TValue>(string name, [AllowNull] TValue value)
+	public bool TryAdd<TValue>(string name, TValue? value)
 	{
 		if (TComponentType.GetProperty(name, BindingFlags.Public | BindingFlags.Instance) is PropertyInfo ccProp)
 		{
@@ -455,7 +455,7 @@ public sealed class ComponentParameterCollectionBuilder<TComponent>
 		=> TComponentType.GetProperty(ChildContent, BindingFlags.Public | BindingFlags.Instance) is PropertyInfo ccProp
 			&& ccProp.PropertyType.IsGenericType;
 
-	private ComponentParameterCollectionBuilder<TComponent> AddParameter<TValue>(string name, [AllowNull] TValue value)
+	private ComponentParameterCollectionBuilder<TComponent> AddParameter<TValue>(string name, TValue? value)
 	{
 		parameters.Add(ComponentParameter.CreateParameter(name, value));
 		return this;

--- a/tests/bunit.core.tests/ComponentParameterCollectionBuilderTests.cs
+++ b/tests/bunit.core.tests/ComponentParameterCollectionBuilderTests.cs
@@ -8,7 +8,7 @@ public partial class ComponentParameterCollectionBuilderTests : TestContext
 
 	private bool EventCallbackCalled { get; set; }
 
-	private void VerifyParameter<T>(string expectedName, [AllowNull] T expectedInput)
+	private void VerifyParameter<T>(string expectedName, T? expectedInput)
 	{
 		Builder.Build()
 			.ShouldHaveSingleItem()

--- a/tests/bunit.core.tests/ShouldlyExtensions.cs
+++ b/tests/bunit.core.tests/ShouldlyExtensions.cs
@@ -8,7 +8,7 @@ public static class ShouldlyExtensions
 		ShouldSatisfyAllConditionsTestExtensions.ShouldSatisfyAllConditions(actual, conds);
 	}
 
-	public static void ShouldBeParameter<TValue>(this ComponentParameter parameter, string? name, [AllowNull] TValue value, bool isCascadingValue)
+	public static void ShouldBeParameter<TValue>(this ComponentParameter parameter, string? name, TValue? value, bool isCascadingValue)
 	{
 		parameter.ShouldSatisfyAllConditions(
 			x => x.Name.ShouldBe(name),


### PR DESCRIPTION
Small cleanup. We used in some places the `AllowNullAtrribute` which I replaced with the nullable reference type annotation.

I did this on `v2` as it is a breaking change itself.