### PR TITLE
fix: Allow obsolete InvokeUnmarshalled method

### DIFF
--- a/tests/bunit.web.tests/JSInterop/BunitJSInteropTest.cs
+++ b/tests/bunit.web.tests/JSInterop/BunitJSInteropTest.cs
@@ -1,3 +1,4 @@
+#pragma warning disable CS0618 // This method is obsolete.
 namespace Bunit.JSInterop;
 
 public partial class BunitJSInteropTest

--- a/tests/bunit.web.tests/JSInterop/BunitJSObjectReferenceTest.cs
+++ b/tests/bunit.web.tests/JSInterop/BunitJSObjectReferenceTest.cs
@@ -6,10 +6,9 @@ using System.Threading;
 using System.Threading.Tasks;
 using AutoFixture.Xunit2;
 using Bunit.JSInterop.InvocationHandlers.Implementation;
-using Microsoft.JSInterop;
 using Microsoft.JSInterop.Implementation;
-using Shouldly;
-using Xunit;
+
+#pragma warning disable CS0618 // This method is obsolete.
 
 namespace Bunit.JSInterop;
 


### PR DESCRIPTION
Fixes #788 