### PR TITLE
fix: Allow obsolete SignOutSessionManager for net7

### DIFF
--- a/src/bunit.web/TestDoubles/Authorization/FakeAuthorizationExtensions.cs
+++ b/src/bunit.web/TestDoubles/Authorization/FakeAuthorizationExtensions.cs
@@ -21,7 +21,9 @@ public static class FakeAuthorizationExtensions
 
 		context.RenderTree.TryAdd<CascadingAuthenticationState>();
 		context.Services.AddSingleton<FakeSignOutSessionStateManager>();
+#pragma warning disable CS0618
 		context.Services.AddSingleton<SignOutSessionStateManager>(s => s.GetRequiredService<FakeSignOutSessionStateManager>());
+#pragma warning restore CS0618
 		var authCtx = new TestAuthorizationContext();
 		authCtx.SetNotAuthorized();
 		authCtx.RegisterAuthorizationServices(context.Services);

--- a/src/bunit.web/TestDoubles/NavigationManager/FakeSignOutSessionStateManager.cs
+++ b/src/bunit.web/TestDoubles/NavigationManager/FakeSignOutSessionStateManager.cs
@@ -6,7 +6,9 @@ namespace Bunit.TestDoubles;
 /// Represents a fake <see cref="SignOutSessionStateManager"/> that captures calls to <see cref="SetSignOutState"/>
 /// that will help later to assert if the user was logged out
 /// </summary>
+#pragma warning disable CS0618
 public class FakeSignOutSessionStateManager : SignOutSessionStateManager
+#pragma warning restore CS0618
 {
 	/// <summary>
 	/// Returns true when <see cref="SetSignOutState"/> was called, otherwise false

--- a/tests/bunit.testassets/SampleComponents/SignOutSessionManagerLoginDisplay.razor
+++ b/tests/bunit.testassets/SampleComponents/SignOutSessionManagerLoginDisplay.razor
@@ -1,6 +1,5 @@
 ﻿@using Microsoft.AspNetCore.Components.Authorization
 @using Microsoft.AspNetCore.Components.WebAssembly.Authentication
-@inject SignOutSessionStateManager signOutManager
 
 <AuthorizeView>
 	<Authorized>
@@ -14,8 +13,12 @@
 </AuthorizeView>
 
 @code {
+#pragma warning disable CS0618
+	[Inject] SignOutSessionStateManager SignOutManager { get;set;} = default!;
+#pragma warning restore CS0618
+
 	private async Task BeginSignOut(MouseEventArgs args)
 	{
-		await signOutManager.SetSignOutState();
+		await SignOutManager.SetSignOutState();
 	}
 }


### PR DESCRIPTION
Fixes #836 

Even though the dotnet team wants to use the `NavigationManager` for logout, we still want to support the `SignOutSessionManager` until it is removed from the framework itself.