### PR TITLE
feat: Easy way to retrieve InteractiveRequestOptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to **bUnit** will be documented in this file. The project ad
 
 ## [Unreleased]
 
+### Added
+- Added method to easily deserialize `InteractiveRequestOptions` via `TryGetInteractiveRequestOptions`, which is used by `NavigationManager.NavigateToLogin`. [@linkdotnet](https://github.com/linkdotnet). 
+
 ## [1.10.14] - 2022-09-16
 
 ### Added

--- a/docs/site/docs/test-doubles/fake-navigation-manager.md
+++ b/docs/site/docs/test-doubles/fake-navigation-manager.md
@@ -137,3 +137,32 @@ var navigationHistory = navMan.History.Single();
 Assert.Equal(NavigationState.Faulted, navigationHistory.NavigationState);
 Assert.NotNull(navigationHistory.Exception);
 ```
+
+## Getting the result of `NavigationManager.NavigateToLogin`
+[`NavigationManager.NavigateToLogin`](https://learn.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.components.navigationmanager.navigateto?view=aspnetcore-7.0) is a function, which was introduced with .NET 7, which allows to login dynamically. The function can also retrieve an `InteractiveRequestOptions` object, which can hold additional parameter.
+
+```csharp
+InteractiveRequestOptions requestOptions = new()
+{
+    Interaction = InteractionType.SignIn,
+    ReturnUrl = NavigationManager.Uri,
+};
+requestOptions.TryAddAdditionalParameter("prompt", "login");
+NavigationManager.NavigateToLogin("authentication/login", requestOptions);
+```
+
+A test could look like this:
+```csharp
+using var ctx = new TestContext();
+var navigationManager = ctx.Services.GetRequiredService<FakeNavigationManager>();
+
+ActionToTriggerTheNavigationManager();
+
+// This helper method retrieves the InteractiveRequestOptions object
+var successful = navigationManager.History.Last().TryGetInteractiveRequestOptions(out var requestOptions);
+Assert.True(successful);
+Asser.NotNull(requestOptions);
+Assert.Equal(requestOptions.Interaction, InteractionType.SignIn);
+options.TryGetAdditionalParameter("prompt", out string prompt);
+Assert.Equal(prompt, "login");
+```

--- a/src/bunit.web/TestDoubles/NavigationManager/NavigationHistory.cs
+++ b/src/bunit.web/TestDoubles/NavigationManager/NavigationHistory.cs
@@ -1,4 +1,8 @@
+#if NET7_0_OR_GREATER
+using System.Text.Json;
 using Microsoft.AspNetCore.Components.Routing;
+using Microsoft.AspNetCore.Components.WebAssembly.Authentication;
+#endif
 
 namespace Bunit.TestDoubles;
 
@@ -81,6 +85,29 @@ public sealed class NavigationHistory : IEquatable<NavigationHistory>
 		State = navigationState;
 		Exception = exception;
 	}
+
+	/// <summary>
+	/// Tries to retrieve the <see cref="InteractiveRequestOptions"/>. This property is set,
+	/// when calling <code>NavigationManager.NavigateToLogin</code>.
+	/// </summary>
+	/// <param name="requestOptions">The object, which was passed to <code>NavigationManager.NavigateToLogin</code></param>
+	/// <returns>True, if the <see cref="InteractiveRequestOptions"/> could be parsed, otherwise false.</returns>
+	public bool TryGetInteractiveRequestOptions([NotNullWhen(true)] out InteractiveRequestOptions? requestOptions)
+	{
+		requestOptions = null;
+		if (string.IsNullOrEmpty(Options.HistoryEntryState))
+			return false;
+
+		try
+		{
+			requestOptions = JsonSerializer.Deserialize<InteractiveRequestOptions>(Options.HistoryEntryState)!;
+			return true;
+		}
+		catch
+		{
+			return false;
+		}
+	}
 #endif
 
 	/// <inheritdoc/>
@@ -88,12 +115,21 @@ public sealed class NavigationHistory : IEquatable<NavigationHistory>
 	public bool Equals(NavigationHistory? other)
 		=> other is not null && string.Equals(Uri, other.Uri, StringComparison.Ordinal) && Options.Equals(other.Options);
 #endif
-#if NET6_0_OR_GREATER
+#if NET6_0
 	public bool Equals(NavigationHistory? other)
 		=> other is not null
 		&& string.Equals(Uri, other.Uri, StringComparison.Ordinal)
 		&& Options.ForceLoad == other.Options.ForceLoad
 		&& Options.ReplaceHistoryEntry == other.Options.ReplaceHistoryEntry;
+#endif
+#if NET7_0_OR_GREATER
+		public bool Equals(NavigationHistory? other)
+		=> other is not null
+		&& string.Equals(Uri, other.Uri, StringComparison.Ordinal)
+		&& Options.ForceLoad == other.Options.ForceLoad
+		&& Options.ReplaceHistoryEntry == other.Options.ReplaceHistoryEntry
+		&& State == other.State
+		&& Exception == other.Exception;
 #endif
 
 	/// <inheritdoc/>


### PR DESCRIPTION
## Pull request description
This PR relates and directly closes #859 .
It gives the user an easy way of retrieving the `InteractiveRequestOptions` from the NavigationHistoryEntry.

### PR meta checklist
- [x] Pull request is targeted at `main` branch for code   
  or targeted at `stable` branch for documentation that is live on bunit.dev.
- [x] Pull request is linked to all related issues, if any.
- [x] I have read the _CONTRIBUTING.md_ document.

### Code PR specific checklist
- [x] My code follows the code style of this project and AspNetCore coding guidelines.
- [x] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly.
- [x] I have updated the appropriate sub section in the _CHANGELOG.md_.
- [x] I have added, updated or removed tests to according to my changes.
  - [x] All tests passed.
