### PR TITLE
fix: Provide RunContinuationsAsynchronously flag to TaskCompletionSource

### DIFF
--- a/src/bunit.core/Extensions/WaitForHelpers/WaitForHelper.cs
+++ b/src/bunit.core/Extensions/WaitForHelpers/WaitForHelper.cs
@@ -51,7 +51,7 @@ public abstract class WaitForHelper<T> : IDisposable
 		this.completeChecker = completeChecker ?? throw new ArgumentNullException(nameof(completeChecker));
 
 		logger = renderedFragment.Services.CreateLogger<WaitForHelper<T>>();
-		checkPassedCompletionSource = new TaskCompletionSource<T>();
+		checkPassedCompletionSource = new TaskCompletionSource<T>(TaskCreationOptions.RunContinuationsAsynchronously);
 		timer = new Timer(_ =>
 		{
 			logger.LogWaiterTimedOut(renderedFragment.ComponentId);

--- a/src/bunit.core/Rendering/TestRenderer.cs
+++ b/src/bunit.core/Rendering/TestRenderer.cs
@@ -352,7 +352,7 @@ public class TestRenderer : Renderer, ITestRenderer
 
 		if (!unhandledExceptionTsc.TrySetResult(capturedUnhandledException))
 		{
-			unhandledExceptionTsc = new TaskCompletionSource<Exception>();
+			unhandledExceptionTsc = new TaskCompletionSource<Exception>(TaskCreationOptions.RunContinuationsAsynchronously);
 			unhandledExceptionTsc.SetResult(capturedUnhandledException);
 		}
 	}
@@ -362,7 +362,7 @@ public class TestRenderer : Renderer, ITestRenderer
 		capturedUnhandledException = null;
 
 		if (unhandledExceptionTsc.Task.IsCompleted)
-			unhandledExceptionTsc = new TaskCompletionSource<Exception>();
+			unhandledExceptionTsc = new TaskCompletionSource<Exception>(TaskCreationOptions.RunContinuationsAsynchronously);
 	}
 
 	private void AssertNoUnhandledExceptions()

--- a/src/bunit.web/JSInterop/InvocationHandlers/JSRuntimeInvocationHandlerBase{TResult}.cs
+++ b/src/bunit.web/JSInterop/InvocationHandlers/JSRuntimeInvocationHandlerBase{TResult}.cs
@@ -31,7 +31,7 @@ public abstract class JSRuntimeInvocationHandlerBase<TResult>
 	protected JSRuntimeInvocationHandlerBase(InvocationMatcher matcher, bool isCatchAllHandler)
 	{
 		invocationMatcher = matcher ?? throw new ArgumentNullException(nameof(matcher));
-		completionSource = new TaskCompletionSource<TResult>();
+		completionSource = new TaskCompletionSource<TResult>(TaskCreationOptions.RunContinuationsAsynchronously);
 		IsCatchAllHandler = isCatchAllHandler;
 	}
 
@@ -41,7 +41,7 @@ public abstract class JSRuntimeInvocationHandlerBase<TResult>
 	protected void SetCanceledBase()
 	{
 		if (completionSource.Task.IsCompleted)
-			completionSource = new TaskCompletionSource<TResult>();
+			completionSource = new TaskCompletionSource<TResult>(TaskCreationOptions.RunContinuationsAsynchronously);
 
 		completionSource.SetCanceled();
 	}
@@ -54,7 +54,7 @@ public abstract class JSRuntimeInvocationHandlerBase<TResult>
 		where TException : Exception
 	{
 		if (completionSource.Task.IsCompleted)
-			completionSource = new TaskCompletionSource<TResult>();
+			completionSource = new TaskCompletionSource<TResult>(TaskCreationOptions.RunContinuationsAsynchronously);
 
 		completionSource.SetException(exception);
 	}
@@ -66,7 +66,7 @@ public abstract class JSRuntimeInvocationHandlerBase<TResult>
 	protected void SetResultBase(TResult result)
 	{
 		if (completionSource.Task.IsCompleted)
-			completionSource = new TaskCompletionSource<TResult>();
+			completionSource = new TaskCompletionSource<TResult>(TaskCreationOptions.RunContinuationsAsynchronously);
 
 		completionSource.SetResult(result);
 	}

--- a/src/bunit.web/TestDoubles/Authorization/FakeAuthenticationStateProvider.cs
+++ b/src/bunit.web/TestDoubles/Authorization/FakeAuthenticationStateProvider.cs
@@ -75,7 +75,7 @@ public class FakeAuthenticationStateProvider : AuthenticationStateProvider
 	private void SetUnauthenticatedState()
 	{
 		if (authState.Task.IsCompleted)
-			authState = new TaskCompletionSource<AuthenticationState>();
+			authState = new TaskCompletionSource<AuthenticationState>(TaskCreationOptions.RunContinuationsAsynchronously);
 
 		authState.SetResult(CreateUnauthenticationState());
 	}
@@ -83,7 +83,7 @@ public class FakeAuthenticationStateProvider : AuthenticationStateProvider
 	private void SetAuthorizingState()
 	{
 		if (authState.Task.IsCompleted)
-			authState = new TaskCompletionSource<AuthenticationState>();
+			authState = new TaskCompletionSource<AuthenticationState>(TaskCreationOptions.RunContinuationsAsynchronously);
 	}
 
 	private void SetAuthenticatedState(
@@ -93,7 +93,7 @@ public class FakeAuthenticationStateProvider : AuthenticationStateProvider
 		string? authenticationType)
 	{
 		if (authState.Task.IsCompleted)
-			authState = new TaskCompletionSource<AuthenticationState>();
+			authState = new TaskCompletionSource<AuthenticationState>(TaskCreationOptions.RunContinuationsAsynchronously);
 
 		authState.SetResult(CreateAuthenticationState(userName, roles, claims, authenticationType));
 	}

--- a/tests/bunit.core.tests/Rendering/TestRendererTest.cs
+++ b/tests/bunit.core.tests/Rendering/TestRendererTest.cs
@@ -328,7 +328,7 @@ public partial class TestRendererTest : TestContext
 	[Fact(DisplayName = "Can render component that awaits uncompleted task in OnInitializedAsync")]
 	public void Test100()
 	{
-		var tcs = new TaskCompletionSource<object>();
+		var tcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
 
 		var cut = RenderComponent<AsyncRenderOfSubComponentDuringInit>(parameters =>
 			parameters.Add(p => p.EitherOr, tcs.Task));
@@ -367,7 +367,7 @@ public partial class TestRendererTest : TestContext
 	[Fact(DisplayName = "UnhandledException has a reference to the exception thrown by an async operation in a component")]
 	public async Task Test201()
 	{
-		var tsc = new TaskCompletionSource<object>();
+		var tsc = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
 		var expectedException = new AsyncOperationThrows.AsyncOperationThrowsException();
 		RenderComponent<AsyncOperationThrows>(ps => ps.Add(p => p.Awaitable, tsc.Task));
 
@@ -380,14 +380,14 @@ public partial class TestRendererTest : TestContext
 	[Fact(DisplayName = "UnhandledException has a reference to latest unhandled exception thrown by a component")]
 	public async Task Test202()
 	{
-		var tsc1 = new TaskCompletionSource<object>();
+		var tsc1 = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
 		RenderComponent<AsyncOperationThrows>(ps => ps.Add(p => p.Awaitable, tsc1.Task));
 		tsc1.SetException(new AsyncOperationThrows.AsyncOperationThrowsException());
 
 		var firstExceptionReported = await Renderer.UnhandledException;
 
 		var secondException = new AsyncOperationThrows.AsyncOperationThrowsException();
-		var tsc2 = new TaskCompletionSource<object>();
+		var tsc2 = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
 		RenderComponent<AsyncOperationThrows>(ps => ps.Add(p => p.Awaitable, tsc2.Task));
 		tsc2.SetException(secondException);
 

--- a/tests/bunit.core.tests/TestContextBaseTest.net5.cs
+++ b/tests/bunit.core.tests/TestContextBaseTest.net5.cs
@@ -149,7 +149,7 @@ public partial class TestContextBaseTest : TestContext
 
 	private sealed class AsyncDisposableComponent : ComponentBase, IAsyncDisposable
 	{
-		private readonly TaskCompletionSource tsc = new();
+		private readonly TaskCompletionSource tsc = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
 		public Task DisposedTask => tsc.Task;
 

--- a/tests/bunit.testassets/BlazorE2E/AsyncEventHandlerComponent.razor
+++ b/tests/bunit.testassets/BlazorE2E/AsyncEventHandlerComponent.razor
@@ -15,7 +15,7 @@
     {
         if (_tcs == null)
         {
-            _tcs = new TaskCompletionSource<object>();
+            _tcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             state = "Started";
             return _tcs.Task.ContinueWith((_) =>

--- a/tests/bunit.testassets/SampleComponents/AsyncRenderChangesProperty.razor
+++ b/tests/bunit.testassets/SampleComponents/AsyncRenderChangesProperty.razor
@@ -1,7 +1,7 @@
 <button id="tick" @onclick="Tick">Tick</button>
 <button id="tock" @onclick="Tock">Tock</button>
 @code {
-	private TaskCompletionSource<object?> _tcs = new TaskCompletionSource<object?>();
+	private TaskCompletionSource<object?> _tcs = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
 	public int Counter;
 
 	private Task Tick()

--- a/tests/bunit.testassets/SampleComponents/Data/AsyncNameDep.cs
+++ b/tests/bunit.testassets/SampleComponents/Data/AsyncNameDep.cs
@@ -2,14 +2,14 @@ namespace Bunit.TestAssets.SampleComponents.Data;
 
 public class AsyncNameDep : IAsyncTestDep
 {
-	private TaskCompletionSource<string> completionSource = new TaskCompletionSource<string>();
+	private TaskCompletionSource<string> completionSource = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
 
 	public Task<string> GetDataAsync() => completionSource.Task;
 
 	public void SetResult(string name)
 	{
 		var prevSource = completionSource;
-		completionSource = new TaskCompletionSource<string>();
+		completionSource = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
 		prevSource.SetResult(name);
 	}
 }

--- a/tests/bunit.testassets/SampleComponents/TwoRendersTwoChanges.razor
+++ b/tests/bunit.testassets/SampleComponents/TwoRendersTwoChanges.razor
@@ -16,7 +16,7 @@
 	{
 		if (_tcs is null)
 		{
-			_tcs = new TaskCompletionSource<object?>();
+			_tcs = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
 
 			state = "Started";
 			tockEnabled = true;


### PR DESCRIPTION
## Description
This Pull Request will pass the `TaskCreationOptions.RunContinuationsAsynchronously` flag to `TaskCompletionSource`. This should address some red test. The begin of my journey was the `DisposeAsync` test which failed from time to time. I do think that was related to that exact issue. Unfortunately I could never reproduce this locally.

## Motivation
Here is an in-depth article about TCS: https://devblogs.microsoft.com/premier-developer/the-danger-of-taskcompletionsourcet-class/

In the end some places would not need the `RunContinuationsAsynchronously` option at all, as it's guaranteed that everything is run synchronously. I thought it might be better to stick to the pattern rather than being over-correct. 