### PR TITLE
`WaitTask` is using async/await in Dispatcher logic

### DIFF
--- a/src/bunit.core/Rendering/TestRenderer.cs
+++ b/src/bunit.core/Rendering/TestRenderer.cs
@@ -12,7 +12,7 @@ public class TestRenderer : Renderer, ITestRenderer
 	private readonly List<RootComponent> rootComponents = new();
 	private readonly ILogger<TestRenderer> logger;
 	private readonly IRenderedComponentActivator activator;
-	private TaskCompletionSource<Exception> unhandledExceptionTsc = new();
+	private TaskCompletionSource<Exception> unhandledExceptionTsc = new(TaskCreationOptions.RunContinuationsAsynchronously);
 	private Exception? capturedUnhandledException;
 
 	/// <inheritdoc/>
@@ -352,7 +352,7 @@ public class TestRenderer : Renderer, ITestRenderer
 
 		if (!unhandledExceptionTsc.TrySetResult(capturedUnhandledException))
 		{
-			unhandledExceptionTsc = new TaskCompletionSource<Exception>();
+			unhandledExceptionTsc = new TaskCompletionSource<Exception>(TaskCreationOptions.RunContinuationsAsynchronously);
 			unhandledExceptionTsc.SetResult(capturedUnhandledException);
 		}
 	}
@@ -362,7 +362,7 @@ public class TestRenderer : Renderer, ITestRenderer
 		capturedUnhandledException = null;
 
 		if (unhandledExceptionTsc.Task.IsCompleted)
-			unhandledExceptionTsc = new TaskCompletionSource<Exception>();
+			unhandledExceptionTsc = new TaskCompletionSource<Exception>(TaskCreationOptions.RunContinuationsAsynchronously);
 	}
 
 	private void AssertNoUnhandledExceptions()

--- a/src/bunit.web/JSInterop/InvocationHandlers/JSRuntimeInvocationHandlerBase{TResult}.cs
+++ b/src/bunit.web/JSInterop/InvocationHandlers/JSRuntimeInvocationHandlerBase{TResult}.cs
@@ -31,7 +31,7 @@ public abstract class JSRuntimeInvocationHandlerBase<TResult>
 	protected JSRuntimeInvocationHandlerBase(InvocationMatcher matcher, bool isCatchAllHandler)
 	{
 		invocationMatcher = matcher ?? throw new ArgumentNullException(nameof(matcher));
-		completionSource = new TaskCompletionSource<TResult>();
+		completionSource = new TaskCompletionSource<TResult>(TaskCreationOptions.RunContinuationsAsynchronously);
 		IsCatchAllHandler = isCatchAllHandler;
 	}
 
@@ -41,7 +41,7 @@ public abstract class JSRuntimeInvocationHandlerBase<TResult>
 	protected void SetCanceledBase()
 	{
 		if (completionSource.Task.IsCompleted)
-			completionSource = new TaskCompletionSource<TResult>();
+			completionSource = new TaskCompletionSource<TResult>(TaskCreationOptions.RunContinuationsAsynchronously);
 
 		completionSource.SetCanceled();
 	}
@@ -54,7 +54,7 @@ public abstract class JSRuntimeInvocationHandlerBase<TResult>
 		where TException : Exception
 	{
 		if (completionSource.Task.IsCompleted)
-			completionSource = new TaskCompletionSource<TResult>();
+			completionSource = new TaskCompletionSource<TResult>(TaskCreationOptions.RunContinuationsAsynchronously);
 
 		completionSource.SetException(exception);
 	}
@@ -66,7 +66,7 @@ public abstract class JSRuntimeInvocationHandlerBase<TResult>
 	protected void SetResultBase(TResult result)
 	{
 		if (completionSource.Task.IsCompleted)
-			completionSource = new TaskCompletionSource<TResult>();
+			completionSource = new TaskCompletionSource<TResult>(TaskCreationOptions.RunContinuationsAsynchronously);
 
 		completionSource.SetResult(result);
 	}

--- a/src/bunit.web/TestDoubles/Authorization/FakeAuthenticationStateProvider.cs
+++ b/src/bunit.web/TestDoubles/Authorization/FakeAuthenticationStateProvider.cs
@@ -75,7 +75,7 @@ public class FakeAuthenticationStateProvider : AuthenticationStateProvider
 	private void SetUnauthenticatedState()
 	{
 		if (authState.Task.IsCompleted)
-			authState = new TaskCompletionSource<AuthenticationState>();
+			authState = new TaskCompletionSource<AuthenticationState>(TaskCreationOptions.RunContinuationsAsynchronously);
 
 		authState.SetResult(CreateUnauthenticationState());
 	}
@@ -83,7 +83,7 @@ public class FakeAuthenticationStateProvider : AuthenticationStateProvider
 	private void SetAuthorizingState()
 	{
 		if (authState.Task.IsCompleted)
-			authState = new TaskCompletionSource<AuthenticationState>();
+			authState = new TaskCompletionSource<AuthenticationState>(TaskCreationOptions.RunContinuationsAsynchronously);
 	}
 
 	private void SetAuthenticatedState(
@@ -93,7 +93,7 @@ public class FakeAuthenticationStateProvider : AuthenticationStateProvider
 		string? authenticationType)
 	{
 		if (authState.Task.IsCompleted)
-			authState = new TaskCompletionSource<AuthenticationState>();
+			authState = new TaskCompletionSource<AuthenticationState>(TaskCreationOptions.RunContinuationsAsynchronously);
 
 		authState.SetResult(CreateAuthenticationState(userName, roles, claims, authenticationType));
 	}


### PR DESCRIPTION
This small experiment is part 1 to make `WaitFor` more stable for our unit tests.

In this PR I wanted to address some issues:
1. Use  `TaskCreationOptions.RunContinuationsAsynchronously` as it is good practice for `TaskCompletionSource`
2. Inside `CreateWaitTask` we can leverage async/await inside the `Dispatcher.InvokeAsync` to reduce the amount of *sync over async* patterns.

I also experimented with `WaitForXXXAsync`, which still leads to some failing test.
Therefore I wanted to start with this PR to ease the situation at least a bit.