### PR TITLE
feat: Added updater for github actions

### DIFF
--- a/.github/workflows/action-updater.yml
+++ b/.github/workflows/action-updater.yml
@@ -11,7 +11,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3.1.0
+      - name: 🛒 Checkout repository
+        uses: actions/checkout@v3.1.0
         with:
           token: ${{ secrets.BUNIT_BOT_TOKEN }}
 
@@ -22,7 +23,7 @@ jobs:
           gpg-private-key: ${{ secrets.BUNIT_BOT_GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.BUNIT_BOT_GPG_KEY_PASSPHRASE }}
 
-      - name: Run GitHub Actions Version Updater
+      - name: 💡 Run GitHub Actions Version Updater
         uses: saadmk11/github-actions-version-updater@v0.7.1
         with:
           token: ${{ secrets.BUNIT_BOT_TOKEN }}

--- a/.github/workflows/action-updater.yml
+++ b/.github/workflows/action-updater.yml
@@ -1,0 +1,30 @@
+name: GitHub Actions Version Updater
+
+on:
+  schedule:
+    - cron:  '0 1 * * *' # Everday 1 o'clock
+
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3.1.0
+        with:
+          token: ${{ secrets.BUNIT_BOT_TOKEN }}
+
+      - name: ⚙️ Import GPG key
+        id: import_gpg
+        uses: crazy-max/ghaction-import-gpg@v3
+        with:
+          gpg-private-key: ${{ secrets.BUNIT_BOT_GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.BUNIT_BOT_GPG_KEY_PASSPHRASE }}
+
+      - name: Run GitHub Actions Version Updater
+        uses: saadmk11/github-actions-version-updater@v0.7.1
+        with:
+          token: ${{ secrets.BUNIT_BOT_TOKEN }}
+          committer_username: "${{ steps.import_gpg.outputs.name }}"
+          committer_email: ${{ steps.import_gpg.outputs.email }}


### PR DESCRIPTION
Added auto-update for our GitHub actions.

Either it runs once a week or manually. The action will create a PR, which then would update all the versions, something like this:https://github.com/linkdotnet/Blog/pull/115 or this https://github.com/linkdotnet/StringBuilder/pull/4

Unfortunately I can't run this workflow on a branch. That makes it a bit tricky to verify if everything is working as it should