### PR TITLE
Experiments: dispatch render updates in xunit sync context

### DIFF
--- a/.github/workflows/verification.yml
+++ b/.github/workflows/verification.yml
@@ -63,10 +63,10 @@ jobs:
         run: |
           dotnet test --filter Category!=sync -c release
       - name: 🧪 Run unit tests (sync)
+        if: always()
         run: |
           dotnet test --filter Category!=async -c release
       - name: 📛 Upload hang- and crash-dumps on test failure
-        if: failure()
         uses: actions/upload-artifact@v3
         with:
           if-no-files-found: ignore
@@ -85,7 +85,7 @@ jobs:
         run: |
           dotnet new --install bunit.template::${NBGV_NuGetPackageVersion} --nuget-source ${{ github.workspace }}/packages
 
-      - name: ✔ Verify xUnit template
+      - name: ✔ Verify xUnit template        
         run: |
           dotnet new bunit --no-restore -o ${{ github.workspace }}/TemplateTestXunit
           echo '<?xml version="1.0" encoding="utf-8"?><Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003"></Project>' >> ${{ github.workspace }}/TemplateTestXunit/Directory.Build.props

--- a/.github/workflows/verification.yml
+++ b/.github/workflows/verification.yml
@@ -93,6 +93,7 @@ jobs:
           dotnet test ${{ github.workspace }}/TemplateTestXunit
 
       - name: ✔ Verify NUnit template
+        if: matrix.os == 'windows-latest'
         run: |
           dotnet new bunit --framework nunit --no-restore -o ${{ github.workspace }}/TemplateTestNunit
           echo '<?xml version="1.0" encoding="utf-8"?><Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003"></Project>' >> ${{ github.workspace }}/TemplateTestNunit/Directory.Build.props
@@ -100,6 +101,7 @@ jobs:
           dotnet test ${{ github.workspace }}/TemplateTestNunit
 
       - name: ✔ Verify MSTest template
+        if: matrix.os == 'windows-latest'
         run: |
           dotnet new bunit --framework mstest --no-restore -o ${{ github.workspace }}/TemplateTestMstest
           echo '<?xml version="1.0" encoding="utf-8"?><Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003"></Project>' >> ${{ github.workspace }}/TemplateTestMstest/Directory.Build.props

--- a/.github/workflows/verification.yml
+++ b/.github/workflows/verification.yml
@@ -93,7 +93,6 @@ jobs:
           dotnet test ${{ github.workspace }}/TemplateTestXunit
 
       - name: ✔ Verify NUnit template
-        if: matrix.os == 'windows-latest'
         run: |
           dotnet new bunit --framework nunit --no-restore -o ${{ github.workspace }}/TemplateTestNunit
           echo '<?xml version="1.0" encoding="utf-8"?><Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003"></Project>' >> ${{ github.workspace }}/TemplateTestNunit/Directory.Build.props
@@ -101,7 +100,6 @@ jobs:
           dotnet test ${{ github.workspace }}/TemplateTestNunit
 
       - name: ✔ Verify MSTest template
-        if: matrix.os == 'windows-latest'
         run: |
           dotnet new bunit --framework mstest --no-restore -o ${{ github.workspace }}/TemplateTestMstest
           echo '<?xml version="1.0" encoding="utf-8"?><Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003"></Project>' >> ${{ github.workspace }}/TemplateTestMstest/Directory.Build.props

--- a/bunit.sln.DotSettings
+++ b/bunit.sln.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Bunit/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/AngleSharpWrappers/Generated/HtmlTableElementWrapper.g.cs
+++ b/src/AngleSharpWrappers/Generated/HtmlTableElementWrapper.g.cs
@@ -166,7 +166,7 @@ namespace AngleSharpWrappers
         public UInt32 Border { get => WrappedElement.Border; set => WrappedElement.Border = value;}
         /// <inheritdoc/>
         [DebuggerHidden]
-        public IHtmlTableCaptionElement? Caption { get => WrappedElement.Caption; set => WrappedElement.Caption = value;}
+        public IHtmlTableCaptionElement Caption { get => WrappedElement.Caption!; set => WrappedElement.Caption = value;}
         /// <inheritdoc/>
         [DebuggerHidden]
         public Int32 ChildElementCount { get => WrappedElement.ChildElementCount; }
@@ -208,13 +208,13 @@ namespace AngleSharpWrappers
         public NodeFlags Flags { get => WrappedElement.Flags; }
         /// <inheritdoc/>
         [DebuggerHidden]
-        public IHtmlTableSectionElement? Foot { get => WrappedElement.Foot; set => WrappedElement.Foot = value;}
+        public IHtmlTableSectionElement Foot { get => WrappedElement.Foot!; set => WrappedElement.Foot = value;}
         /// <inheritdoc/>
         [DebuggerHidden]
         public Boolean HasChildNodes { get => WrappedElement.HasChildNodes; }
         /// <inheritdoc/>
         [DebuggerHidden]
-        public IHtmlTableSectionElement? Head { get => WrappedElement.Head; set => WrappedElement.Head = value;}
+        public IHtmlTableSectionElement Head { get => WrappedElement.Head!; set => WrappedElement.Head = value;}
         /// <inheritdoc/>
         [DebuggerHidden]
         public String? Id { get => WrappedElement.Id; set => WrappedElement.Id = value;}

--- a/src/bunit.core/Rendering/RenderEvent.cs
+++ b/src/bunit.core/Rendering/RenderEvent.cs
@@ -5,7 +5,7 @@ namespace Bunit.Rendering;
 /// </summary>
 public sealed class RenderEvent
 {
-	internal readonly RenderBatch RenderBatch;
+	private readonly RenderBatch RenderBatch;
 
 	/// <summary>
 	/// Gets a collection of <see cref="ArrayRange{RenderTreeFrame}"/>, accessible via the ID

--- a/src/bunit.core/Rendering/RenderEvent.cs
+++ b/src/bunit.core/Rendering/RenderEvent.cs
@@ -5,7 +5,7 @@ namespace Bunit.Rendering;
 /// </summary>
 public sealed class RenderEvent
 {
-	private readonly RenderBatch renderBatch;
+	internal readonly RenderBatch RenderBatch;
 
 	/// <summary>
 	/// Gets a collection of <see cref="ArrayRange{RenderTreeFrame}"/>, accessible via the ID
@@ -16,11 +16,11 @@ public sealed class RenderEvent
 	/// <summary>
 	/// Initializes a new instance of the <see cref="RenderEvent"/> class.
 	/// </summary>
-	/// <param name="renderBatch">The <see cref="RenderBatch"/> update from the render event.</param>
+	/// <param name="renderBatch">The <see cref="Microsoft.AspNetCore.Components.RenderTree.RenderBatch"/> update from the render event.</param>
 	/// <param name="frames">The <see cref="RenderTreeFrameDictionary"/> from the current render.</param>
-	internal RenderEvent(RenderBatch renderBatch, RenderTreeFrameDictionary frames)
+	public RenderEvent(in RenderBatch renderBatch, RenderTreeFrameDictionary frames)
 	{
-		this.renderBatch = renderBatch;
+		this.RenderBatch = renderBatch;
 		Frames = frames;
 	}
 
@@ -50,9 +50,9 @@ public sealed class RenderEvent
 
 	private bool DidComponentDispose(IRenderedFragmentBase renderedComponent)
 	{
-		for (var i = 0; i < renderBatch.DisposedComponentIDs.Count; i++)
+		for (var i = 0; i < RenderBatch.DisposedComponentIDs.Count; i++)
 		{
-			if (renderBatch.DisposedComponentIDs.Array[i].Equals(renderedComponent.ComponentId))
+			if (RenderBatch.DisposedComponentIDs.Array[i].Equals(renderedComponent.ComponentId))
 			{
 				return true;
 			}
@@ -63,7 +63,7 @@ public sealed class RenderEvent
 
 	/// <summary>
 	/// This method determines if the <paramref name="renderedComponent"/> or any of the
-	/// components underneath it in the render tree rendered and whether they they changed
+	/// components underneath it in the render tree rendered and whether they changed
 	/// their render tree during render.
 	///
 	/// It does this by getting the status from the <paramref name="renderedComponent"/>,
@@ -81,9 +81,9 @@ public sealed class RenderEvent
 
 		void GetStatus(int componentId)
 		{
-			for (var i = 0; i < renderBatch.UpdatedComponents.Count; i++)
+			for (var i = 0; i < RenderBatch.UpdatedComponents.Count; i++)
 			{
-				ref var update = ref renderBatch.UpdatedComponents.Array[i];
+				ref var update = ref RenderBatch.UpdatedComponents.Array[i];
 				if (update.ComponentId == componentId)
 				{
 					result.Rendered = true;

--- a/src/bunit.core/Rendering/RenderEvent.cs
+++ b/src/bunit.core/Rendering/RenderEvent.cs
@@ -5,7 +5,10 @@ namespace Bunit.Rendering;
 /// </summary>
 public sealed class RenderEvent
 {
-	private readonly RenderBatch RenderBatch;
+	/// <summary>
+	/// The render batch!
+	/// </summary>
+	public RenderBatch RenderBatch { get; }
 
 	/// <summary>
 	/// Gets a collection of <see cref="ArrayRange{RenderTreeFrame}"/>, accessible via the ID

--- a/src/bunit.core/Rendering/RenderTreeFrameDictionary.cs
+++ b/src/bunit.core/Rendering/RenderTreeFrameDictionary.cs
@@ -47,5 +47,8 @@ public sealed class RenderTreeFrameDictionary : IReadOnlyDictionary<int, ArrayRa
 	/// <inheritdoc/>
 	IEnumerator IEnumerable.GetEnumerator() => currentRenderTree.GetEnumerator();
 
+	/// <summary>
+	/// TODO
+	/// </summary>
 	public void Add(int componentId, ArrayRange<RenderTreeFrame> frames) => currentRenderTree.Add(componentId, frames);
 }

--- a/src/bunit.core/Rendering/RenderTreeFrameDictionary.cs
+++ b/src/bunit.core/Rendering/RenderTreeFrameDictionary.cs
@@ -28,7 +28,7 @@ public sealed class RenderTreeFrameDictionary : IReadOnlyDictionary<int, ArrayRa
 	/// <summary>
 	/// Initializes a new instance of the <see cref="RenderTreeFrameDictionary"/> class.
 	/// </summary>
-	internal RenderTreeFrameDictionary() { }
+	public RenderTreeFrameDictionary() { }
 
 	/// <summary>
 	/// Checks whether the collection contains a <see cref="ArrayRange{RenderTreeFrame}"/> for the <paramref name="componentId"/>.
@@ -47,5 +47,5 @@ public sealed class RenderTreeFrameDictionary : IReadOnlyDictionary<int, ArrayRa
 	/// <inheritdoc/>
 	IEnumerator IEnumerable.GetEnumerator() => currentRenderTree.GetEnumerator();
 
-	internal void Add(int componentId, ArrayRange<RenderTreeFrame> frames) => currentRenderTree.Add(componentId, frames);
+	public void Add(int componentId, ArrayRange<RenderTreeFrame> frames) => currentRenderTree.Add(componentId, frames);
 }

--- a/src/bunit.template/template/CounterCSharpTests.cs
+++ b/src/bunit.template/template/CounterCSharpTests.cs
@@ -14,7 +14,7 @@ public class CounterCSharpTests : BunitTestContext
 #endif
 {
 #if (testFramework_xunit)
-	[Fact]
+	[UIFact]
 #elif (testFramework_nunit)
 	[Test]
 #elif (testFramework_mstest)
@@ -30,7 +30,7 @@ public class CounterCSharpTests : BunitTestContext
 	}
 
 #if (testFramework_xunit)
-	[Fact]
+	[UIFact]
 #elif (testFramework_nunit)
 	[Test]
 #elif (testFramework_mstest)

--- a/src/bunit.template/template/CounterRazorTests.razor
+++ b/src/bunit.template/template/CounterRazorTests.razor
@@ -13,7 +13,7 @@ Learn more at https://bunit.dev/docs/getting-started/writing-tests.html#creating
 
 @code {
 @*#if (testFramework_xunit)*@
-    [Fact]
+    [UIFact]
 @*#elif (testFramework_nunit)*@
     [Test]
 @*#elif (testFramework_mstest)*@
@@ -28,7 +28,7 @@ Learn more at https://bunit.dev/docs/getting-started/writing-tests.html#creating
 		cut.Find("p").MarkupMatches(@<p>Current count: 0</p>);
 	}
 @*#if (testFramework_xunit)*@
-    [Fact]
+    [UIFact]
 @*#elif (testFramework_nunit)*@
     [Test]
 @*#elif (testFramework_mstest)*@

--- a/src/bunit.web/TestContext.cs
+++ b/src/bunit.web/TestContext.cs
@@ -42,15 +42,15 @@ public class TestContext : TestContextBase
 	/// <typeparam name="TComponent">Type of the component to render.</typeparam>
 	/// <param name="parameterBuilder">The ComponentParameterBuilder action to add type safe parameters to pass to the component when it is rendered.</param>
 	/// <returns>The rendered <typeparamref name="TComponent"/>.</returns>
-	public virtual IRenderedComponent<TComponent> RenderComponent<TComponent>(Action<ComponentParameterCollectionBuilder<TComponent>> parameterBuilder)
-		where TComponent : IComponent
-	{
-		var renderFragment = new ComponentParameterCollectionBuilder<TComponent>(parameterBuilder)
-			.Build()
-			.ToRenderFragment<TComponent>();
+		public virtual IRenderedComponent<TComponent> RenderComponent<TComponent>(Action<ComponentParameterCollectionBuilder<TComponent>> parameterBuilder)
+			where TComponent : IComponent
+		{
+			var renderFragment = new ComponentParameterCollectionBuilder<TComponent>(parameterBuilder)
+				.Build()
+				.ToRenderFragment<TComponent>();
 
-		return Render<TComponent>(renderFragment);
-	}
+			return Render<TComponent>(renderFragment);
+		}
 
 	/// <summary>
 	/// Renders the <paramref name="renderFragment"/> and returns the first <typeparamref name="TComponent"/> in the resulting render tree.

--- a/src/bunit.web/V2/.editorconfig
+++ b/src/bunit.web/V2/.editorconfig
@@ -1,0 +1,4 @@
+[*.cs]
+
+# CS1591: Missing XML comment for publicly visible type or member
+dotnet_diagnostic.CS1591.severity = none

--- a/src/bunit.web/V2/BunitContext.cs
+++ b/src/bunit.web/V2/BunitContext.cs
@@ -1,0 +1,39 @@
+using Bunit.V2.Rendering;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Bunit.V2;
+
+[SuppressMessage("Major Code Smell", "S3881:\"IDisposable\" should be implemented correctly", Justification = "<Pending>")]
+public class BunitContext : IDisposable
+{
+	private readonly ILoggerFactory loggerFactory;
+	private BunitRenderer? bunitRenderer;
+
+	protected ILogger Logger { get; }
+
+	public TestServiceProvider Services { get; } = new();
+
+	public BunitContext(ILoggerFactory? loggerFactory = null)
+	{
+		this.loggerFactory = loggerFactory ?? NullLoggerFactory.Instance;
+		Services.AddSingleton<ILoggerFactory>(this.loggerFactory);
+		Services.AddSingleton(typeof(ILogger<>), typeof(Logger<>));
+		Logger = this.loggerFactory.CreateLogger<BunitContext>();
+	}
+
+	public Task<RenderedFragment> RenderAsync<TComponent>(Action<ComponentParameterCollectionBuilder<TComponent>>? parameterBuilder = null)
+		where TComponent : IComponent
+	{
+		var renderFragment = new ComponentParameterCollectionBuilder<TComponent>(parameterBuilder)
+			.Build()
+			.ToRenderFragment<TComponent>();
+
+		bunitRenderer = new BunitRenderer(Services, loggerFactory);
+
+		return bunitRenderer.RenderAsync(renderFragment);
+	}
+
+	public void Dispose()
+		=> bunitRenderer?.Dispose();
+}

--- a/src/bunit.web/V2/Rendering/BunitRenderer.Log.cs
+++ b/src/bunit.web/V2/Rendering/BunitRenderer.Log.cs
@@ -1,0 +1,48 @@
+using Microsoft.Extensions.Logging;
+
+namespace Bunit.V2.Rendering;
+
+public partial class BunitRenderer : Renderer
+{
+	[LoggerMessage(
+		EventId = 1,
+		Level = LogLevel.Error,
+		Message = "An unhandled exception happened during rendering.")]
+	private static partial void LogUnhandledException(ILogger logger, Exception exception);
+
+	[LoggerMessage(
+		EventId = 2,
+		Level = LogLevel.Debug,
+		Message = "Processing pending renders.")]
+	private static partial void LogProcessingPendingRenders(ILogger logger);
+
+	[LoggerMessage(
+		EventId = 3,
+		Level = LogLevel.Debug,
+		Message = "New render batch received.")]
+	private static partial void LogNewRenderBatchReceived(ILogger logger);
+
+	[LoggerMessage(
+		EventId = 4,
+		Level = LogLevel.Debug,
+		Message = "Component {ComponentId} has been disposed.")]
+	private static partial void LogComponentDisposed(ILogger logger, int componentId);
+
+	[LoggerMessage(
+		EventId = 5,
+		Level = LogLevel.Debug,
+		Message = "Component {ComponentId} has been rendered.")]
+	private static partial void LogComponentRendered(ILogger logger, int componentId);
+
+	[LoggerMessage(
+		EventId = 6,
+		Level = LogLevel.Debug,
+		Message = "Finished updating the markup of changed components.")]
+	private static partial void LogChangedComponentsMarkupUpdated(ILogger logger);
+
+	[LoggerMessage(
+		EventId = 7,
+		Level = LogLevel.Debug,
+		Message = "Finished updating the markup of changed components.")]
+	private static partial void LogAsyncInitialRender(ILogger logger);
+}

--- a/src/bunit.web/V2/Rendering/BunitRenderer.cs
+++ b/src/bunit.web/V2/Rendering/BunitRenderer.cs
@@ -1,0 +1,162 @@
+using System.Runtime.ExceptionServices;
+using Bunit.Rendering;
+using Microsoft.Extensions.Logging;
+
+namespace Bunit.V2.Rendering;
+
+public partial class BunitRenderer : Renderer
+{
+	private readonly SynchronizationContext callerSyncContext;
+	private readonly ILogger<BunitRenderer> logger;
+	private readonly RootComponent root;
+	private readonly int rootComponentId;
+	private readonly RenderedFragment renderedFragment;
+	private readonly BunitHtmlParser htmlParser;
+	private Exception? capturedUnhandledException;
+
+	/// <summary>
+	/// Gets the number of times the renderer performed a render cycle.
+	/// </summary>
+	public int RenderCount { get; private set; }
+
+	/// <inheritdoc/>
+	public override Dispatcher Dispatcher { get; } = Dispatcher.CreateDefault();
+
+	public BunitRenderer(
+		IServiceProvider serviceProvider,
+		ILoggerFactory loggerFactory)
+		: base(serviceProvider, loggerFactory)
+	{
+		callerSyncContext = SynchronizationContext.Current ?? throw new ArgumentException("No current SynchronizationContext");
+		logger = loggerFactory.CreateLogger<BunitRenderer>();
+		renderedFragment = new RenderedFragment(loggerFactory.CreateLogger<RenderedFragment>());
+		root = new RootComponent();
+		rootComponentId = AssignRootComponentId(root);
+		htmlParser = new BunitHtmlParser();
+	}
+
+	public async Task<RenderedFragment> RenderAsync(RenderFragment renderFragment)
+	{
+		root.ChildContent = renderFragment;
+		try
+		{
+			await Dispatcher.InvokeAsync(async () =>
+			{
+				await RenderRootComponentAsync(rootComponentId)
+					.ConfigureAwait(false);
+				AssertNoUnhandledExceptions();
+			}).ConfigureAwait(false);
+		}
+		catch (Exception ex)
+		{
+			HandleException(ex);
+			throw;
+		}
+
+		return renderedFragment;
+	}
+
+	protected override Task UpdateDisplayAsync(in RenderBatch renderBatch)
+	{
+		LogNewRenderBatchReceived(logger);
+		RenderCount++;
+		var frames = new RenderTreeFrameDictionary();
+		LoadRenderTreeFrames(rootComponentId, frames);
+		var state = (this, frames);
+		callerSyncContext.Send(UpdateRenderedFragmentState, state);
+		return Task.CompletedTask;
+	}
+
+	/// <summary>
+	/// Populates the <paramref name="framesCollection"/> with <see cref="ArrayRange{RenderTreeFrame}"/>
+	/// starting with the one that belongs to the component with ID <paramref name="componentId"/>.
+	/// </summary>
+	private void LoadRenderTreeFrames(int componentId, RenderTreeFrameDictionary framesCollection)
+	{
+		var frames = GetOrLoadRenderTreeFrame(framesCollection, componentId);
+
+		for (var i = 0; i < frames.Count; i++)
+		{
+			ref var frame = ref frames.Array[i];
+			if (frame.FrameType == RenderTreeFrameType.Component)
+			{
+				LoadRenderTreeFrames(frame.ComponentId, framesCollection);
+			}
+		}
+	}
+
+	/// <summary>
+	/// Gets the <see cref="ArrayRange{RenderTreeFrame}"/> from the <paramref name="framesCollection"/>.
+	/// If the <paramref name="framesCollection"/> does not contain the frames, they are loaded into it first.
+	/// </summary>
+	private ArrayRange<RenderTreeFrame> GetOrLoadRenderTreeFrame(RenderTreeFrameDictionary framesCollection, int componentId)
+	{
+		if (!framesCollection.Contains(componentId))
+		{
+			var frames = GetCurrentRenderTreeFrames(componentId);
+			framesCollection.Add(componentId, frames);
+		}
+
+		return framesCollection[componentId];
+	}
+
+	private static void UpdateRenderedFragmentState(object? state)
+	{
+		var (renderer, frames) = (ValueTuple<BunitRenderer, RenderTreeFrameDictionary>)state!;
+		var markup = Htmlizer.GetHtml(renderer.rootComponentId, frames);
+		renderer.renderedFragment.Markup = markup;
+		renderer.renderedFragment.Nodes = renderer.htmlParser.Parse(markup);
+		LogChangedComponentsMarkupUpdated(renderer.logger);
+		renderer.renderedFragment.NotifyRenderComplete();
+	}
+
+	/// <inheritdoc/>
+	public override async Task DispatchEventAsync(ulong eventHandlerId, EventFieldInfo? fieldInfo, EventArgs eventArgs)
+	{
+		await Dispatcher.InvokeAsync(async () =>
+		{
+			try
+			{
+				await base
+					.DispatchEventAsync(eventHandlerId, fieldInfo, eventArgs)
+					.ConfigureAwait(false);
+			}
+			catch (Exception ex)
+			{
+				HandleException(ex);
+				throw;
+			}
+		}).ConfigureAwait(false);
+
+		AssertNoUnhandledExceptions();
+	}
+
+	/// <inheritdoc/>
+	protected override void HandleException(Exception exception)
+	{
+		if (exception is null)
+		{
+			return;
+		}
+
+		capturedUnhandledException = exception;
+		LogUnhandledException(logger, exception);
+	}
+
+	private void AssertNoUnhandledExceptions()
+	{
+		if (capturedUnhandledException is Exception unhandled)
+		{
+			capturedUnhandledException = null;
+
+			if (unhandled is AggregateException aggregateException && aggregateException.InnerExceptions.Count == 1)
+			{
+				ExceptionDispatchInfo.Capture(aggregateException.InnerExceptions[0]).Throw();
+			}
+			else
+			{
+				ExceptionDispatchInfo.Capture(unhandled).Throw();
+			}
+		}
+	}
+}

--- a/src/bunit.web/V2/Rendering/EmptyNodeList.cs
+++ b/src/bunit.web/V2/Rendering/EmptyNodeList.cs
@@ -1,0 +1,26 @@
+﻿using System.Collections;
+using AngleSharp;
+using AngleSharp.Dom;
+
+namespace Bunit.V2.Rendering;
+
+internal class EmptyNodeList : INodeList
+{
+	public static readonly INodeList Empty = new EmptyNodeList();
+
+	INode INodeList.this[int index]
+	{
+		get
+		{
+			throw new IndexOutOfRangeException();
+		}
+	}
+
+	public int Length => 0;
+
+	public IEnumerator<INode> GetEnumerator() { yield break; }
+
+	public void ToHtml(TextWriter writer, IMarkupFormatter formatter) { }
+
+	IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+}

--- a/src/bunit.web/V2/Rendering/RenderedFragment.Log.cs
+++ b/src/bunit.web/V2/Rendering/RenderedFragment.Log.cs
@@ -1,0 +1,30 @@
+using Microsoft.Extensions.Logging;
+
+namespace Bunit.V2.Rendering;
+
+public partial class RenderedFragment
+{
+	[LoggerMessage(
+		EventId = 1,
+		Level = LogLevel.Debug,
+		Message = "Rendered fragment updated.")]
+	private static partial void LogRenderedFragmentUpdated(ILogger logger);
+
+	[LoggerMessage(
+		EventId = 10,
+		Level = LogLevel.Debug,
+		Message = "Trying on after render action.")]
+	private static partial void LogTryOnAfterAction(ILogger logger);
+
+	[LoggerMessage(
+		EventId = 11,
+		Level = LogLevel.Debug,
+		Message = "On after render action completed successfully.")]
+	private static partial void LogOnAfterActionCompleted(ILogger logger);
+
+	[LoggerMessage(
+		EventId = 12,
+		Level = LogLevel.Debug,
+		Message = "On after render action failed.")]
+	private static partial void LogOnAfterActionFailed(ILogger logger);
+}

--- a/src/bunit.web/V2/Rendering/RenderedFragment.cs
+++ b/src/bunit.web/V2/Rendering/RenderedFragment.cs
@@ -14,14 +14,20 @@ public partial class RenderedFragment
 
 	public INodeList Nodes { get; internal set; }
 
-	public RenderedFragment(ILogger<RenderedFragment> logger)
+	public BunitRenderer Renderer { get; }
+
+	internal RenderedFragment(BunitRenderer renderer, ILogger<RenderedFragment> logger)
 	{
+		Renderer = renderer;
 		this.logger = logger;
 		Markup = string.Empty;
 		Nodes = EmptyNodeList.Empty;
 	}
 
-	public async Task OnAfterRenderAsync(Action afterRenderAction, TimeSpan? timeout = null)
+	public IElement? Find(string cssSelector)
+		=> Nodes.QuerySelector(cssSelector);
+
+	public async Task AssertAfterRenderAsync(Action afterRenderAction, TimeSpan? timeout = null)
 	{
 		onAfterRenderAction = afterRenderAction;
 		onAfterRenderTask = new TaskCompletionSource();

--- a/src/bunit.web/V2/Rendering/RenderedFragment.cs
+++ b/src/bunit.web/V2/Rendering/RenderedFragment.cs
@@ -1,0 +1,73 @@
+using AngleSharp.Dom;
+using Microsoft.Extensions.Logging;
+
+namespace Bunit.V2.Rendering;
+
+public partial class RenderedFragment
+{
+	private readonly ILogger<RenderedFragment> logger;
+	private Exception? onAfterRenderActionException;
+	private Action? onAfterRenderAction;
+	private TaskCompletionSource? onAfterRenderTask;
+
+	public string Markup { get; internal set; }
+
+	public INodeList Nodes { get; internal set; }
+
+	public RenderedFragment(ILogger<RenderedFragment> logger)
+	{
+		this.logger = logger;
+		Markup = string.Empty;
+		Nodes = EmptyNodeList.Empty;
+	}
+
+	public async Task OnAfterRenderAsync(Action afterRenderAction, TimeSpan? timeout = null)
+	{
+		onAfterRenderAction = afterRenderAction;
+		onAfterRenderTask = new TaskCompletionSource();
+		TryAfterRenderAction();
+
+		try
+		{
+			await onAfterRenderTask
+				.Task
+				.WaitAsync(timeout ?? TimeSpan.FromSeconds(1));
+
+			onAfterRenderActionException = null;
+			onAfterRenderAction = null;
+			onAfterRenderTask = null;
+		}
+		catch (TimeoutException)
+		{
+			throw new TimeoutException("The after render action did not complete successfully before the timeout was reached.", onAfterRenderActionException);
+		}
+	}
+
+	private void TryAfterRenderAction()
+	{
+		if (onAfterRenderAction is null || onAfterRenderTask is null)
+		{
+			return;
+		}
+
+		LogTryOnAfterAction(logger);
+
+		try
+		{
+			onAfterRenderAction.Invoke();
+			LogOnAfterActionCompleted(logger);
+			onAfterRenderTask.SetResult();
+		}
+		catch (Exception ex)
+		{
+			onAfterRenderActionException = ex;
+			LogOnAfterActionFailed(logger);
+		}
+	}
+
+	internal void NotifyRenderComplete()
+	{
+		LogRenderedFragmentUpdated(logger);
+		TryAfterRenderAction();
+	}
+}

--- a/src/bunit.web/V2/Rendering/RenderedFragment.cs
+++ b/src/bunit.web/V2/Rendering/RenderedFragment.cs
@@ -38,14 +38,16 @@ public partial class RenderedFragment
 			await onAfterRenderTask
 				.Task
 				.WaitAsync(timeout ?? TimeSpan.FromSeconds(1));
-
-			onAfterRenderActionException = null;
-			onAfterRenderAction = null;
-			onAfterRenderTask = null;
 		}
 		catch (TimeoutException)
 		{
 			throw new TimeoutException("The after render action did not complete successfully before the timeout was reached.", onAfterRenderActionException);
+		}
+		finally
+		{
+			onAfterRenderActionException = null;
+			onAfterRenderAction = null;
+			onAfterRenderTask = null;
 		}
 	}
 

--- a/src/bunit.web/V2/Rendering/RootComponent.cs
+++ b/src/bunit.web/V2/Rendering/RootComponent.cs
@@ -1,0 +1,21 @@
+namespace Bunit.V2.Rendering;
+
+internal sealed class RootComponent : IComponent
+{
+	private RenderHandle? renderHandle;
+
+	internal RenderFragment? ChildContent { get; set; }
+
+	public void Attach(RenderHandle renderHandle)
+		=> this.renderHandle = renderHandle;
+
+	public Task SetParametersAsync(ParameterView parameters)
+	{
+		if (renderHandle.HasValue && ChildContent is not null)
+		{
+			renderHandle.Value.Render(ChildContent);
+		}
+
+		return Task.CompletedTask;
+	}
+}

--- a/src/bunit.web/bunit.web.csproj
+++ b/src/bunit.web/bunit.web.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFrameworks>net6.0;net7.0</TargetFrameworks>
@@ -57,11 +57,11 @@
 
 		<ItemGroup>
 			<!-- Add file to package with consideration of sub folder. If empty, the root folder is chosen. -->
-			<BuildOutputInPackage Include="@(_ReferenceCopyLocalPaths)" TargetPath="%(_ReferenceCopyLocalPaths.DestinationSubDirectory)"/>
+			<BuildOutputInPackage Include="@(_ReferenceCopyLocalPaths)" TargetPath="%(_ReferenceCopyLocalPaths.DestinationSubDirectory)" />
 		</ItemGroup>
 	</Target>
 
-	<ItemGroup Label="Implicit usings" Condition="$(MSBuildProjectName) != 'bunit.template' AND $(MSBuildProjectName) != 'bunit'">
+	<ItemGroup Label="Implicit usings">
 		<Using Include="Microsoft.AspNetCore.Components.Web" />
 		<Using Include="Microsoft.JSInterop" />
 	</ItemGroup>

--- a/src/bunit.web/bunit.web.csproj
+++ b/src/bunit.web/bunit.web.csproj
@@ -49,7 +49,7 @@
 	<Target Name="CopyProjectReferencesToPackage" DependsOnTargets="BuildOnlySettings;ResolveReferences">
 		<ItemGroup>
 			<!-- Filter out unnecessary files -->
-			<_ReferenceCopyLocalPaths Include="@(ReferenceCopyLocalPaths->WithMetadataValue('ReferenceSourceTarget', 'ProjectReference')->WithMetadataValue('PrivateAssets', 'All'))"/>
+			<_ReferenceCopyLocalPaths Include="@(ReferenceCopyLocalPaths-&gt;WithMetadataValue('ReferenceSourceTarget', 'ProjectReference')-&gt;WithMetadataValue('PrivateAssets', 'All'))" />
 		</ItemGroup>
 
 		<!-- Print batches for debug purposes -->

--- a/tests/AngleSharpWrappers.Tests/ElementWrapperTest.cs
+++ b/tests/AngleSharpWrappers.Tests/ElementWrapperTest.cs
@@ -14,7 +14,7 @@ namespace AngleSharpWrappers;
     {
         private HtmlParser Parser { get; } = new HtmlParser();
 
-        [Fact(DisplayName = "QuerySelectorAll works the same with wrapped and non-wrapped element")]
+        [UIFact(DisplayName = "QuerySelectorAll works the same with wrapped and non-wrapped element")]
         public void Test001()
         {
             var elm = Parser.Parse(
@@ -31,7 +31,7 @@ namespace AngleSharpWrappers;
             sutQueryRes.ShouldBe(elmQueryRes);
         }
 
-        [Fact(DisplayName = "QuerySelector works the same with wrapped and non-wrapped element")]
+        [UIFact(DisplayName = "QuerySelector works the same with wrapped and non-wrapped element")]
         public void Test002()
         {
             var elm = Parser.Parse(

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -14,6 +14,7 @@
 	</PropertyGroup>
 
 	<ItemGroup Condition="$(MSBuildProjectName) != 'bunit.testassets'">
+		<PackageReference Include="Xunit.StaFact" Version="1.1.11" />
 		<PackageReference Include="AutoFixture" Version="4.17.0" />
 		<PackageReference Include="AutoFixture.Xunit2" Version="4.17.0" />
 	    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />

--- a/tests/bunit.core.tests/ComponentFactories/ConditionalComponentFactoryTest.cs
+++ b/tests/bunit.core.tests/ComponentFactories/ConditionalComponentFactoryTest.cs
@@ -2,22 +2,22 @@ namespace Bunit.ComponentFactories;
 
 public class ConditionalComponentFactoryTest : TestContext
 {
-	[Fact(DisplayName = "Add throws when factories is null")]
+	[UIFact(DisplayName = "Add throws when factories is null")]
 	public void Test001()
 		=> Should.Throw<ArgumentNullException>(
 			() => ComponentFactoryCollectionExtensions.Add(default, default(Predicate<Type>), default(Func<Type, IComponent>)));
 
-	[Fact(DisplayName = "Add throws when condition is null")]
+	[UIFact(DisplayName = "Add throws when condition is null")]
 	public void Test002()
 		=> Should.Throw<ArgumentNullException>(
 			() => ComponentFactories.Add(default(Predicate<Type>), default(Func<Type, IComponent>)));
 
-	[Fact(DisplayName = "Add throws when factory is null")]
+	[UIFact(DisplayName = "Add throws when factory is null")]
 	public void Test003()
 	=> Should.Throw<ArgumentNullException>(
 		() => ComponentFactories.Add(_ => true, default(Func<Type, IComponent>)));
 
-	[Fact(DisplayName = "Component is replaced in render tree with component from factory when matches returns true")]
+	[UIFact(DisplayName = "Component is replaced in render tree with component from factory when matches returns true")]
 	public void Test010()
 	{
 		var mockComponent = Mock.Of<Simple1>();
@@ -29,7 +29,7 @@ public class ConditionalComponentFactoryTest : TestContext
 			.Instance.ShouldBeSameAs(mockComponent);
 	}
 
-	[Fact(DisplayName = "Component is replaced in render tree with component from factory when matches returns true")]
+	[UIFact(DisplayName = "Component is replaced in render tree with component from factory when matches returns true")]
 	public void Test011()
 	{
 		var mockRepo = new MockRepository(MockBehavior.Loose);
@@ -45,7 +45,7 @@ public class ConditionalComponentFactoryTest : TestContext
 		cut.FindComponents<NoArgs>().ShouldAllBe(x => Mock.Get(x.Instance));
 	}
 
-	[Fact(DisplayName = "When matches returns false, factory is never called")]
+	[UIFact(DisplayName = "When matches returns false, factory is never called")]
 	public void Test012()
 	{
 		ComponentFactories.Add(_ => false, _ => throw new NotImplementedException("DONT CALL FACTORY"));

--- a/tests/bunit.core.tests/ComponentFactories/GenericComponentFactoryTest.cs
+++ b/tests/bunit.core.tests/ComponentFactories/GenericComponentFactoryTest.cs
@@ -10,11 +10,11 @@ namespace Bunit.ComponentFactories;
 
 public class GenericComponentFactoryTest : TestContext
 {
-	[Fact(DisplayName = "Add throws when factories is null")]
+	[UIFact(DisplayName = "Add throws when factories is null")]
 	public void Test001()
 		=> Should.Throw<ArgumentNullException>(() => ComponentFactoryCollectionExtensions.Add<Simple1, FakeSimple1>(factories: default));
 
-	[Fact(DisplayName = "Add<TComponent, TReplacementComponent> replaces components of type TComponent with TReplacementComponent")]
+	[UIFact(DisplayName = "Add<TComponent, TReplacementComponent> replaces components of type TComponent with TReplacementComponent")]
 	public void Test002()
 	{
 		ComponentFactories.Add<Simple1, FakeSimple1>();

--- a/tests/bunit.core.tests/ComponentFactories/InstanceComponentFactoryTest.cs
+++ b/tests/bunit.core.tests/ComponentFactories/InstanceComponentFactoryTest.cs
@@ -2,15 +2,15 @@ namespace Bunit.ComponentFactories;
 
 public class InstanceComponentFactoryTest : TestContext
 {
-	[Fact(DisplayName = "Add throws when factories is null")]
+	[UIFact(DisplayName = "Add throws when factories is null")]
 	public void Test001()
 		=> Should.Throw<ArgumentNullException>(() => ComponentFactoryCollectionExtensions.Add<Simple1>(default, default(Simple1)));
 
-	[Fact(DisplayName = "Add throws when instance is null")]
+	[UIFact(DisplayName = "Add throws when instance is null")]
 	public void Test002()
 		=> Should.Throw<ArgumentNullException>(() => ComponentFactories.Add<Simple1>(default(Simple1)));
 
-	[Fact(DisplayName = "Factory replaces one TComponent with instance in the render tree")]
+	[UIFact(DisplayName = "Factory replaces one TComponent with instance in the render tree")]
 	public void Test010()
 	{
 		var simple1Mock = new Mock<Simple1>();
@@ -22,7 +22,7 @@ public class InstanceComponentFactoryTest : TestContext
 			.Instance.ShouldBeSameAs(simple1Mock.Object);
 	}
 
-	[Fact(DisplayName = "Factory throws if component instance is requested twice for TComponent that inherits from ComponentBase")]
+	[UIFact(DisplayName = "Factory throws if component instance is requested twice for TComponent that inherits from ComponentBase")]
 	public void Test020()
 	{
 		var simple1Mock = new Mock<Simple1>();
@@ -33,7 +33,7 @@ public class InstanceComponentFactoryTest : TestContext
 			   .Add<Simple1>(p => p.Second)));
 	}
 
-	[Fact(DisplayName = "Factory throws if component instance is requested twice for TComponent that implements from IComponent")]
+	[UIFact(DisplayName = "Factory throws if component instance is requested twice for TComponent that implements from IComponent")]
 	public void Test021()
 	{
 		var simple1Mock = new Mock<BasicComponent>();

--- a/tests/bunit.core.tests/ComponentFactories/TypeBasedComponentFactoryTest.cs
+++ b/tests/bunit.core.tests/ComponentFactories/TypeBasedComponentFactoryTest.cs
@@ -2,16 +2,16 @@ namespace Bunit.ComponentFactories;
 
 public class TypeBasedComponentFactoryTest : TestContext
 {
-	[Fact(DisplayName = "Add throws when factories is null")]
+	[UIFact(DisplayName = "Add throws when factories is null")]
 	public void Test001()
 		=> Should.Throw<ArgumentNullException>(
 			() => ComponentFactoryCollectionExtensions.Add<Simple1>(default, default(Func<Simple1>)));
 
-	[Fact(DisplayName = "Add throws when instance is null")]
+	[UIFact(DisplayName = "Add throws when instance is null")]
 	public void Test002()
 		=> Should.Throw<ArgumentNullException>(() => ComponentFactories.Add<Simple1>(default(Func<Simple1>)));
 
-	[Fact(DisplayName = "TComponent replaced in render tree with component from factory method")]
+	[UIFact(DisplayName = "TComponent replaced in render tree with component from factory method")]
 	public void Test010()
 	{
 		var simple1Mock = Mock.Of<Simple1>();
@@ -23,7 +23,7 @@ public class TypeBasedComponentFactoryTest : TestContext
 			.Instance.ShouldBeSameAs(simple1Mock);
 	}
 
-	[Fact(DisplayName = "Multiple TComponent replaced in render tree with component from factory method")]
+	[UIFact(DisplayName = "Multiple TComponent replaced in render tree with component from factory method")]
 	public void Test011()
 	{
 		var mockRepo = new MockRepository(MockBehavior.Loose);

--- a/tests/bunit.core.tests/ComponentParameterCollectionBuilderTests.cs
+++ b/tests/bunit.core.tests/ComponentParameterCollectionBuilderTests.cs
@@ -49,46 +49,46 @@ public partial class ComponentParameterCollectionBuilderTests : TestContext
 		return res.FindComponent<TComponent>();
 	}
 
-	[Fact(DisplayName = "Null for parameter selector throws")]
+	[UIFact(DisplayName = "Null for parameter selector throws")]
 	public void Test000()
 	{
 		Should.Throw<ArgumentNullException>(() => Builder.Add(default!, 42));
 	}
 
-	[Fact(DisplayName = "Selecting a non property with parameter selector throws")]
+	[UIFact(DisplayName = "Selecting a non property with parameter selector throws")]
 	public void Test0000()
 	{
 		Should.Throw<ArgumentException>(() => Builder.Add(x => x.Field, 42));
 	}
 
-	[Fact(DisplayName = "Selecting a non parameter property with parameter selector throws")]
+	[UIFact(DisplayName = "Selecting a non parameter property with parameter selector throws")]
 	public void Test00000()
 	{
 		Should.Throw<ArgumentException>(() => Builder.Add(x => x.NonParamProp, new object()));
 	}
 
-	[Fact(DisplayName = "Value type with parameter selector")]
+	[UIFact(DisplayName = "Value type with parameter selector")]
 	public void Test001()
 	{
 		Builder.Add(x => x.ValueTypeParam, 42);
 		VerifyParameter("ValueTypeParam", 42);
 	}
 
-	[Fact(DisplayName = "Null for struct? with parameter selector")]
+	[UIFact(DisplayName = "Null for struct? with parameter selector")]
 	public void Test002()
 	{
 		Builder.Add(x => x.NullableValueTypeParam, null);
 		VerifyParameter<int?>("NullableValueTypeParam", null);
 	}
 
-	[Fact(DisplayName = "Struct? with parameter selector")]
+	[UIFact(DisplayName = "Struct? with parameter selector")]
 	public void Test003()
 	{
 		Builder.Add(x => x.NullableValueTypeParam, 1234);
 		VerifyParameter("NullableValueTypeParam", 1234);
 	}
 
-	[Fact(DisplayName = "Object with parameter selector")]
+	[UIFact(DisplayName = "Object with parameter selector")]
 	public void Test004()
 	{
 		var input = new object();
@@ -96,14 +96,14 @@ public partial class ComponentParameterCollectionBuilderTests : TestContext
 		VerifyParameter("Param", input);
 	}
 
-	[Fact(DisplayName = "Null for object with parameter selector")]
+	[UIFact(DisplayName = "Null for object with parameter selector")]
 	public void Test005()
 	{
 		Builder.Add(x => x.Param, null);
 		VerifyParameter<object>("Param", null);
 	}
 
-	[Fact(DisplayName = "EventCallback with parameter selector")]
+	[UIFact(DisplayName = "EventCallback with parameter selector")]
 	public void Test010()
 	{
 		var input = EventCallback.Empty;
@@ -111,62 +111,62 @@ public partial class ComponentParameterCollectionBuilderTests : TestContext
 		VerifyParameter("EC", input);
 	}
 
-	[Fact(DisplayName = "Null to EventCallback throws")]
+	[UIFact(DisplayName = "Null to EventCallback throws")]
 	public void Test011()
 	{
 		Should.Throw<ArgumentNullException>(() => Builder.Add(x => x.EC, null!));
 	}
 
-	[Fact(DisplayName = "Null for EventCallback? with parameter selector")]
+	[UIFact(DisplayName = "Null for EventCallback? with parameter selector")]
 	public void Test011_2()
 	{
 		Builder.Add<EventCallback?>(x => x.NullableEC, null);
 		VerifyParameter<EventCallback?>("NullableEC", null);
 	}
 
-	[Fact(DisplayName = "Action to EventCallback with parameter selector")]
+	[UIFact(DisplayName = "Action to EventCallback with parameter selector")]
 	public async Task Test012()
 	{
 		Builder.Add(x => x.EC, () => { EventCallbackCalled = true; });
 		await VerifyEventCallbackAsync("EC");
 	}
 
-	[Fact(DisplayName = "Action<object> to EventCallback with parameter selector")]
+	[UIFact(DisplayName = "Action<object> to EventCallback with parameter selector")]
 	public async Task Test013()
 	{
 		Builder.Add(x => x.EC, _ => { EventCallbackCalled = true; });
 		await VerifyEventCallbackAsync("EC");
 	}
 
-	[Fact(DisplayName = "Func<Task> to EventCallback with parameter selector")]
+	[UIFact(DisplayName = "Func<Task> to EventCallback with parameter selector")]
 	public async Task Test014()
 	{
 		Builder.Add(x => x.EC, () => { EventCallbackCalled = true; return Task.CompletedTask; });
 		await VerifyEventCallbackAsync("EC");
 	}
 
-	[Fact(DisplayName = "Action to EventCallback? with parameter selector")]
+	[UIFact(DisplayName = "Action to EventCallback? with parameter selector")]
 	public async Task Test015()
 	{
 		Builder.Add(x => x.NullableEC, () => { EventCallbackCalled = true; });
 		await VerifyEventCallbackAsync("NullableEC");
 	}
 
-	[Fact(DisplayName = "Action<object> to EventCallback? with parameter selector")]
+	[UIFact(DisplayName = "Action<object> to EventCallback? with parameter selector")]
 	public async Task Test016()
 	{
 		Builder.Add(x => x.NullableEC, _ => { EventCallbackCalled = true; });
 		await VerifyEventCallbackAsync("NullableEC");
 	}
 
-	[Fact(DisplayName = "Func<Task> to EventCallback? with parameter selector")]
+	[UIFact(DisplayName = "Func<Task> to EventCallback? with parameter selector")]
 	public async Task Test017()
 	{
 		Builder.Add(x => x.NullableEC, () => { EventCallbackCalled = true; return Task.CompletedTask; });
 		await VerifyEventCallbackAsync("NullableEC");
 	}
 
-	[Fact(DisplayName = "EventCallback<T> with parameter selector")]
+	[UIFact(DisplayName = "EventCallback<T> with parameter selector")]
 	public void Test018()
 	{
 		var input = EventCallback<EventArgs>.Empty;
@@ -174,28 +174,28 @@ public partial class ComponentParameterCollectionBuilderTests : TestContext
 		VerifyParameter("ECWithArgs", input);
 	}
 
-	[Fact(DisplayName = "Action to EventCallback<T> with parameter selector")]
+	[UIFact(DisplayName = "Action to EventCallback<T> with parameter selector")]
 	public async Task Test019()
 	{
 		Builder.Add(x => x.ECWithArgs, () => { EventCallbackCalled = true; });
 		await VerifyEventCallbackAsync<EventArgs>("ECWithArgs");
 	}
 
-	[Fact(DisplayName = "Action<object> to EventCallback<T> with parameter selector")]
+	[UIFact(DisplayName = "Action<object> to EventCallback<T> with parameter selector")]
 	public async Task Test020()
 	{
 		Builder.Add(x => x.ECWithArgs, _ => { EventCallbackCalled = true; });
 		await VerifyEventCallbackAsync<EventArgs>("ECWithArgs");
 	}
 
-	[Fact(DisplayName = "Func<Task> to EventCallback<T> with parameter selector")]
+	[UIFact(DisplayName = "Func<Task> to EventCallback<T> with parameter selector")]
 	public async Task Test021()
 	{
 		Builder.Add(x => x.ECWithArgs, () => { EventCallbackCalled = true; return Task.CompletedTask; });
 		await VerifyEventCallbackAsync<EventArgs>("ECWithArgs");
 	}
 
-	[Fact(DisplayName = "EventCallback<T> with parameter selector")]
+	[UIFact(DisplayName = "EventCallback<T> with parameter selector")]
 	public void Test022()
 	{
 		var input = EventCallback<EventArgs>.Empty;
@@ -203,28 +203,28 @@ public partial class ComponentParameterCollectionBuilderTests : TestContext
 		VerifyParameter("NullableECWithArgs", input);
 	}
 
-	[Fact(DisplayName = "Action to EventCallback<T> with parameter selector")]
+	[UIFact(DisplayName = "Action to EventCallback<T> with parameter selector")]
 	public async Task Test023()
 	{
 		Builder.Add(x => x.NullableECWithArgs, () => { EventCallbackCalled = true; });
 		await VerifyEventCallbackAsync<EventArgs>("NullableECWithArgs");
 	}
 
-	[Fact(DisplayName = "Action<object> to EventCallback<T> with parameter selector")]
+	[UIFact(DisplayName = "Action<object> to EventCallback<T> with parameter selector")]
 	public async Task Test024()
 	{
 		Builder.Add(x => x.NullableECWithArgs, _ => { EventCallbackCalled = true; });
 		await VerifyEventCallbackAsync<EventArgs>("NullableECWithArgs");
 	}
 
-	[Fact(DisplayName = "Func<Task> to EventCallback<T> with parameter selector")]
+	[UIFact(DisplayName = "Func<Task> to EventCallback<T> with parameter selector")]
 	public async Task Test025()
 	{
 		Builder.Add(x => x.NullableECWithArgs, () => { EventCallbackCalled = true; return Task.CompletedTask; });
 		await VerifyEventCallbackAsync<EventArgs>("NullableECWithArgs");
 	}
 
-	[Fact(DisplayName = "ChildContent can be passed as RenderFragment")]
+	[UIFact(DisplayName = "ChildContent can be passed as RenderFragment")]
 	public void Test030()
 	{
 		RenderFragment input = b => b.AddMarkupContent(0, string.Empty);
@@ -232,7 +232,7 @@ public partial class ComponentParameterCollectionBuilderTests : TestContext
 		VerifyParameter<RenderFragment>("ChildContent", input);
 	}
 
-	[Fact(DisplayName = "Calling AddChildContent when TCompnent does not have a parameter named ChildContent throws")]
+	[UIFact(DisplayName = "Calling AddChildContent when TCompnent does not have a parameter named ChildContent throws")]
 	public void Test031()
 	{
 		RenderFragment input = b => b.AddMarkupContent(0, string.Empty);
@@ -240,7 +240,7 @@ public partial class ComponentParameterCollectionBuilderTests : TestContext
 		Assert.Throws<ArgumentException>(() => new ComponentParameterCollectionBuilder<NonChildContentParameter>().AddChildContent(input));
 	}
 
-	[Fact(DisplayName = "ChildContent can be passed as a nested component parameter builder")]
+	[UIFact(DisplayName = "ChildContent can be passed as a nested component parameter builder")]
 	public void Test032()
 	{
 		Builder.AddChildContent<InhertedParams>(parameters => parameters.Add(p => p.ValueTypeParam, 42));
@@ -251,7 +251,7 @@ public partial class ComponentParameterCollectionBuilderTests : TestContext
 		actualComponent.Instance.ValueTypeParam.ShouldBe(42);
 	}
 
-	[Fact(DisplayName = "ChildContent can be passed as a child component without parameters")]
+	[UIFact(DisplayName = "ChildContent can be passed as a child component without parameters")]
 	public void Test033()
 	{
 		Builder.AddChildContent<NoParams>();
@@ -262,7 +262,7 @@ public partial class ComponentParameterCollectionBuilderTests : TestContext
 		actualComponent.Instance.ShouldBeOfType<NoParams>();
 	}
 
-	[Fact(DisplayName = "ChildContent can be passed as a markup string")]
+	[UIFact(DisplayName = "ChildContent can be passed as a markup string")]
 	public void Test034()
 	{
 		var input = "<p>42</p>";
@@ -274,7 +274,7 @@ public partial class ComponentParameterCollectionBuilderTests : TestContext
 		actualComponent.Markup.ShouldBe(input);
 	}
 
-	[Fact(DisplayName = "RenderFragment can be passed as a nested component parameter builder")]
+	[UIFact(DisplayName = "RenderFragment can be passed as a nested component parameter builder")]
 	public void Test040()
 	{
 		Builder.Add<InhertedParams>(x => x.OtherFragment, parameters => parameters.Add(p => p.ValueTypeParam, 42));
@@ -285,7 +285,7 @@ public partial class ComponentParameterCollectionBuilderTests : TestContext
 		actualComponent.Instance.ValueTypeParam.ShouldBe(42);
 	}
 
-	[Fact(DisplayName = "RenderFragment can be passed as a child component without parameters")]
+	[UIFact(DisplayName = "RenderFragment can be passed as a child component without parameters")]
 	public void Test041()
 	{
 		Builder.Add<NoParams>(x => x.OtherFragment);
@@ -296,7 +296,7 @@ public partial class ComponentParameterCollectionBuilderTests : TestContext
 		actualComponent.Instance.ShouldBeOfType<NoParams>();
 	}
 
-	[Fact(DisplayName = "RenderFragment can be passed as a markup string")]
+	[UIFact(DisplayName = "RenderFragment can be passed as a markup string")]
 	public void Test042()
 	{
 		var input = "<p>42</p>";
@@ -308,7 +308,7 @@ public partial class ComponentParameterCollectionBuilderTests : TestContext
 		actualComponent.Markup.ShouldBe(input);
 	}
 
-	[Fact(DisplayName = "RenderFragment can be passed RenderFragment")]
+	[UIFact(DisplayName = "RenderFragment can be passed RenderFragment")]
 	public void Test043()
 	{
 		RenderFragment input = b => b.AddMarkupContent(0, string.Empty);
@@ -319,7 +319,7 @@ public partial class ComponentParameterCollectionBuilderTests : TestContext
 			.ShouldBeParameter("OtherFragment", input, isCascadingValue: false);
 	}
 
-	[Fact(DisplayName = "RenderFragment can be passed multiple times")]
+	[UIFact(DisplayName = "RenderFragment can be passed multiple times")]
 	public void Test044()
 	{
 		var input = "FOO";
@@ -336,7 +336,7 @@ public partial class ComponentParameterCollectionBuilderTests : TestContext
 		}
 	}
 
-	[Fact(DisplayName = "RenderFragment<T>? can be passed as RenderFragment")]
+	[UIFact(DisplayName = "RenderFragment<T>? can be passed as RenderFragment")]
 	public void Test050()
 	{
 		RenderFragment<string> input = s => b => b.AddMarkupContent(0, s);
@@ -347,7 +347,7 @@ public partial class ComponentParameterCollectionBuilderTests : TestContext
 			.ShouldBeParameter("Template", input, isCascadingValue: false);
 	}
 
-	[Fact(DisplayName = "RenderFragment<T>? can be passed lambda builder")]
+	[UIFact(DisplayName = "RenderFragment<T>? can be passed lambda builder")]
 	public void Test051()
 	{
 		var input = "FOO";
@@ -359,7 +359,7 @@ public partial class ComponentParameterCollectionBuilderTests : TestContext
 		actualComponent.Markup.ShouldBe(input);
 	}
 
-	[Fact(DisplayName = "RenderFragment<T>? can be passed as nested object builder")]
+	[UIFact(DisplayName = "RenderFragment<T>? can be passed as nested object builder")]
 	public void Test052()
 	{
 		var input = "FOO";
@@ -374,7 +374,7 @@ public partial class ComponentParameterCollectionBuilderTests : TestContext
 		actualComponent.Instance.Param.ShouldBe(input);
 	}
 
-	[Fact(DisplayName = "RenderFragment<T> can be passed multiple times")]
+	[UIFact(DisplayName = "RenderFragment<T> can be passed multiple times")]
 	public void Test053()
 	{
 		Builder.Add(x => x.Template, value => value);
@@ -391,7 +391,7 @@ public partial class ComponentParameterCollectionBuilderTests : TestContext
 		}
 	}
 
-	[Fact(DisplayName = "Cascading values can be passed using Add and parameter selector")]
+	[UIFact(DisplayName = "Cascading values can be passed using Add and parameter selector")]
 	public void Test060()
 	{
 		Builder.Add(p => p.NullableCC, "FOO");
@@ -414,7 +414,7 @@ public partial class ComponentParameterCollectionBuilderTests : TestContext
 			});
 	}
 
-	[Fact(DisplayName = "AddCascadingValue can add unnamed cascading values")]
+	[UIFact(DisplayName = "AddCascadingValue can add unnamed cascading values")]
 	public void Test061()
 	{
 		var input = "FOO";
@@ -425,7 +425,7 @@ public partial class ComponentParameterCollectionBuilderTests : TestContext
 			.ShouldBeParameter(null, input, isCascadingValue: true);
 	}
 
-	[Fact(DisplayName = "AddCascadingValue can add named cascading values")]
+	[UIFact(DisplayName = "AddCascadingValue can add named cascading values")]
 	public void Test062()
 	{
 		var name = "NAME";
@@ -437,7 +437,7 @@ public partial class ComponentParameterCollectionBuilderTests : TestContext
 			.ShouldBeParameter(name, input, isCascadingValue: true);
 	}
 
-	[Fact(DisplayName = "AddUnmatched can add unmatched empty value attributes as parameters")]
+	[UIFact(DisplayName = "AddUnmatched can add unmatched empty value attributes as parameters")]
 	public void Test070()
 	{
 		var name = "NAME";
@@ -449,7 +449,7 @@ public partial class ComponentParameterCollectionBuilderTests : TestContext
 			.ShouldBeParameter<object>(name, null, isCascadingValue: false);
 	}
 
-	[Fact(DisplayName = "AddUnmatched can add unmatched value attributes as parameters")]
+	[UIFact(DisplayName = "AddUnmatched can add unmatched value attributes as parameters")]
 	public void Test071()
 	{
 		var name = "NAME";
@@ -462,7 +462,7 @@ public partial class ComponentParameterCollectionBuilderTests : TestContext
 			.ShouldBeParameter(name, value, isCascadingValue: false);
 	}
 
-	[Theory(DisplayName = "AddUnmatched throws if name is null or whitespace")]
+	[UITheory(DisplayName = "AddUnmatched throws if name is null or whitespace")]
 	[InlineData("")]
 	[InlineData(" ")]
 	public void Test072(string emptyName)
@@ -470,7 +470,7 @@ public partial class ComponentParameterCollectionBuilderTests : TestContext
 		Should.Throw<ArgumentException>(() => Builder.AddUnmatched(emptyName));
 	}
 
-	[Fact(DisplayName = "AddUnmatched throws if component doesnt have an Parameter(CaptureUnmatchedValues = true)")]
+	[UIFact(DisplayName = "AddUnmatched throws if component doesnt have an Parameter(CaptureUnmatchedValues = true)")]
 	public void Test073()
 	{
 		var sut = new ComponentParameterCollectionBuilder<NoParams>();
@@ -478,7 +478,7 @@ public partial class ComponentParameterCollectionBuilderTests : TestContext
 		Should.Throw<ArgumentException>(() => sut.AddUnmatched("foo"));
 	}
 
-	[Fact(DisplayName = "Can select parameters inherited from base component ")]
+	[UIFact(DisplayName = "Can select parameters inherited from base component ")]
 	public void Test101()
 	{
 		Builder.Add(x => x.Param, new object());
@@ -486,7 +486,7 @@ public partial class ComponentParameterCollectionBuilderTests : TestContext
 		Builder.Build().ShouldHaveSingleItem();
 	}
 
-	[Fact(DisplayName = "TryAdd returns false when parameter does not exist on component")]
+	[UIFact(DisplayName = "TryAdd returns false when parameter does not exist on component")]
 	public void Test200()
 	{
 		var sut = new ComponentParameterCollectionBuilder<NoParams>();
@@ -497,7 +497,7 @@ public partial class ComponentParameterCollectionBuilderTests : TestContext
 		sut.Build().Count.ShouldBe(0);
 	}
 
-	[Fact(DisplayName = "TryAdd returns true when parameter exists on component")]
+	[UIFact(DisplayName = "TryAdd returns true when parameter exists on component")]
 	public void Test201()
 	{
 		var name = nameof(Params.ValueTypeParam);
@@ -510,7 +510,7 @@ public partial class ComponentParameterCollectionBuilderTests : TestContext
 			.ShouldBeParameter(name, input, isCascadingValue: false);
 	}
 
-	[Fact(DisplayName = "TryAdd returns true when unnamed cascading parameter exists on component")]
+	[UIFact(DisplayName = "TryAdd returns true when unnamed cascading parameter exists on component")]
 	public void Test202()
 	{
 		var name = nameof(Params.CC);
@@ -523,7 +523,7 @@ public partial class ComponentParameterCollectionBuilderTests : TestContext
 			.ShouldBeParameter(null, input, isCascadingValue: true);
 	}
 
-	[Fact(DisplayName = "TryAdd returns true when named cascading parameter exists on component")]
+	[UIFact(DisplayName = "TryAdd returns true when named cascading parameter exists on component")]
 	public void Test203()
 	{
 		var name = nameof(Params.NamedCC);
@@ -536,7 +536,7 @@ public partial class ComponentParameterCollectionBuilderTests : TestContext
 			.ShouldBeParameter(name + "NAME", input, isCascadingValue: true);
 	}
 
-	[Fact(DisplayName = "Add of inherited overriden parameter works")]
+	[UIFact(DisplayName = "Add of inherited overriden parameter works")]
 	public void Test300()
 	{
 		var sut = new ComponentParameterCollectionBuilder<InheritedParamsWithOverride>();
@@ -548,7 +548,7 @@ public partial class ComponentParameterCollectionBuilderTests : TestContext
 			.ShouldBeParameter("Value", true, isCascadingValue: false);
 	}
 
-	[Fact(DisplayName = "Add of inherited parameter works")]
+	[UIFact(DisplayName = "Add of inherited parameter works")]
 	public void Test301()
 	{
 		var sut = new ComponentParameterCollectionBuilder<InheritedParamsWithoutOverride>();
@@ -560,7 +560,7 @@ public partial class ComponentParameterCollectionBuilderTests : TestContext
 			.ShouldBeParameter("Value", true, isCascadingValue: false);
 	}
 
-	[Fact(DisplayName = "AddChildContent on generic child content parameter throws")]
+	[UIFact(DisplayName = "AddChildContent on generic child content parameter throws")]
 	public void Test302()
 	{
 		Action addChildContent = () => new ComponentParameterCollectionBuilder<TemplatedChildContent>().AddChildContent("<p>item</p>");
@@ -568,7 +568,7 @@ public partial class ComponentParameterCollectionBuilderTests : TestContext
 		addChildContent.ShouldThrow<ArgumentException>();
 	}
 
-	[Fact(DisplayName = "Add with generic child content works")]
+	[UIFact(DisplayName = "Add with generic child content works")]
 	public void Test303()
 	{
 		var sut = new ComponentParameterCollectionBuilder<TemplatedChildContent>();
@@ -580,7 +580,7 @@ public partial class ComponentParameterCollectionBuilderTests : TestContext
 			.ShouldBeParameter<RenderFragment<string>?>(nameof(TemplatedChildContent.ChildContent), false);
 	}
 
-	[Fact(DisplayName = "Bind should add Value and ValueChanged event")]
+	[UIFact(DisplayName = "Bind should add Value and ValueChanged event")]
 	public void Test304()
 	{
 		var sut = new ComponentParameterCollectionBuilder<SimpleBind>();
@@ -592,7 +592,7 @@ public partial class ComponentParameterCollectionBuilderTests : TestContext
 			x => x.ShouldBeParameter<EventCallback<string>>("ValueChanged", false));
 	}
 
-	[Fact(DisplayName = "Bind should add Expression event when available")]
+	[UIFact(DisplayName = "Bind should add Expression event when available")]
 	public void Test305()
 	{
 		var sut = new ComponentParameterCollectionBuilder<FullBind>();
@@ -605,7 +605,7 @@ public partial class ComponentParameterCollectionBuilderTests : TestContext
 			.ShouldHaveSingleItem();
 	}
 
-	[Fact(DisplayName = "Throw an exception when no Changed event available")]
+	[UIFact(DisplayName = "Throw an exception when no Changed event available")]
 	public void Test306()
 	{
 		var sut = new ComponentParameterCollectionBuilder<NoTwoWayBind>();
@@ -615,7 +615,7 @@ public partial class ComponentParameterCollectionBuilderTests : TestContext
 		action.ShouldThrow<InvalidOperationException>();
 	}
 
-	[Fact(DisplayName = "Throw an exception when cascading parameter")]
+	[UIFact(DisplayName = "Throw an exception when cascading parameter")]
 	public void Test307()
 	{
 		var sut = new ComponentParameterCollectionBuilder<ComponentWithCascadingParameter>();
@@ -625,7 +625,7 @@ public partial class ComponentParameterCollectionBuilderTests : TestContext
 		action.ShouldThrow<ArgumentException>();
 	}
 
-	[Fact(DisplayName = "Throw an exception when Changed event is not a public parameter")]
+	[UIFact(DisplayName = "Throw an exception when Changed event is not a public parameter")]
 	public void Test308()
 	{
 		var sut = new ComponentParameterCollectionBuilder<InvalidTwoWayBind>();
@@ -635,7 +635,7 @@ public partial class ComponentParameterCollectionBuilderTests : TestContext
 		action.ShouldThrow<InvalidOperationException>();
 	}
 
-	[Fact(DisplayName = "Throw exception when parameter selector is null")]
+	[UIFact(DisplayName = "Throw exception when parameter selector is null")]
 	public void Test309()
 	{
 		var sut = new ComponentParameterCollectionBuilder<SimpleBind>();
@@ -645,7 +645,7 @@ public partial class ComponentParameterCollectionBuilderTests : TestContext
 		action.ShouldThrow<ArgumentNullException>();
 	}
 
-	[Fact(DisplayName = "Throw exception when changed action is null")]
+	[UIFact(DisplayName = "Throw exception when changed action is null")]
 	public void Test310()
 	{
 		var sut = new ComponentParameterCollectionBuilder<SimpleBind>();
@@ -655,7 +655,7 @@ public partial class ComponentParameterCollectionBuilderTests : TestContext
 		action.ShouldThrow<ArgumentNullException>();
 	}
 
-	[Fact(DisplayName = "Throw exception when wrong parameter is changed action")]
+	[UIFact(DisplayName = "Throw exception when wrong parameter is changed action")]
 	public void Test311()
 	{
 		var sut = new ComponentParameterCollectionBuilder<SimpleBind>();
@@ -665,7 +665,7 @@ public partial class ComponentParameterCollectionBuilderTests : TestContext
 		action.ShouldThrow<ArgumentException>();
 	}
 
-	[Fact(DisplayName = "Throw exception when wrong parameter is expression")]
+	[UIFact(DisplayName = "Throw exception when wrong parameter is expression")]
 	public void Test312()
 	{
 		const string value = "some string";
@@ -676,7 +676,7 @@ public partial class ComponentParameterCollectionBuilderTests : TestContext
 		action.ShouldThrow<ArgumentException>();
 	}
 
-	[Fact(DisplayName = "Properties with Changed at the end, which are not of type EventCallback can be bound")]
+	[UIFact(DisplayName = "Properties with Changed at the end, which are not of type EventCallback can be bound")]
 	public void Test313()
 	{
 		var sut = new ComponentParameterCollectionBuilder<ValidNamesComponent>();
@@ -686,7 +686,7 @@ public partial class ComponentParameterCollectionBuilderTests : TestContext
 		action.ShouldNotThrow();
 	}
 
-	[Fact(DisplayName = "Properties with Expression at the end, which are not of type expression can be bound")]
+	[UIFact(DisplayName = "Properties with Expression at the end, which are not of type expression can be bound")]
 	public void Test314()
 	{
 		var sut = new ComponentParameterCollectionBuilder<ValidNamesComponent>();

--- a/tests/bunit.core.tests/ComponentParameterCollectionBuilderTests.razor
+++ b/tests/bunit.core.tests/ComponentParameterCollectionBuilderTests.razor
@@ -1,6 +1,6 @@
 @inherits TestContext
 @code {
-    [Fact(DisplayName = "Bind method should behave like bind-directive")]
+    [UIFact(DisplayName = "Bind method should behave like bind-directive")]
     public async Task Test400()
     {
         // arrange

--- a/tests/bunit.core.tests/ComponentParameterCollectionTest.cs
+++ b/tests/bunit.core.tests/ComponentParameterCollectionTest.cs
@@ -8,7 +8,7 @@ public class ComponentParameterCollectionTest : TestContext
 		return res.FindComponent<Params>();
 	}
 
-	[Fact(DisplayName = "ComponentParameters can be added to collection")]
+	[UIFact(DisplayName = "ComponentParameters can be added to collection")]
 	public void Test001()
 	{
 		var sut = new ComponentParameterCollection();
@@ -20,7 +20,7 @@ public class ComponentParameterCollectionTest : TestContext
 		sut.Contains(p).ShouldBeTrue();
 	}
 
-	[Fact(DisplayName = "Add() throws if invalid parameter is passed to it")]
+	[UIFact(DisplayName = "Add() throws if invalid parameter is passed to it")]
 	public void Test002()
 	{
 		var sut = new ComponentParameterCollection();
@@ -29,7 +29,7 @@ public class ComponentParameterCollectionTest : TestContext
 		Should.Throw<ArgumentException>(() => sut.Add(p));
 	}
 
-	[Fact(DisplayName = "ToComponentRenderFragment creates RenderFragment for component when empty")]
+	[UIFact(DisplayName = "ToComponentRenderFragment creates RenderFragment for component when empty")]
 	public void Test010()
 	{
 		var sut = new ComponentParameterCollection();
@@ -40,7 +40,7 @@ public class ComponentParameterCollectionTest : TestContext
 		c.VerifyParamsHaveDefaultValues();
 	}
 
-	[Fact(DisplayName = "ToComponentRenderFragment passes regular params to component in RenderFragment")]
+	[UIFact(DisplayName = "ToComponentRenderFragment passes regular params to component in RenderFragment")]
 	public void Test011()
 	{
 		var sut = new ComponentParameterCollection
@@ -58,7 +58,7 @@ public class ComponentParameterCollectionTest : TestContext
 		c.NullableValueTypeParam.ShouldBe(1337);
 	}
 
-	[Fact(DisplayName = "ToComponentRenderFragment passes single ChildContent param to component in RenderFragment")]
+	[UIFact(DisplayName = "ToComponentRenderFragment passes single ChildContent param to component in RenderFragment")]
 	public void Test012()
 	{
 		var sut = new ComponentParameterCollection
@@ -72,7 +72,7 @@ public class ComponentParameterCollectionTest : TestContext
 		rc.Markup.ShouldBe("FOO");
 	}
 
-	[Fact(DisplayName = "ToComponentRenderFragment passes multiple ChildContent params to component in RenderFragment")]
+	[UIFact(DisplayName = "ToComponentRenderFragment passes multiple ChildContent params to component in RenderFragment")]
 	public void Test013()
 	{
 		var sut = new ComponentParameterCollection
@@ -88,7 +88,7 @@ public class ComponentParameterCollectionTest : TestContext
 		rc.Markup.ShouldBe("FOOBARBAZ");
 	}
 
-	[Fact(DisplayName = "ToComponentRenderFragment passes single RenderFragment param to component in RenderFragment")]
+	[UIFact(DisplayName = "ToComponentRenderFragment passes single RenderFragment param to component in RenderFragment")]
 	public void Test014()
 	{
 		var sut = new ComponentParameterCollection
@@ -102,7 +102,7 @@ public class ComponentParameterCollectionTest : TestContext
 		rc.Markup.ShouldBe("FOO");
 	}
 
-	[Fact(DisplayName = "ToComponentRenderFragment passes multiple RenderFragment params to component in RenderFragment")]
+	[UIFact(DisplayName = "ToComponentRenderFragment passes multiple RenderFragment params to component in RenderFragment")]
 	public void Test015()
 	{
 		var sut = new ComponentParameterCollection
@@ -118,7 +118,7 @@ public class ComponentParameterCollectionTest : TestContext
 		rc.Markup.ShouldBe("FOOBARBAZ");
 	}
 
-	[Fact(DisplayName = "ToComponentRenderFragment passes unmatched attributes to component in RenderFragment")]
+	[UIFact(DisplayName = "ToComponentRenderFragment passes unmatched attributes to component in RenderFragment")]
 	public void Test016()
 	{
 		var sut = new ComponentParameterCollection
@@ -132,7 +132,7 @@ public class ComponentParameterCollectionTest : TestContext
 		c.Attributes?.ContainsKey("attr").ShouldBeTrue();
 	}
 
-	[Fact(DisplayName = "ToComponentRenderFragment passes EventCallback params to component in RenderFragment")]
+	[UIFact(DisplayName = "ToComponentRenderFragment passes EventCallback params to component in RenderFragment")]
 	public void Test017()
 	{
 		// arrange
@@ -159,7 +159,7 @@ public class ComponentParameterCollectionTest : TestContext
 		c.ECWithArgs.ShouldBe(ec4);
 	}
 
-	[Fact(DisplayName = "ToComponentRenderFragment passes single template param to component in RenderFragment")]
+	[UIFact(DisplayName = "ToComponentRenderFragment passes single template param to component in RenderFragment")]
 	public void Test018()
 	{
 		var sut = new ComponentParameterCollection
@@ -173,7 +173,7 @@ public class ComponentParameterCollectionTest : TestContext
 		rc.Markup.ShouldBe(Params.TemplateContent);
 	}
 
-	[Fact(DisplayName = "ToComponentRenderFragment passes multiple template params to component in RenderFragment")]
+	[UIFact(DisplayName = "ToComponentRenderFragment passes multiple template params to component in RenderFragment")]
 	public void Test019()
 	{
 		var sut = new ComponentParameterCollection
@@ -188,7 +188,7 @@ public class ComponentParameterCollectionTest : TestContext
 		rc.Markup.ShouldBe($"{Params.TemplateContent}1{Params.TemplateContent}2");
 	}
 
-	[Fact(DisplayName = "ToComponentRenderFragment with different template types to same param throws")]
+	[UIFact(DisplayName = "ToComponentRenderFragment with different template types to same param throws")]
 	public void Test020()
 	{
 		var sut = new ComponentParameterCollection
@@ -202,7 +202,7 @@ public class ComponentParameterCollectionTest : TestContext
 		Should.Throw<ArgumentException>(() => RenderWithRenderFragment(rf));
 	}
 
-	[Fact(DisplayName = "ToComponentRenderFragment passes skips null RenderFragment params")]
+	[UIFact(DisplayName = "ToComponentRenderFragment passes skips null RenderFragment params")]
 	public void Test030()
 	{
 		var sut = new ComponentParameterCollection
@@ -217,7 +217,7 @@ public class ComponentParameterCollectionTest : TestContext
 		rc.Markup.ShouldBe("BAR");
 	}
 
-	[Fact(DisplayName = "ToComponentRenderFragment throws if same regular param is added twice")]
+	[UIFact(DisplayName = "ToComponentRenderFragment throws if same regular param is added twice")]
 	public void Test040()
 	{
 		var sut = new ComponentParameterCollection
@@ -231,7 +231,7 @@ public class ComponentParameterCollectionTest : TestContext
 		Should.Throw<ArgumentException>(() => RenderWithRenderFragment(rf));
 	}
 
-	[Fact(DisplayName = "ToComponentRenderFragment throws if same regular null value param is added twice")]
+	[UIFact(DisplayName = "ToComponentRenderFragment throws if same regular null value param is added twice")]
 	public void Test041()
 	{
 		var sut = new ComponentParameterCollection
@@ -245,7 +245,7 @@ public class ComponentParameterCollectionTest : TestContext
 		Should.Throw<ArgumentException>(() => RenderWithRenderFragment(rf));
 	}
 
-	[Fact(DisplayName = "ToComponentRenderFragment wraps component in unnamed cascading values in RenderFragment")]
+	[UIFact(DisplayName = "ToComponentRenderFragment wraps component in unnamed cascading values in RenderFragment")]
 	public void Test050()
 	{
 		var sut = new ComponentParameterCollection
@@ -259,7 +259,7 @@ public class ComponentParameterCollectionTest : TestContext
 		c.NullableCC.ShouldBe("FOO");
 	}
 
-	[Fact(DisplayName = "ToComponentRenderFragment wraps component in multiple unnamed cascading values in RenderFragment")]
+	[UIFact(DisplayName = "ToComponentRenderFragment wraps component in multiple unnamed cascading values in RenderFragment")]
 	public void Test051()
 	{
 		var sut = new ComponentParameterCollection
@@ -275,7 +275,7 @@ public class ComponentParameterCollectionTest : TestContext
 		c.CC.ShouldBe(42);
 	}
 
-	[Fact(DisplayName = "ToComponentRenderFragment throws when multiple unnamed cascading values with same type is added")]
+	[UIFact(DisplayName = "ToComponentRenderFragment throws when multiple unnamed cascading values with same type is added")]
 	public void Test052()
 	{
 		var sut = new ComponentParameterCollection
@@ -289,7 +289,7 @@ public class ComponentParameterCollectionTest : TestContext
 		Should.Throw<ArgumentException>(() => sut.ToRenderFragment<Params>());
 	}
 
-	[Fact(DisplayName = "ToComponentRenderFragment wraps component in named cascading values in RenderFragment")]
+	[UIFact(DisplayName = "ToComponentRenderFragment wraps component in named cascading values in RenderFragment")]
 	public void Test053()
 	{
 		var sut = new ComponentParameterCollection
@@ -303,7 +303,7 @@ public class ComponentParameterCollectionTest : TestContext
 		c.NullableNamedCC.ShouldBe("FOO");
 	}
 
-	[Fact(DisplayName = "ToComponentRenderFragment wraps component in multiple named cascading values in RenderFragment")]
+	[UIFact(DisplayName = "ToComponentRenderFragment wraps component in multiple named cascading values in RenderFragment")]
 	public void Test054()
 	{
 		var sut = new ComponentParameterCollection
@@ -321,7 +321,7 @@ public class ComponentParameterCollectionTest : TestContext
 		c.AnotherNamedCC.ShouldBe(1337);
 	}
 
-	[Fact(DisplayName = "ToComponentRenderFragment throws when multiple named cascading values with same name and type is added")]
+	[UIFact(DisplayName = "ToComponentRenderFragment throws when multiple named cascading values with same name and type is added")]
 	public void Test055()
 	{
 		var sut = new ComponentParameterCollection

--- a/tests/bunit.core.tests/ComponentParameterFactoryTest.cs
+++ b/tests/bunit.core.tests/ComponentParameterFactoryTest.cs
@@ -15,7 +15,7 @@ public class ComponentParameterFactoryTest
 
 	private string? Actual { get; set; }
 
-	[Fact(DisplayName = "EventCallback(Action) creates parameter with provided name and callback")]
+	[UIFact(DisplayName = "EventCallback(Action) creates parameter with provided name and callback")]
 	public async Task Test001()
 	{
 		Action action = () => Actual = EXPECTED;
@@ -25,7 +25,7 @@ public class ComponentParameterFactoryTest
 		await VerifyEventCallbackParameter(cp);
 	}
 
-	[Fact(DisplayName = "EventCallback(Action<object>) creates parameter with provided name and callback")]
+	[UIFact(DisplayName = "EventCallback(Action<object>) creates parameter with provided name and callback")]
 	public async Task Test002()
 	{
 		Action<object> action = _ => Actual = EXPECTED;
@@ -35,7 +35,7 @@ public class ComponentParameterFactoryTest
 		await VerifyEventCallbackParameter(cp);
 	}
 
-	[Fact(DisplayName = "EventCallback(Func<Task>) creates parameter with provided name and callback")]
+	[UIFact(DisplayName = "EventCallback(Func<Task>) creates parameter with provided name and callback")]
 	public async Task Test003()
 	{
 		Func<Task> action = () => { Actual = EXPECTED; return Task.CompletedTask; };
@@ -45,7 +45,7 @@ public class ComponentParameterFactoryTest
 		await VerifyEventCallbackParameter(cp);
 	}
 
-	[Fact(DisplayName = "EventCallback(Func<object, Task>) creates parameter with provided name and callback")]
+	[UIFact(DisplayName = "EventCallback(Func<object, Task>) creates parameter with provided name and callback")]
 	public async Task Test004()
 	{
 		Func<object, Task> action = _ => { Actual = EXPECTED; return Task.CompletedTask; };
@@ -55,7 +55,7 @@ public class ComponentParameterFactoryTest
 		await VerifyEventCallbackParameter(cp);
 	}
 
-	[Fact(DisplayName = "EventCallback<TValue>(Action) creates parameter with provided name and callback")]
+	[UIFact(DisplayName = "EventCallback<TValue>(Action) creates parameter with provided name and callback")]
 	public async Task Test011()
 	{
 		Action action = () => Actual = EXPECTED;
@@ -65,7 +65,7 @@ public class ComponentParameterFactoryTest
 		await VerifyEventCallbackParameter<EventArgs>(cp);
 	}
 
-	[Fact(DisplayName = "EventCallback<TValue>(Action<TValue>) creates parameter with provided name and callback")]
+	[UIFact(DisplayName = "EventCallback<TValue>(Action<TValue>) creates parameter with provided name and callback")]
 	public async Task Test012()
 	{
 		Action<EventArgs> action = _ => Actual = EXPECTED;
@@ -75,7 +75,7 @@ public class ComponentParameterFactoryTest
 		await VerifyEventCallbackParameter<EventArgs>(cp);
 	}
 
-	[Fact(DisplayName = "EventCallback(Func<Task>) creates parameter with provided name and callback")]
+	[UIFact(DisplayName = "EventCallback(Func<Task>) creates parameter with provided name and callback")]
 	public async Task Test013()
 	{
 		Func<Task> action = () => { Actual = EXPECTED; return Task.CompletedTask; };
@@ -85,7 +85,7 @@ public class ComponentParameterFactoryTest
 		await VerifyEventCallbackParameter<EventArgs>(cp);
 	}
 
-	[Fact(DisplayName = "EventCallback(Func<object, Task>) creates parameter with provided name and callback")]
+	[UIFact(DisplayName = "EventCallback(Func<object, Task>) creates parameter with provided name and callback")]
 	public async Task Test014()
 	{
 		Func<EventArgs, Task> action = _ => { Actual = EXPECTED; return Task.CompletedTask; };
@@ -112,7 +112,7 @@ public class ComponentParameterFactoryTest
 		Actual.ShouldBe(EXPECTED);
 	}
 
-	[Fact(DisplayName = "Parameter creates a parameter with provided name and value")]
+	[UIFact(DisplayName = "Parameter creates a parameter with provided name and value")]
 	public void Test020()
 	{
 		var cp = Parameter(NAME, EXPECTED);
@@ -122,7 +122,7 @@ public class ComponentParameterFactoryTest
 		cp.IsCascadingValue.ShouldBeFalse();
 	}
 
-	[Fact(DisplayName = "Parameter creates a parameter with provided name and null value")]
+	[UIFact(DisplayName = "Parameter creates a parameter with provided name and null value")]
 	public void Test021()
 	{
 		var cp = Parameter(NAME, null);
@@ -132,7 +132,7 @@ public class ComponentParameterFactoryTest
 		cp.IsCascadingValue.ShouldBeFalse();
 	}
 
-	[Fact(DisplayName = "CascadingValue(name, value) creates a named cascading value parameter with provided name and value")]
+	[UIFact(DisplayName = "CascadingValue(name, value) creates a named cascading value parameter with provided name and value")]
 	public void Test030()
 	{
 		var cp = CascadingValue(NAME, EXPECTED);
@@ -142,7 +142,7 @@ public class ComponentParameterFactoryTest
 		cp.IsCascadingValue.ShouldBeTrue();
 	}
 
-	[Fact(DisplayName = "CascadingValue(name, value) creates a unnamed cascading value parameter with provided name and value")]
+	[UIFact(DisplayName = "CascadingValue(name, value) creates a unnamed cascading value parameter with provided name and value")]
 	public void Test031()
 	{
 		var cp = CascadingValue(EXPECTED);
@@ -152,7 +152,7 @@ public class ComponentParameterFactoryTest
 		cp.IsCascadingValue.ShouldBeTrue();
 	}
 
-	[Fact(DisplayName = "ChildContent(string markup) creates a parameter with a RenderFragment that renders the provided markup")]
+	[UIFact(DisplayName = "ChildContent(string markup) creates a parameter with a RenderFragment that renders the provided markup")]
 	public void Test040()
 	{
 		var cp = ChildContent(EXPECTED);
@@ -164,7 +164,7 @@ public class ComponentParameterFactoryTest
 		renderedFragment.Markup.ShouldBe(EXPECTED);
 	}
 
-	[Fact(DisplayName = "ChildContent<TComponent>() creates a parameter with a RenderFragment that renders a component of type TComponent")]
+	[UIFact(DisplayName = "ChildContent<TComponent>() creates a parameter with a RenderFragment that renders a component of type TComponent")]
 	public void Test041()
 	{
 		var cp = ChildContent<TestComponent>();
@@ -176,7 +176,7 @@ public class ComponentParameterFactoryTest
 		renderedFragment.Markup.ShouldBe(nameof(TestComponent));
 	}
 
-	[Fact(DisplayName = "ChildContent<TComponent>(component parameters) creates a parameter with a RenderFragment that renders a component of type TComponent")]
+	[UIFact(DisplayName = "ChildContent<TComponent>(component parameters) creates a parameter with a RenderFragment that renders a component of type TComponent")]
 	public void Test042()
 	{
 		var cp = ChildContent<TestComponent>((nameof(TestComponent.Input), EXPECTED));
@@ -188,7 +188,7 @@ public class ComponentParameterFactoryTest
 		renderedFragment.Markup.ShouldBe(nameof(TestComponent) + EXPECTED);
 	}
 
-	[Fact(DisplayName = "ChildContent(RenderFragment) creates a parameter with a RenderFragment passed to ChildContent")]
+	[UIFact(DisplayName = "ChildContent(RenderFragment) creates a parameter with a RenderFragment passed to ChildContent")]
 	public void Test043()
 	{
 		var cp = ChildContent(b => b.AddMarkupContent(0, EXPECTED));
@@ -200,7 +200,7 @@ public class ComponentParameterFactoryTest
 		renderedFragment.Markup.ShouldBe(EXPECTED);
 	}
 
-	[Fact(DisplayName = "RenderFragment(name, markup) creates a parameter with a RenderFragment that renders a component of type TComponent")]
+	[UIFact(DisplayName = "RenderFragment(name, markup) creates a parameter with a RenderFragment that renders a component of type TComponent")]
 	public void Test051()
 	{
 		var cp = RenderFragment(NAME, EXPECTED);
@@ -212,7 +212,7 @@ public class ComponentParameterFactoryTest
 		renderedFragment.Markup.ShouldBe(EXPECTED);
 	}
 
-	[Fact(DisplayName = "RenderFragment<TComponent>(name, component parameters) creates a parameter with a RenderFragment that renders a component of type TComponent")]
+	[UIFact(DisplayName = "RenderFragment<TComponent>(name, component parameters) creates a parameter with a RenderFragment that renders a component of type TComponent")]
 	public void Test052()
 	{
 		var cp = RenderFragment<TestComponent>(NAME, (nameof(TestComponent.Input), EXPECTED));
@@ -224,7 +224,7 @@ public class ComponentParameterFactoryTest
 		renderedFragment.Markup.ShouldBe(nameof(TestComponent) + EXPECTED);
 	}
 
-	[Fact(DisplayName = "Template<TValue>(string, RenderFragment<TValue>) creates a parameter with a Template")]
+	[UIFact(DisplayName = "Template<TValue>(string, RenderFragment<TValue>) creates a parameter with a Template")]
 	public void Test061()
 	{
 		var cp = Template<string>(NAME, s => b => b.AddMarkupContent(0, s));
@@ -236,7 +236,7 @@ public class ComponentParameterFactoryTest
 		renderedFragment.Markup.ShouldBe(EXPECTED);
 	}
 
-	[Fact(DisplayName = "Template<TValue>(string, Func<TValue, string>) creates a parameter with a Template")]
+	[UIFact(DisplayName = "Template<TValue>(string, Func<TValue, string>) creates a parameter with a Template")]
 	public void Test062()
 	{
 		var cp = Template<string>(NAME, s => s);
@@ -248,7 +248,7 @@ public class ComponentParameterFactoryTest
 		renderedFragment.Markup.ShouldBe(EXPECTED);
 	}
 
-	[Fact(DisplayName = "Template<TValue>(string, Func<TValue, string>) creates a parameter with a Template")]
+	[UIFact(DisplayName = "Template<TValue>(string, Func<TValue, string>) creates a parameter with a Template")]
 	public void Test063()
 	{
 		var cp = Template<TestComponent, string>(NAME, value => new ComponentParameter[]

--- a/tests/bunit.core.tests/Extensions/RenderedComponentInvokeAsyncExtensionsTest.cs
+++ b/tests/bunit.core.tests/Extensions/RenderedComponentInvokeAsyncExtensionsTest.cs
@@ -2,7 +2,7 @@ namespace Bunit.Extensions;
 
 public class RenderedComponentInvokeAsyncExtensionsTest : TestContext
 {
-	[Fact(DisplayName = "Dispatcher awaits Task-returning callback")]
+	[UIFact(DisplayName = "Dispatcher awaits Task-returning callback")]
 	public async Task Test003()
 	{
 		// Arrange
@@ -22,7 +22,7 @@ public class RenderedComponentInvokeAsyncExtensionsTest : TestContext
 		delegateFinished.ShouldBeTrue();
 	}
 
-	[Fact(DisplayName = "Dispatcher does not await void-returning callback")]
+	[UIFact(DisplayName = "Dispatcher does not await void-returning callback")]
 	public async Task Test004()
 	{
 		// Arrange

--- a/tests/bunit.core.tests/Extensions/RenderedComponentRenderExtensionsTest.cs
+++ b/tests/bunit.core.tests/Extensions/RenderedComponentRenderExtensionsTest.cs
@@ -2,7 +2,7 @@ namespace Bunit;
 
 public class RenderedComponentRenderExtensionsTest : TestContext
 {
-	[Fact(DisplayName = "SetParametersAndRender rethrows exceptions from SetParameterAsync")]
+	[UIFact(DisplayName = "SetParametersAndRender rethrows exceptions from SetParameterAsync")]
 	public void Test001()
 	{
 		var cut = RenderComponent<ThrowsOnParameterSet>();

--- a/tests/bunit.core.tests/Extensions/WaitForHelpers/RenderedFragmentWaitForHelperExtensionsTest.cs
+++ b/tests/bunit.core.tests/Extensions/WaitForHelpers/RenderedFragmentWaitForHelperExtensionsTest.cs
@@ -10,7 +10,7 @@ public class RenderedFragmentWaitForHelperExtensionsTest : TestContext
 		Services.AddXunitLogger(testOutput);
 	}
 
-	[Fact(DisplayName = "WaitForAssertion can wait for multiple renders and changes to occur")]
+	[UIFact(DisplayName = "WaitForAssertion can wait for multiple renders and changes to occur")]
 	public void Test110()
 	{
 		// Initial state is stopped
@@ -28,7 +28,7 @@ public class RenderedFragmentWaitForHelperExtensionsTest : TestContext
 		cut.WaitForAssertion(() => cut.Find("#state").TextContent.ShouldBe("Stopped"));
 	}
 
-	[Fact(DisplayName = "WaitForAssertion throws assertion exception after timeout")]
+	[UIFact(DisplayName = "WaitForAssertion throws assertion exception after timeout")]
 	public void Test011()
 	{
 		var cut = RenderComponent<Simple1>();
@@ -39,7 +39,7 @@ public class RenderedFragmentWaitForHelperExtensionsTest : TestContext
 		expected.Message.ShouldStartWith(WaitForAssertionHelper.TimeoutMessage);
 	}
 
-	[Fact(DisplayName = "WaitForState throws exception after timeout")]
+	[UIFact(DisplayName = "WaitForState throws exception after timeout")]
 	public void Test012()
 	{
 		var cut = RenderComponent<Simple1>();
@@ -50,7 +50,7 @@ public class RenderedFragmentWaitForHelperExtensionsTest : TestContext
 		expected.Message.ShouldStartWith(WaitForStateHelper.TimeoutBeforePassMessage);
 	}
 
-	[Fact(DisplayName = "WaitForState throws exception if statePredicate throws on a later render")]
+	[UIFact(DisplayName = "WaitForState throws exception if statePredicate throws on a later render")]
 	public void Test013()
 	{
 		const string expectedInnerMessage = "INNER MESSAGE";
@@ -71,7 +71,7 @@ public class RenderedFragmentWaitForHelperExtensionsTest : TestContext
 			.Message.ShouldBe(expectedInnerMessage);
 	}
 
-	[Fact(DisplayName = "WaitForState can wait for multiple renders and changes to occur")]
+	[UIFact(DisplayName = "WaitForState can wait for multiple renders and changes to occur")]
 	public void Test100()
 	{
 		// Initial state is stopped
@@ -91,7 +91,7 @@ public class RenderedFragmentWaitForHelperExtensionsTest : TestContext
 		});
 	}
 
-	[Fact(DisplayName = "WaitForState can detect async changes to properties in the CUT")]
+	[UIFact(DisplayName = "WaitForState can detect async changes to properties in the CUT")]
 	public void Test200()
 	{
 		var cut = RenderComponent<AsyncRenderChangesProperty>();
@@ -109,7 +109,7 @@ public class RenderedFragmentWaitForHelperExtensionsTest : TestContext
 		cut.Instance.Counter.ShouldBe(2);
 	}
 
-	[Fact(DisplayName = "WaitForAssertion rethrows unhandled exception from a components async operation's methods")]
+	[UIFact(DisplayName = "WaitForAssertion rethrows unhandled exception from a components async operation's methods")]
 	public void Test300()
 	{
 		var cut = RenderComponent<ThrowsAfterAsyncOperation>();
@@ -119,7 +119,7 @@ public class RenderedFragmentWaitForHelperExtensionsTest : TestContext
 			() => cut.WaitForAssertion(() => false.ShouldBeTrue(), TimeSpan.FromSeconds(5)));
 	}
 
-	[Fact(DisplayName = "WaitForState rethrows unhandled exception from components async operation's methods")]
+	[UIFact(DisplayName = "WaitForState rethrows unhandled exception from components async operation's methods")]
 	public void Test301()
 	{
 		var cut = RenderComponent<ThrowsAfterAsyncOperation>();

--- a/tests/bunit.core.tests/Rendering/ComponentParameterTest.cs
+++ b/tests/bunit.core.tests/Rendering/ComponentParameterTest.cs
@@ -20,21 +20,21 @@ public class ComponentParameterTest
 		yield return new object[] { p1, p5, false };
 	}
 
-	[Fact(DisplayName = "Creating a cascading value with null throws")]
+	[UIFact(DisplayName = "Creating a cascading value with null throws")]
 	public void Test001()
 	{
 		Should.Throw<ArgumentNullException>(() => ComponentParameter.CreateCascadingValue(null, null!));
 		Should.Throw<ArgumentNullException>(() => (ComponentParameter)(null, null, true));
 	}
 
-	[Fact(DisplayName = "Creating a regular parameter without a name throws")]
+	[UIFact(DisplayName = "Creating a regular parameter without a name throws")]
 	public void Test002()
 	{
 		Should.Throw<ArgumentNullException>(() => ComponentParameter.CreateParameter(null!, null));
 		Should.Throw<ArgumentNullException>(() => (ComponentParameter)(null, null, false));
 	}
 
-	[Theory(DisplayName = "Equals compares correctly")]
+	[UITheory(DisplayName = "Equals compares correctly")]
 	[MemberData(nameof(GetEqualsTestData))]
 	public void Test003(ComponentParameter left, ComponentParameter right, bool expectedResult)
 	{
@@ -46,7 +46,7 @@ public class ComponentParameterTest
 		right.Equals((object)left).ShouldBe(expectedResult);
 	}
 
-	[Fact(DisplayName = "Equals operator works as expected with non compatible types")]
+	[UIFact(DisplayName = "Equals operator works as expected with non compatible types")]
 	public void Test004()
 	{
 		ComponentParameter.CreateParameter(string.Empty, string.Empty)
@@ -54,7 +54,7 @@ public class ComponentParameterTest
 			.ShouldBeFalse();
 	}
 
-	[Theory(DisplayName = "GetHashCode returns same result for equal ComponentParameter")]
+	[UITheory(DisplayName = "GetHashCode returns same result for equal ComponentParameter")]
 	[MemberData(nameof(GetEqualsTestData))]
 	public void Test005(ComponentParameter left, ComponentParameter right, bool expectedResult)
 	{

--- a/tests/bunit.core.tests/Rendering/RootRenderTreeTest.cs
+++ b/tests/bunit.core.tests/Rendering/RootRenderTreeTest.cs
@@ -5,7 +5,7 @@ namespace Bunit;
 
 public class RootRenderTreeTest : TestContext
 {
-	[Fact(DisplayName = "Count returns number of component registrations added")]
+	[UIFact(DisplayName = "Count returns number of component registrations added")]
 	public void Test010()
 	{
 		RenderTree.Add<LayoutComponent>();
@@ -13,7 +13,7 @@ public class RootRenderTreeTest : TestContext
 		RenderTree.Count.ShouldBe(1);
 	}
 
-	[Fact(DisplayName = "GetEnumerator enumerates registered components")]
+	[UIFact(DisplayName = "GetEnumerator enumerates registered components")]
 	public void Test011()
 	{
 		RenderTree.Add<LayoutComponent>();
@@ -28,7 +28,7 @@ public class RootRenderTreeTest : TestContext
 			x => x.ComponentType.ShouldBe(typeof(CascadingValue<string>)));
 	}
 
-	[Fact(DisplayName = "RenderTree.Add<T> throws when T doesn't have a ChildContent or Body parameter")]
+	[UIFact(DisplayName = "RenderTree.Add<T> throws when T doesn't have a ChildContent or Body parameter")]
 	public void Test100()
 	{
 		Should.Throw<ArgumentException>(() =>
@@ -38,7 +38,7 @@ public class RootRenderTreeTest : TestContext
 		});
 	}
 
-	[Fact(DisplayName = "RenderTree.Add<T> adds T to render tree which CUT is rendered as child of")]
+	[UIFact(DisplayName = "RenderTree.Add<T> adds T to render tree which CUT is rendered as child of")]
 	public void Test110()
 	{
 		RenderTree.Add<LayoutComponent>();
@@ -48,7 +48,7 @@ public class RootRenderTreeTest : TestContext
 		cut.Markup.ShouldBe("<div>LAYOUT VALUE</div>");
 	}
 
-	[Fact(DisplayName = "RenderTree.Add<T> allows passing parameters to render tree components")]
+	[UIFact(DisplayName = "RenderTree.Add<T> allows passing parameters to render tree components")]
 	public void Test111()
 	{
 		RenderTree.Add<LayoutComponent>(parameters => parameters.Add(p => p.Value, "ANOTHER VALUE"));
@@ -58,7 +58,7 @@ public class RootRenderTreeTest : TestContext
 		cut.Markup.ShouldBe("<div>ANOTHER VALUE</div>");
 	}
 
-	[Fact(DisplayName = "RenderTree.Add<T> can be called multiple times")]
+	[UIFact(DisplayName = "RenderTree.Add<T> can be called multiple times")]
 	public void Test112()
 	{
 		RenderTree.Add<CascadingValue<string>>(parameters => parameters.Add(p => p.Value, "VALUE"));
@@ -69,7 +69,7 @@ public class RootRenderTreeTest : TestContext
 		cut.Markup.ShouldBe("<div>VALUE42</div>");
 	}
 
-	[Fact(DisplayName = "RenderComponent<T> finds correct component when T is also added to render tree")]
+	[UIFact(DisplayName = "RenderComponent<T> finds correct component when T is also added to render tree")]
 	public void Test113()
 	{
 		RenderTree.Add<CascadingValue<string>>(parameters => parameters.Add(p => p.Value, "VALUE"));
@@ -82,7 +82,7 @@ public class RootRenderTreeTest : TestContext
 		cut.Markup.ShouldBe("<div>VALUE42</div>");
 	}
 
-	[Fact(DisplayName = "RenderComponent<T> finds correct component when T is also added to render tree")]
+	[UIFact(DisplayName = "RenderComponent<T> finds correct component when T is also added to render tree")]
 	public void Test113_2()
 	{
 		RenderTree.Add<CascadingValue<string>>(parameters => parameters.Add(p => p.Value, "VALUE"));
@@ -94,7 +94,7 @@ public class RootRenderTreeTest : TestContext
 		cut.Instance.Value.ShouldBe("FOO");
 	}
 
-	[Fact(DisplayName = "Multiple RenderTree.Add<T> calls are added to render tree in call order")]
+	[UIFact(DisplayName = "Multiple RenderTree.Add<T> calls are added to render tree in call order")]
 	public void Test114()
 	{
 		RenderTree.Add<LayoutComponent>(parameters => parameters.Add(p => p.Value, "FOO"));
@@ -105,7 +105,7 @@ public class RootRenderTreeTest : TestContext
 		cut.Markup.ShouldBe($"<div>BAR</div>");
 	}
 
-	[Fact(DisplayName = "RenderTree.TryAdd<T> only adds T if it hasn't already been added")]
+	[UIFact(DisplayName = "RenderTree.TryAdd<T> only adds T if it hasn't already been added")]
 	public void Test120()
 	{
 		RenderTree.Add<LayoutComponent>(parameters => parameters.Add(p => p.Value, "FOO"));
@@ -116,14 +116,14 @@ public class RootRenderTreeTest : TestContext
 		cut.Markup.ShouldBe("<div>FOO</div>");
 	}
 
-	[Fact(DisplayName = "RenderTree.TryAdd<T> returns true if T was added")]
+	[UIFact(DisplayName = "RenderTree.TryAdd<T> returns true if T was added")]
 	public void Test121()
 	{
 		var result = RenderTree.TryAdd<LayoutComponent>();
 		result.ShouldBeTrue();
 	}
 
-	[Fact(DisplayName = "RenderTree.TryAdd<T> returns false if T was previously added and not added again.")]
+	[UIFact(DisplayName = "RenderTree.TryAdd<T> returns false if T was previously added and not added again.")]
 	public void Test122()
 	{
 		RenderTree.Add<LayoutComponent>();
@@ -133,7 +133,7 @@ public class RootRenderTreeTest : TestContext
 		result.ShouldBeFalse();
 	}
 
-	[Fact(DisplayName = "RenderTree.TryAdd<T> distinguishes between different generic types of a generic component")]
+	[UIFact(DisplayName = "RenderTree.TryAdd<T> distinguishes between different generic types of a generic component")]
 	public void Test123()
 	{
 		RenderTree.TryAdd<CascadingValue<string>>();

--- a/tests/bunit.core.tests/Rendering/TestRendererTest.cs
+++ b/tests/bunit.core.tests/Rendering/TestRendererTest.cs
@@ -12,7 +12,7 @@ public class TestRendererTest : TestContext
 		Services.AddXunitLogger(outputHelper);
 	}
 
-	[Fact(DisplayName = "RenderFragment re-throws exception from component")]
+	[UIFact(DisplayName = "RenderFragment re-throws exception from component")]
 	public void Test004()
 	{
 		var sut = Services.GetRequiredService<ITestRenderer>();
@@ -22,7 +22,7 @@ public class TestRendererTest : TestContext
 			.Message.ShouldBe(ThrowsDuringSetParams.EXCEPTION.Message);
 	}
 
-	[Fact(DisplayName = "RenderComponent re-throws exception from component")]
+	[UIFact(DisplayName = "RenderComponent re-throws exception from component")]
 	public void Test003()
 	{
 		var sut = Services.GetRequiredService<ITestRenderer>();
@@ -31,7 +31,7 @@ public class TestRendererTest : TestContext
 			.Message.ShouldBe(ThrowsDuringSetParams.EXCEPTION.Message);
 	}
 
-	[Fact(DisplayName = "Can render fragment without children and no parameters")]
+	[UIFact(DisplayName = "Can render fragment without children and no parameters")]
 	public void Test001()
 	{
 		const string MARKUP = "<h1>hello world</h1>";
@@ -43,7 +43,7 @@ public class TestRendererTest : TestContext
 		cut.Markup.ShouldBe(MARKUP);
 	}
 
-	[Fact(DisplayName = "Can render component without children and no parameters")]
+	[UIFact(DisplayName = "Can render component without children and no parameters")]
 	public void Test002()
 	{
 		var sut = Services.GetRequiredService<ITestRenderer>();
@@ -55,7 +55,7 @@ public class TestRendererTest : TestContext
 		cut.Instance.ShouldBeOfType<NoChildNoParams>();
 	}
 
-	[Fact(DisplayName = "Can render component with parameters")]
+	[UIFact(DisplayName = "Can render component with parameters")]
 	public void Test005()
 	{
 		const string VALUE = "FOO BAR";
@@ -66,7 +66,7 @@ public class TestRendererTest : TestContext
 		cut.Instance.Value.ShouldBe(VALUE);
 	}
 
-	[Fact(DisplayName = "Can render component with child component")]
+	[UIFact(DisplayName = "Can render component with child component")]
 	public void Test006()
 	{
 		const string PARENT_VALUE = "PARENT";
@@ -82,7 +82,7 @@ public class TestRendererTest : TestContext
 		cut.Markup.ShouldEndWith(CHILD_VALUE);
 	}
 
-	[Fact(DisplayName = "Rendered component gets RenderCount updated on re-render")]
+	[UIFact(DisplayName = "Rendered component gets RenderCount updated on re-render")]
 	public async Task Test010()
 	{
 		var sut = Services.GetRequiredService<ITestRenderer>();
@@ -96,7 +96,7 @@ public class TestRendererTest : TestContext
 		cut.RenderCount.ShouldBe(2);
 	}
 
-	[Fact(DisplayName = "Rendered component gets Markup updated on re-render")]
+	[UIFact(DisplayName = "Rendered component gets Markup updated on re-render")]
 	public async Task Test011()
 	{
 		// arrange
@@ -114,7 +114,7 @@ public class TestRendererTest : TestContext
 		cut.Markup.ShouldBe(EXPECTED);
 	}
 
-	[Fact(DisplayName = "FindComponent returns first component nested inside another rendered component")]
+	[UIFact(DisplayName = "FindComponent returns first component nested inside another rendered component")]
 	public void Test020()
 	{
 		// arrange
@@ -135,7 +135,7 @@ public class TestRendererTest : TestContext
 		childCut.RenderCount.ShouldBe(1);
 	}
 
-	[Fact(DisplayName = "FindComponent throws if parentComponent parameter is null")]
+	[UIFact(DisplayName = "FindComponent throws if parentComponent parameter is null")]
 	public void Test021()
 	{
 		var sut = Services.GetRequiredService<ITestRenderer>();
@@ -143,7 +143,7 @@ public class TestRendererTest : TestContext
 		Should.Throw<ArgumentNullException>(() => sut.FindComponent<HasParams>(null!));
 	}
 
-	[Fact(DisplayName = "FindComponent throws if component is not found")]
+	[UIFact(DisplayName = "FindComponent throws if component is not found")]
 	public void Test022()
 	{
 		var sut = Services.GetRequiredService<ITestRenderer>();
@@ -152,7 +152,7 @@ public class TestRendererTest : TestContext
 		Should.Throw<ComponentNotFoundException>(() => sut.FindComponent<HasParams>(cut));
 	}
 
-	[Fact(DisplayName = "FindComponent returns same rendered component when called multiple times")]
+	[UIFact(DisplayName = "FindComponent returns same rendered component when called multiple times")]
 	public void Test023()
 	{
 		var sut = Services.GetRequiredService<ITestRenderer>();
@@ -166,7 +166,7 @@ public class TestRendererTest : TestContext
 		child1.ShouldBe(child2);
 	}
 
-	[Fact(DisplayName = "FindComponents returns all components nested inside another rendered component")]
+	[UIFact(DisplayName = "FindComponents returns all components nested inside another rendered component")]
 	public void Test030()
 	{
 		// arrange
@@ -196,7 +196,7 @@ public class TestRendererTest : TestContext
 		childCuts[1].RenderCount.ShouldBe(1);
 	}
 
-	[Fact(DisplayName = "FindComponents throws if parentComponent parameter is null")]
+	[UIFact(DisplayName = "FindComponents throws if parentComponent parameter is null")]
 	public void Test031()
 	{
 		var sut = Services.GetRequiredService<ITestRenderer>();
@@ -204,7 +204,7 @@ public class TestRendererTest : TestContext
 		Should.Throw<ArgumentNullException>(() => sut.FindComponents<HasParams>(null!));
 	}
 
-	[Fact(DisplayName = "FindComponents returns same rendered components when called multiple times")]
+	[UIFact(DisplayName = "FindComponents returns same rendered components when called multiple times")]
 	public void Test032()
 	{
 		// arrange
@@ -221,7 +221,7 @@ public class TestRendererTest : TestContext
 		childCuts1.ShouldBe(childCuts2);
 	}
 
-	[Fact(DisplayName = "Retrieved rendered child component with FindComponent gets updated on re-render")]
+	[UIFact(DisplayName = "Retrieved rendered child component with FindComponent gets updated on re-render")]
 	public async Task Test040()
 	{
 		var sut = Services.GetRequiredService<ITestRenderer>();
@@ -240,7 +240,7 @@ public class TestRendererTest : TestContext
 		cut.Markup.ShouldBe("X");
 	}
 
-	[Fact(DisplayName = "Retrieved rendered child component with FindComponents gets updated on re-render")]
+	[UIFact(DisplayName = "Retrieved rendered child component with FindComponents gets updated on re-render")]
 	public async Task Test041()
 	{
 		var sut = Services.GetRequiredService<ITestRenderer>();
@@ -259,7 +259,7 @@ public class TestRendererTest : TestContext
 		cut.Markup.ShouldBe("X");
 	}
 
-	[Fact(DisplayName = "Rendered component updates on re-renders from child components with changes in render tree")]
+	[UIFact(DisplayName = "Rendered component updates on re-renders from child components with changes in render tree")]
 	public async Task Test050()
 	{
 		// arrange
@@ -277,7 +277,7 @@ public class TestRendererTest : TestContext
 		cut.Markup.ShouldBe("X");
 	}
 
-	[Fact(DisplayName = "When component is disposed by renderer, getting Markup throws and IsDisposed returns true")]
+	[UIFact(DisplayName = "When component is disposed by renderer, getting Markup throws and IsDisposed returns true")]
 	public async Task Test060()
 	{
 		// arrange
@@ -295,7 +295,7 @@ public class TestRendererTest : TestContext
 		Should.Throw<ComponentDisposedException>(() => child.Markup);
 	}
 
-	[Fact(DisplayName = "Rendered component updates itself if a child's child is disposed")]
+	[UIFact(DisplayName = "Rendered component updates itself if a child's child is disposed")]
 	public async Task Test061()
 	{
 		// arrange
@@ -315,7 +315,7 @@ public class TestRendererTest : TestContext
 		cut.Markup.ShouldBe(string.Empty);
 	}
 
-	[Fact(DisplayName = "When test renderer is disposed, so is all rendered components")]
+	[UIFact(DisplayName = "When test renderer is disposed, so is all rendered components")]
 	public void Test070()
 	{
 		var sut = (TestRenderer)Services.GetRequiredService<ITestRenderer>();
@@ -326,7 +326,7 @@ public class TestRendererTest : TestContext
 		cut.IsDisposed.ShouldBeTrue();
 	}
 
-	[Fact(DisplayName = "Can render component that awaits uncompleted task in OnInitializedAsync")]
+	[UIFact(DisplayName = "Can render component that awaits uncompleted task in OnInitializedAsync")]
 	public void Test100()
 	{
 		var tcs = new TaskCompletionSource<object>();
@@ -337,7 +337,7 @@ public class TestRendererTest : TestContext
 		cut.Find("h1").TextContent.ShouldBe("FIRST");
 	}
 
-	[Fact(DisplayName = "Can render component that awaits yielding task in OnInitializedAsync")]
+	[UIFact(DisplayName = "Can render component that awaits yielding task in OnInitializedAsync")]
 	[Trait("Category", "async")]
 	public async Task Test101()
 	{
@@ -347,7 +347,7 @@ public class TestRendererTest : TestContext
 		await cut.WaitForAssertionAsync(() => cut.Find("h1").TextContent.ShouldBe("SECOND"));
 	}
 
-	[Fact(DisplayName = "Can render component that awaits yielding task in OnInitializedAsync")]
+	[UIFact(DisplayName = "Can render component that awaits yielding task in OnInitializedAsync")]
 	[Trait("Category", "sync")]
 	public void Test101_Sync()
 	{
@@ -357,7 +357,7 @@ public class TestRendererTest : TestContext
 		cut.WaitForAssertion(() => cut.Find("h1").TextContent.ShouldBe("SECOND"));
 	}
 
-	[Fact(DisplayName = "Can render component that awaits completed task in OnInitializedAsync")]
+	[UIFact(DisplayName = "Can render component that awaits completed task in OnInitializedAsync")]
 	public void Test102()
 	{
 		var cut = RenderComponent<AsyncRenderOfSubComponentDuringInit>(parameters =>
@@ -366,7 +366,7 @@ public class TestRendererTest : TestContext
 		cut.Find("h1").TextContent.ShouldBe("SECOND");
 	}
 
-	[Fact(DisplayName = "UnhandledException has a reference to the exception thrown by component synchronously")]
+	[UIFact(DisplayName = "UnhandledException has a reference to the exception thrown by component synchronously")]
 	public async Task Test200()
 	{
 		var syncException = Should.Throw<SyncOperationThrows.SyncOperationThrowsException>(
@@ -376,7 +376,7 @@ public class TestRendererTest : TestContext
 		capturedException.ShouldBe(syncException);
 	}
 
-	[Fact(DisplayName = "UnhandledException has a reference to the exception thrown by an async operation in a component")]
+	[UIFact(DisplayName = "UnhandledException has a reference to the exception thrown by an async operation in a component")]
 	public async Task Test201()
 	{
 		var tsc = new TaskCompletionSource<object>();
@@ -389,7 +389,7 @@ public class TestRendererTest : TestContext
 		actualException.ShouldBe(expectedException);
 	}
 
-	[Fact(DisplayName = "UnhandledException has a reference to latest unhandled exception thrown by a component")]
+	[UIFact(DisplayName = "UnhandledException has a reference to latest unhandled exception thrown by a component")]
 	public async Task Test202()
 	{
 		var tsc1 = new TaskCompletionSource<object>();
@@ -408,7 +408,7 @@ public class TestRendererTest : TestContext
 		firstExceptionReported.ShouldNotBe(secondException);
 	}
 
-	[Fact(DisplayName = "UnhandledException has a reference to latest unhandled exception thrown by a component during OnAfterRenderAsync")]
+	[UIFact(DisplayName = "UnhandledException has a reference to latest unhandled exception thrown by a component during OnAfterRenderAsync")]
 	public void Test203()
 	{
 		// Arrange
@@ -423,7 +423,7 @@ public class TestRendererTest : TestContext
 		Renderer.UnhandledException.Result.ShouldBeOfType<InvalidOperationException>();
 	}
 
-	[Fact(DisplayName = "given a IComponentActivator, " +
+	[UIFact(DisplayName = "given a IComponentActivator, " +
 					"when passed to constructor," +
 					"then it used to create components")]
 	public void Test1000()

--- a/tests/bunit.core.tests/TestContextBaseTest.cs
+++ b/tests/bunit.core.tests/TestContextBaseTest.cs
@@ -4,7 +4,7 @@ namespace Bunit;
 
 public class TestContextBaseTest : TestContext
 {
-	[Fact(DisplayName = "DisposeComponents disposes rendered components in parent to child order")]
+	[UIFact(DisplayName = "DisposeComponents disposes rendered components in parent to child order")]
 	public void Test101()
 	{
 		var callStack = new List<string>();
@@ -17,7 +17,7 @@ public class TestContextBaseTest : TestContext
 		callStack[1].ShouldBe("ChildDispose");
 	}
 
-	[Fact(DisplayName = "DisposeComponents disposes multiple rendered components")]
+	[UIFact(DisplayName = "DisposeComponents disposes multiple rendered components")]
 	public void Test102()
 	{
 		var callStack = new List<string>();
@@ -29,7 +29,7 @@ public class TestContextBaseTest : TestContext
 		callStack.Count.ShouldBe(2);
 	}
 
-	[Fact(DisplayName = "DisposeComponents rethrows exceptions from Dispose methods in components")]
+	[UIFact(DisplayName = "DisposeComponents rethrows exceptions from Dispose methods in components")]
 	public void Test103()
 	{
 		RenderComponent<ThrowExceptionComponent>();
@@ -38,7 +38,7 @@ public class TestContextBaseTest : TestContext
 		action.ShouldThrow<NotSupportedException>();
 	}
 
-	[Fact(DisplayName = "DisposeComponents disposes components nested in render fragments")]
+	[UIFact(DisplayName = "DisposeComponents disposes components nested in render fragments")]
 	public void Test104()
 	{
 		var callStack = new List<string>();
@@ -49,7 +49,7 @@ public class TestContextBaseTest : TestContext
 		callStack.Count.ShouldBe(1);
 	}
 
-	[Fact(DisplayName = "ComponentFactories CanCreate() method are checked during component instantiation")]
+	[UIFact(DisplayName = "ComponentFactories CanCreate() method are checked during component instantiation")]
 	public void Test0001()
 	{
 		var mock = CreateMockComponentFactory(canCreate: _ => false, create: _ => null);
@@ -61,7 +61,7 @@ public class TestContextBaseTest : TestContext
 		mock.Verify(x => x.Create(It.IsAny<Type>()), Times.Never);
 	}
 
-	[Fact(DisplayName = "ComponentFactories Create() method is called when their CanCreate() method returns true")]
+	[UIFact(DisplayName = "ComponentFactories Create() method is called when their CanCreate() method returns true")]
 	public void Test0002()
 	{
 		var mock = CreateMockComponentFactory(canCreate: _ => true, create: _ => new Simple1());
@@ -73,7 +73,7 @@ public class TestContextBaseTest : TestContext
 		mock.Verify(x => x.Create(typeof(Simple1)), Times.Once);
 	}
 
-	[Fact(DisplayName = "ComponentFactories is used in last added order")]
+	[UIFact(DisplayName = "ComponentFactories is used in last added order")]
 	public void Test0003()
 	{
 		var firstMock = CreateMockComponentFactory(canCreate: _ => true, create: _ => new Simple1());
@@ -89,7 +89,7 @@ public class TestContextBaseTest : TestContext
 		secondMock.Verify(x => x.Create(typeof(Simple1)), Times.Once);
 	}
 
-	[Fact(DisplayName = "DisposeComponents captures exceptions from DisposeAsync in Renderer.UnhandledException")]
+	[UIFact(DisplayName = "DisposeComponents captures exceptions from DisposeAsync in Renderer.UnhandledException")]
 	public async Task Test201()
 	{
 		RenderComponent<AsyncThrowExceptionComponent>();
@@ -100,7 +100,7 @@ public class TestContextBaseTest : TestContext
 		exception.ShouldBeOfType<NotSupportedException>();
 	}
 
-	[Fact(DisplayName = "DisposeComponents calls DisposeAsync on rendered components")]
+	[UIFact(DisplayName = "DisposeComponents calls DisposeAsync on rendered components")]
 	public async Task Test202()
 	{
 		var cut = RenderComponent<AsyncDisposableComponent>();
@@ -111,7 +111,7 @@ public class TestContextBaseTest : TestContext
 		await wasDisposedTask.ShouldCompleteWithin(TimeSpan.FromMilliseconds(100));
 	}
 
-	[Fact(DisplayName = "DisposeComponents should dispose components added via ComponentFactory")]
+	[UIFact(DisplayName = "DisposeComponents should dispose components added via ComponentFactory")]
 	public void Test203()
 	{
 		ComponentFactories.Add<ChildDispose, MyChildDisposeStub>();
@@ -123,7 +123,7 @@ public class TestContextBaseTest : TestContext
 		instance.WasDisposed.ShouldBeTrue();
 	}
 
-	[Fact(DisplayName = "Can correctly resolve and dispose of scoped disposable service")]
+	[UIFact(DisplayName = "Can correctly resolve and dispose of scoped disposable service")]
 	public void Net5Test001()
 	{
 		AsyncDisposableService asyncDisposable;
@@ -135,7 +135,7 @@ public class TestContextBaseTest : TestContext
 		asyncDisposable.IsDisposed.ShouldBeTrue();
 	}
 
-	[Fact(DisplayName = "Can correctly resolve and dispose of transient disposable service")]
+	[UIFact(DisplayName = "Can correctly resolve and dispose of transient disposable service")]
 	public void Net5Test002()
 	{
 		AsyncDisposableService asyncDisposable;
@@ -147,7 +147,7 @@ public class TestContextBaseTest : TestContext
 		asyncDisposable.IsDisposed.ShouldBeTrue();
 	}
 
-	[Fact(DisplayName = "Can correctly resolve and dispose of singleton disposable service")]
+	[UIFact(DisplayName = "Can correctly resolve and dispose of singleton disposable service")]
 	public void Net5Test003()
 	{
 		AsyncDisposableService asyncDisposable;

--- a/tests/bunit.core.tests/TestDoubles/PersistentComponentState/FakePersistentComponentStateTest.cs
+++ b/tests/bunit.core.tests/TestDoubles/PersistentComponentState/FakePersistentComponentStateTest.cs
@@ -15,7 +15,7 @@ public class FakePersistentComponentStateTest : TestContext
 		Services.AddXunitLogger(outputHelper);
 	}
 
-	[Fact(DisplayName = "AddFakePersistentComponentState is registers PersistentComponentState in services")]
+	[UIFact(DisplayName = "AddFakePersistentComponentState is registers PersistentComponentState in services")]
 	public void Test001()
 	{
 		_ = this.AddFakePersistentComponentState();
@@ -25,7 +25,7 @@ public class FakePersistentComponentStateTest : TestContext
 		actual.ShouldNotBeNull();
 	}
 
-	[Fact(DisplayName = "AddFakePersistentComponentState enables PersistentComponentState injection into components")]
+	[UIFact(DisplayName = "AddFakePersistentComponentState enables PersistentComponentState injection into components")]
 	public void Test002()
 	{
 		this.AddFakePersistentComponentState();
@@ -35,7 +35,7 @@ public class FakePersistentComponentStateTest : TestContext
 		cut.Instance.State.ShouldNotBeNull();
 	}
 
-	[Theory(DisplayName = "Persist stores state in store for components to consume")]
+	[UITheory(DisplayName = "Persist stores state in store for components to consume")]
 	[AutoData]
 	public void Test011(string key, string data)
 	{
@@ -48,7 +48,7 @@ public class FakePersistentComponentStateTest : TestContext
 		actual.ShouldBe(data);
 	}
 
-	[Fact(DisplayName = "TryTake returns true if key contains data saved in store")]
+	[UIFact(DisplayName = "TryTake returns true if key contains data saved in store")]
 	public void Test012()
 	{
 		var fakeState = this.AddFakePersistentComponentState();
@@ -60,7 +60,7 @@ public class FakePersistentComponentStateTest : TestContext
 		actual.ShouldBeEquivalentTo(cut.Instance.Forecasts);
 	}
 
-	[Theory(DisplayName = "TryTake returns false if key is not in store")]
+	[UITheory(DisplayName = "TryTake returns false if key is not in store")]
 	[AutoData]
 	public void Test013(string key)
 	{
@@ -69,7 +69,7 @@ public class FakePersistentComponentStateTest : TestContext
 		fakeState.TryTake<string>(key, out var actual).ShouldBeFalse();
 	}
 
-	[Fact(DisplayName = "TriggerOnPersisting triggers OnPersisting callbacks added to store")]
+	[UIFact(DisplayName = "TriggerOnPersisting triggers OnPersisting callbacks added to store")]
 	public void Test014()
 	{
 		var onPersistingCalledTimes = 0;

--- a/tests/bunit.core.tests/TestServiceProviderTest.cs
+++ b/tests/bunit.core.tests/TestServiceProviderTest.cs
@@ -4,7 +4,7 @@ namespace Bunit;
 
 public class TestServiceProviderTest
 {
-	[Fact(DisplayName = "Provider initialized without a service collection has zero services by default")]
+	[UIFact(DisplayName = "Provider initialized without a service collection has zero services by default")]
 	public void Test001()
 	{
 		using var sut = new TestServiceProvider();
@@ -12,7 +12,7 @@ public class TestServiceProviderTest
 		sut.Count.ShouldBe(0);
 	}
 
-	[Fact(DisplayName = "Provider initialized with a service collection has the services form the provided collection")]
+	[UIFact(DisplayName = "Provider initialized with a service collection has the services form the provided collection")]
 	public void Test002()
 	{
 		var services = new ServiceCollection();
@@ -23,7 +23,7 @@ public class TestServiceProviderTest
 		sut[0].ServiceType.ShouldBe(typeof(DummyService));
 	}
 
-	[Fact(DisplayName = "Services can be registered in the provider like a normal service collection")]
+	[UIFact(DisplayName = "Services can be registered in the provider like a normal service collection")]
 	public void Test010()
 	{
 		using var sut = new TestServiceProvider();
@@ -37,7 +37,7 @@ public class TestServiceProviderTest
 		sut[1].ServiceType.ShouldBe(typeof(DummyService));
 	}
 
-	[Fact(DisplayName = "Services can be removed in the provider like a normal service collection")]
+	[UIFact(DisplayName = "Services can be removed in the provider like a normal service collection")]
 	public void Test011()
 	{
 		using var sut = new TestServiceProvider();
@@ -59,7 +59,7 @@ public class TestServiceProviderTest
 		sut.ShouldBeEmpty();
 	}
 
-	[Fact(DisplayName = "Misc collection methods works as expected")]
+	[UIFact(DisplayName = "Misc collection methods works as expected")]
 	public void Test012()
 	{
 		using var sut = new TestServiceProvider();
@@ -75,7 +75,7 @@ public class TestServiceProviderTest
 		((IEnumerable)sut).OfType<ServiceDescriptor>().Count().ShouldBe(1);
 	}
 
-	[Fact(DisplayName = "After the first service is requested, " +
+	[UIFact(DisplayName = "After the first service is requested, " +
 						"the provider does not allow changes to service collection")]
 	public void Test013()
 	{
@@ -100,7 +100,7 @@ public class TestServiceProviderTest
 		sut.IsReadOnly.ShouldBeTrue();
 	}
 
-	[Fact(DisplayName = "Registered services can be retrieved from the provider")]
+	[UIFact(DisplayName = "Registered services can be retrieved from the provider")]
 	public void Test020()
 	{
 		using var sut = new TestServiceProvider();
@@ -112,7 +112,7 @@ public class TestServiceProviderTest
 		actual.ShouldBe(expected);
 	}
 
-	[Fact(DisplayName = "No registered service returns null")]
+	[UIFact(DisplayName = "No registered service returns null")]
 	public void Test021()
 	{
 		using var sut = new TestServiceProvider();
@@ -122,7 +122,7 @@ public class TestServiceProviderTest
 		Assert.Null(result);
 	}
 
-	[Fact(DisplayName = "Registered fallback service provider returns value")]
+	[UIFact(DisplayName = "Registered fallback service provider returns value")]
 	public void Test022()
 	{
 		using var sut = new TestServiceProvider();
@@ -134,14 +134,14 @@ public class TestServiceProviderTest
 		Assert.IsType<DummyService>(result);
 	}
 
-	[Fact(DisplayName = "Register fallback service with null value")]
+	[UIFact(DisplayName = "Register fallback service with null value")]
 	public void Test023()
 	{
 		using var sut = new TestServiceProvider();
 		Assert.Throws<ArgumentNullException>(() => sut.AddFallbackServiceProvider(null!));
 	}
 
-	[Fact(DisplayName = "Service provider returns value before fallback service provider")]
+	[UIFact(DisplayName = "Service provider returns value before fallback service provider")]
 	public void Test024()
 	{
 		const string exceptionStringResult = "exceptionStringResult";
@@ -157,7 +157,7 @@ public class TestServiceProviderTest
 		Assert.IsType<DummyService>(fallbackResult);
 	}
 
-	[Fact(DisplayName = "Latest fallback provider is used")]
+	[UIFact(DisplayName = "Latest fallback provider is used")]
 	public void Test025()
 	{
 		using var sut = new TestServiceProvider();
@@ -169,7 +169,7 @@ public class TestServiceProviderTest
 		Assert.IsType<AnotherDummyService>(result);
 	}
 
-	[Fact(DisplayName = "Fallback service provider can be used to resolve services required by components")]
+	[UIFact(DisplayName = "Fallback service provider can be used to resolve services required by components")]
 	public void Test030()
 	{
 		// Arrange
@@ -183,7 +183,7 @@ public class TestServiceProviderTest
 		Should.NotThrow(() => ctx.RenderComponent<DummyComponentWhichRequiresDummyService>());
 	}
 
-	[Fact(DisplayName = "Can correctly resolve and dispose of scoped disposable service")]
+	[UIFact(DisplayName = "Can correctly resolve and dispose of scoped disposable service")]
 	public void Test031()
 	{
 		var sut = new TestServiceProvider();
@@ -195,7 +195,7 @@ public class TestServiceProviderTest
 		disposable.IsDisposed.ShouldBeTrue();
 	}
 
-	[Fact(DisplayName = "Can correctly resolve and dispose of transient disposable service")]
+	[UIFact(DisplayName = "Can correctly resolve and dispose of transient disposable service")]
 	public void Test032()
 	{
 		var sut = new TestServiceProvider();
@@ -207,7 +207,7 @@ public class TestServiceProviderTest
 		disposable.IsDisposed.ShouldBeTrue();
 	}
 
-	[Fact(DisplayName = "Can correctly resolve and dispose of singleton disposable service")]
+	[UIFact(DisplayName = "Can correctly resolve and dispose of singleton disposable service")]
 	public void Test033()
 	{
 		var sut = new TestServiceProvider();
@@ -219,7 +219,7 @@ public class TestServiceProviderTest
 		disposable.IsDisposed.ShouldBeTrue();
 	}
 
-	[Fact(DisplayName = "Validates that all dependencies can be created when the first service is requested, if ServiceProviderOptions.ValidateOnBuild is true")]
+	[UIFact(DisplayName = "Validates that all dependencies can be created when the first service is requested, if ServiceProviderOptions.ValidateOnBuild is true")]
 	public void Test035()
 	{
 		using var sut = new TestServiceProvider();
@@ -235,7 +235,7 @@ public class TestServiceProviderTest
 		action.ShouldThrow<AggregateException>("Some services are not able to be constructed (Error while validating the service descriptor");
 	}
 
-	[Fact(DisplayName = "Does not validate all dependencies can be created when the first service is requested, if ServiceProviderOptions.ValidateOnBuild is false")]
+	[UIFact(DisplayName = "Does not validate all dependencies can be created when the first service is requested, if ServiceProviderOptions.ValidateOnBuild is false")]
 	public void Test036()
 	{
 		using var sut = new TestServiceProvider();
@@ -252,7 +252,7 @@ public class TestServiceProviderTest
 		result.ShouldNotBeNull();
 	}
 
-	[Fact(DisplayName = "Does not validate all dependencies can be created when the first service is requested, if no ServiceProviderOptions is provided (backwards compatibility)")]
+	[UIFact(DisplayName = "Does not validate all dependencies can be created when the first service is requested, if no ServiceProviderOptions is provided (backwards compatibility)")]
 	public void Test037()
 	{
 		using var sut = new TestServiceProvider();

--- a/tests/bunit.testassets/AssertExtensions/TaskAssertionExtensions.cs
+++ b/tests/bunit.testassets/AssertExtensions/TaskAssertionExtensions.cs
@@ -2,17 +2,8 @@ namespace Bunit;
 
 public static class TaskAssertionExtensions
 {
-	public static async Task ShouldCompleteWithin(this Task task, TimeSpan timeout)
+	public static Task ShouldCompleteWithin(this Task task, TimeSpan timeout)
 	{
-#if NET6_0_OR_GREATER
-		await task.WaitAsync(timeout);
-#else
-		using var cts = new CancellationTokenSource();
-        var delayTask = Task.Delay(timeout, cts.Token);
-        if (task != await Task.WhenAny(task, delayTask))
-            throw new TimeoutException();
-
-        cts.Cancel();
-#endif
+		return task.WaitAsync(timeout);
 	}
 }

--- a/tests/bunit.testassets/ServiceCollectionLoggingExtensions.cs
+++ b/tests/bunit.testassets/ServiceCollectionLoggingExtensions.cs
@@ -26,14 +26,15 @@ public static class ServiceCollectionLoggingExtensions
 		return services;
 	}
 
-	private sealed class ThreadIDEnricher : ILogEventEnricher
-	{
-		internal const string DefaultConsoleOutputTemplate = "{Timestamp:yyyy-MM-dd HH:mm:ss} ({ThreadID}) [{Level}] {Message}{NewLine}{Exception}";
+}
 
-		public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
-		{
-			logEvent.AddPropertyIfAbsent(propertyFactory.CreateProperty(
-			  "ThreadID", Environment.CurrentManagedThreadId.ToString("D4", CultureInfo.InvariantCulture)));
-		}
+public class ThreadIDEnricher : ILogEventEnricher
+{
+	public const string DefaultConsoleOutputTemplate = "{Timestamp:yyyy-MM-dd HH:mm:ss} ({ThreadID}) [{Level}] {Properties} {Message}{NewLine}{Exception}";
+
+	public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
+	{
+		logEvent.AddPropertyIfAbsent(propertyFactory.CreateProperty(
+		  "ThreadID", Environment.CurrentManagedThreadId.ToString("D4", CultureInfo.InvariantCulture)));
 	}
 }

--- a/tests/bunit.web.tests/Asserting/CompareToDiffingExtensionsTest.cs
+++ b/tests/bunit.web.tests/Asserting/CompareToDiffingExtensionsTest.cs
@@ -27,7 +27,7 @@ public class CompareToDiffingExtensionsTest : TestContext
 		}
 	}
 
-	[Theory(DisplayName = "CompareTo null values throws")]
+	[UITheory(DisplayName = "CompareTo null values throws")]
 	[MemberData(nameof(GetCompareToMethods))]
 	public void Test001(MethodInfo methodInfo, string argName, object[] args)
 	{
@@ -37,7 +37,7 @@ public class CompareToDiffingExtensionsTest : TestContext
 			.ParamName.ShouldBe(argName);
 	}
 
-	[Fact(DisplayName = "CompareTo with rendered fragment and string")]
+	[UIFact(DisplayName = "CompareTo with rendered fragment and string")]
 	public void Test002()
 	{
 		var rf1 = RenderComponent<Simple1>((nameof(Simple1.Header), "FOO"));
@@ -46,7 +46,7 @@ public class CompareToDiffingExtensionsTest : TestContext
 		rf1.CompareTo(rf2.Markup).Count.ShouldBe(1);
 	}
 
-	[Fact(DisplayName = "CompareTo with rendered fragment and rendered fragment")]
+	[UIFact(DisplayName = "CompareTo with rendered fragment and rendered fragment")]
 	public void Test003()
 	{
 		var rf1 = RenderComponent<Simple1>((nameof(Simple1.Header), "FOO"));
@@ -55,7 +55,7 @@ public class CompareToDiffingExtensionsTest : TestContext
 		rf1.CompareTo(rf2).Count.ShouldBe(1);
 	}
 
-	[Fact(DisplayName = "CompareTo with INode and INodeList")]
+	[UIFact(DisplayName = "CompareTo with INode and INodeList")]
 	public void Test004()
 	{
 		var rf1 = RenderComponent<Simple1>((nameof(Simple1.Header), "FOO"));
@@ -65,7 +65,7 @@ public class CompareToDiffingExtensionsTest : TestContext
 		elm.CompareTo(rf2.Nodes).Count.ShouldBe(1);
 	}
 
-	[Fact(DisplayName = "CompareTo with INodeList and INode")]
+	[UIFact(DisplayName = "CompareTo with INodeList and INode")]
 	public void Test005()
 	{
 		var rf1 = RenderComponent<Simple1>((nameof(Simple1.Header), "FOO"));

--- a/tests/bunit.web.tests/Asserting/DiffAssertExtensionsTest.cs
+++ b/tests/bunit.web.tests/Asserting/DiffAssertExtensionsTest.cs
@@ -5,7 +5,7 @@ namespace Bunit;
 
 public class DiffAssertExtensionsTest
 {
-	[Fact(DisplayName = "ShouldHaveSingleChange throws when input is null")]
+	[UIFact(DisplayName = "ShouldHaveSingleChange throws when input is null")]
 	public void Test001()
 	{
 		IReadOnlyList<IDiff>? diffs = null;
@@ -23,7 +23,7 @@ public class DiffAssertExtensionsTest
 		exception.ShouldBeOfType<ArgumentNullException>();
 	}
 
-	[Theory(DisplayName = "ShouldHaveSingleChange throws when input length not exactly 1")]
+	[UITheory(DisplayName = "ShouldHaveSingleChange throws when input length not exactly 1")]
 	[MemberData(nameof(GetDiffLists))]
 	public void Test002(IReadOnlyList<IDiff> diffs)
 	{
@@ -41,7 +41,7 @@ public class DiffAssertExtensionsTest
 		exception.ShouldBeOfType<ActualExpectedAssertException>();
 	}
 
-	[Fact(DisplayName = "ShouldHaveSingleChange returns the single diff in input when there is only one")]
+	[UIFact(DisplayName = "ShouldHaveSingleChange returns the single diff in input when there is only one")]
 	public void Test003()
 	{
 		var input = new IDiff[] { Mock.Of<IDiff>() };

--- a/tests/bunit.web.tests/Asserting/JSRuntimeAssertExtensionsTest.cs
+++ b/tests/bunit.web.tests/Asserting/JSRuntimeAssertExtensionsTest.cs
@@ -7,13 +7,13 @@ public class JSRuntimeAssertExtensionsTest
 {
 	private static BunitJSInterop CreateSut(JSRuntimeMode mode = JSRuntimeMode.Loose) => new() { Mode = mode };
 
-	[Fact(DisplayName = "BunitJSInterop.VerifyNotInvoke throws if handler is null")]
+	[UIFact(DisplayName = "BunitJSInterop.VerifyNotInvoke throws if handler is null")]
 	public void Test001()
 	{
 		Should.Throw<ArgumentNullException>(() => default(BunitJSInterop)!.VerifyNotInvoke(string.Empty));
 	}
 
-	[Fact(DisplayName = "BunitJSInterop.VerifyNotInvoke throws JSInvokeCountExpectedException if identifier " +
+	[UIFact(DisplayName = "BunitJSInterop.VerifyNotInvoke throws JSInvokeCountExpectedException if identifier " +
 						"has been invoked one or more times")]
 	public async Task Test002()
 	{
@@ -25,7 +25,7 @@ public class JSRuntimeAssertExtensionsTest
 		Should.Throw<JSInvokeCountExpectedException>(() => sut.VerifyNotInvoke(identifier));
 	}
 
-	[Fact(DisplayName = "BunitJSInterop.VerifyNotInvoke throws JSInvokeCountExpectedException if identifier " +
+	[UIFact(DisplayName = "BunitJSInterop.VerifyNotInvoke throws JSInvokeCountExpectedException if identifier " +
 						"has been invoked one or more times, with custom error message")]
 	public async Task Test003()
 	{
@@ -39,14 +39,14 @@ public class JSRuntimeAssertExtensionsTest
 			.Message.ShouldContain(errMsg);
 	}
 
-	[Fact(DisplayName = "BunitJSInterop.VerifyNotInvoke does not throw if identifier has not been invoked")]
+	[UIFact(DisplayName = "BunitJSInterop.VerifyNotInvoke does not throw if identifier has not been invoked")]
 	public void Test004()
 	{
 		var sut = CreateSut();
 		sut.VerifyNotInvoke("FOOBAR");
 	}
 
-	[Fact(DisplayName = "BunitJSInterop.VerifyInvoke throws if handler is null")]
+	[UIFact(DisplayName = "BunitJSInterop.VerifyInvoke throws if handler is null")]
 	public void Test100()
 	{
 		BunitJSInterop? sut = null;
@@ -54,7 +54,7 @@ public class JSRuntimeAssertExtensionsTest
 		Should.Throw<ArgumentNullException>(() => (sut!).VerifyInvoke(string.Empty, 42));
 	}
 
-	[Fact(DisplayName = "BunitJSInterop.VerifyInvoke throws invokeCount is less than 1")]
+	[UIFact(DisplayName = "BunitJSInterop.VerifyInvoke throws invokeCount is less than 1")]
 	public void Test101()
 	{
 		var sut = CreateSut();
@@ -62,7 +62,7 @@ public class JSRuntimeAssertExtensionsTest
 		Should.Throw<ArgumentException>(() => sut.VerifyInvoke(string.Empty, 0));
 	}
 
-	[Fact(DisplayName = "BunitJSInterop.VerifyInvoke throws JSInvokeCountExpectedException when " +
+	[UIFact(DisplayName = "BunitJSInterop.VerifyInvoke throws JSInvokeCountExpectedException when " +
 						"invocation count doesn't match the expected")]
 	public async Task Test103()
 	{
@@ -76,7 +76,7 @@ public class JSRuntimeAssertExtensionsTest
 		actual.Identifier.ShouldBe(identifier);
 	}
 
-	[Fact(DisplayName = "BunitJSInterop.VerifyInvoke returns the invocation(s) if the expected count matched")]
+	[UIFact(DisplayName = "BunitJSInterop.VerifyInvoke returns the invocation(s) if the expected count matched")]
 	public async Task Test104()
 	{
 		var sut = CreateSut();
@@ -90,7 +90,7 @@ public class JSRuntimeAssertExtensionsTest
 		invocation.ShouldBe(sut.Invocations[identifier][0]);
 	}
 
-	[Fact(DisplayName = "ShouldBeElementReferenceTo throws if actualArgument or targeted element is null")]
+	[UIFact(DisplayName = "ShouldBeElementReferenceTo throws if actualArgument or targeted element is null")]
 	public void Test200()
 	{
 		Should.Throw<ArgumentNullException>(() => JSRuntimeAssertExtensions.ShouldBeElementReferenceTo(null!, null!))
@@ -99,14 +99,14 @@ public class JSRuntimeAssertExtensionsTest
 			.ParamName.ShouldBe("expectedTargetElement");
 	}
 
-	[Fact(DisplayName = "ShouldBeElementReferenceTo throws if actualArgument is not a ElementReference")]
+	[UIFact(DisplayName = "ShouldBeElementReferenceTo throws if actualArgument is not a ElementReference")]
 	public void Test201()
 	{
 		var obj = new object();
 		Should.Throw<ActualExpectedAssertException>(() => obj.ShouldBeElementReferenceTo(Mock.Of<IElement>()));
 	}
 
-	[Fact(DisplayName = "ShouldBeElementReferenceTo throws if element reference does not point to the provided element")]
+	[UIFact(DisplayName = "ShouldBeElementReferenceTo throws if element reference does not point to the provided element")]
 	public void Test202()
 	{
 		using var htmlParser = new BunitHtmlParser();
@@ -120,13 +120,13 @@ public class JSRuntimeAssertExtensionsTest
 		Should.Throw<ActualExpectedAssertException>(() => elmRef.ShouldBeElementReferenceTo(elmWithoutRefAttr));
 	}
 
-	[Fact(DisplayName = "JSRuntimeInvocationHandler.VerifyNotInvoke throws if handler is null")]
+	[UIFact(DisplayName = "JSRuntimeInvocationHandler.VerifyNotInvoke throws if handler is null")]
 	public void Test301()
 	{
 		Should.Throw<ArgumentNullException>(() => default(JSRuntimeInvocationHandler)!.VerifyNotInvoke(string.Empty));
 	}
 
-	[Fact(DisplayName = "JSRuntimeInvocationHandler.VerifyNotInvoke throws JSInvokeCountExpectedException if identifier " +
+	[UIFact(DisplayName = "JSRuntimeInvocationHandler.VerifyNotInvoke throws JSInvokeCountExpectedException if identifier " +
 				"has been invoked one or more times")]
 	public async Task Test302()
 	{
@@ -139,7 +139,7 @@ public class JSRuntimeAssertExtensionsTest
 		Should.Throw<JSInvokeCountExpectedException>(() => handler.VerifyNotInvoke(identifier));
 	}
 
-	[Fact(DisplayName = "JSRuntimeInvocationHandler.VerifyNotInvoke throws JSInvokeCountExpectedException if identifier " +
+	[UIFact(DisplayName = "JSRuntimeInvocationHandler.VerifyNotInvoke throws JSInvokeCountExpectedException if identifier " +
 				"has been invoked one or more times, with custom error message")]
 	public async Task Test303()
 	{
@@ -154,7 +154,7 @@ public class JSRuntimeAssertExtensionsTest
 			.Message.ShouldContain(errMsg);
 	}
 
-	[Fact(DisplayName = "JSRuntimeInvocationHandler.VerifyNotInvoke does not throw if identifier has not been invoked")]
+	[UIFact(DisplayName = "JSRuntimeInvocationHandler.VerifyNotInvoke does not throw if identifier has not been invoked")]
 	public void Test304()
 	{
 		var sut = CreateSut();
@@ -163,14 +163,14 @@ public class JSRuntimeAssertExtensionsTest
 		handler.VerifyNotInvoke("FOOBAR");
 	}
 
-	[Fact(DisplayName = "JSRuntimeInvocationHandler.VerifyInvoke throws if handler is null")]
+	[UIFact(DisplayName = "JSRuntimeInvocationHandler.VerifyInvoke throws if handler is null")]
 	public void Test305()
 	{
 		Should.Throw<ArgumentNullException>(() => default(JSRuntimeInvocationHandler)!.VerifyInvoke(string.Empty));
 		Should.Throw<ArgumentNullException>(() => default(JSRuntimeInvocationHandler)!.VerifyInvoke(string.Empty, 42));
 	}
 
-	[Fact(DisplayName = "JSRuntimeInvocationHandler.VerifyInvoke throws invokeCount is less than 1")]
+	[UIFact(DisplayName = "JSRuntimeInvocationHandler.VerifyInvoke throws invokeCount is less than 1")]
 	public void Test306()
 	{
 		var sut = CreateSut();
@@ -179,7 +179,7 @@ public class JSRuntimeAssertExtensionsTest
 		Should.Throw<ArgumentException>(() => handler.VerifyInvoke(string.Empty, 0));
 	}
 
-	[Fact(DisplayName = "JSRuntimeInvocationHandler.VerifyInvoke throws JSInvokeCountExpectedException when " +
+	[UIFact(DisplayName = "JSRuntimeInvocationHandler.VerifyInvoke throws JSInvokeCountExpectedException when " +
 						"invocation count doesn't match the expected")]
 	public async Task Test307()
 	{
@@ -195,7 +195,7 @@ public class JSRuntimeAssertExtensionsTest
 		actual.Identifier.ShouldBe(identifier);
 	}
 
-	[Fact(DisplayName = "JSRuntimeInvocationHandler.VerifyInvoke returns the invocation(s) if the expected count matched")]
+	[UIFact(DisplayName = "JSRuntimeInvocationHandler.VerifyInvoke returns the invocation(s) if the expected count matched")]
 	public async Task Test308()
 	{
 		var sut = CreateSut();
@@ -211,7 +211,7 @@ public class JSRuntimeAssertExtensionsTest
 		invocation.ShouldBe(handler.Invocations[identifier][0]);
 	}
 
-	[Fact(DisplayName = "JSRuntimeInvocationHandler.VerifyInvoke reports the actual and expected amount")]
+	[UIFact(DisplayName = "JSRuntimeInvocationHandler.VerifyInvoke reports the actual and expected amount")]
 	public async Task Test309()
 	{
 		var sut = CreateSut();

--- a/tests/bunit.web.tests/Asserting/MarkupMatchesAssertExtensionsTest.cs
+++ b/tests/bunit.web.tests/Asserting/MarkupMatchesAssertExtensionsTest.cs
@@ -15,7 +15,7 @@ public class MarkupMatchesAssertExtensionsTest : TestContext
 	private INode ActualNode => ActualNodeList[0];
 	private INode ExpectedNode => ExpectedNodeList[0];
 
-	[Fact(DisplayName = "MarkupMatches with null arguments throws ArgumentNullException")]
+	[UIFact(DisplayName = "MarkupMatches with null arguments throws ArgumentNullException")]
 	public void Test001()
 	{
 		Should.Throw<ArgumentNullException>(() => default(string)!.MarkupMatches(ExpectedMarkup));
@@ -55,52 +55,52 @@ public class MarkupMatchesAssertExtensionsTest : TestContext
 		Should.Throw<ArgumentNullException>(() => default(INodeList)!.MarkupMatches(default(RenderFragment)!));
 	}
 
-	[Fact(DisplayName = "MarkupMatches(string, string) correctly diffs markup")]
+	[UIFact(DisplayName = "MarkupMatches(string, string) correctly diffs markup")]
 	public void Test002()
 		=> Should.Throw<HtmlEqualException>(() => ActualMarkup.MarkupMatches(ExpectedMarkup));
 
-	[Fact(DisplayName = "MarkupMatches(string, IRenderedFragment) correctly diffs markup")]
+	[UIFact(DisplayName = "MarkupMatches(string, IRenderedFragment) correctly diffs markup")]
 	public void Test003()
 		=> Should.Throw<HtmlEqualException>(() => ActualMarkup.MarkupMatches(ExpectedRenderedFragment));
 
-	[Fact(DisplayName = "MarkupMatches(string, INodeList) correctly diffs markup")]
+	[UIFact(DisplayName = "MarkupMatches(string, INodeList) correctly diffs markup")]
 	public void Test004()
 		=> Should.Throw<HtmlEqualException>(() => ActualMarkup.MarkupMatches(ExpectedNodeList));
 
-	[Fact(DisplayName = "MarkupMatches(INodeList, INodeList) correctly diffs markup")]
+	[UIFact(DisplayName = "MarkupMatches(INodeList, INodeList) correctly diffs markup")]
 	public void Test005()
 		=> Should.Throw<HtmlEqualException>(() => ActualNodeList.MarkupMatches(ExpectedNodeList));
 
-	[Fact(DisplayName = "MarkupMatches(INodeList, INode) correctly diffs markup")]
+	[UIFact(DisplayName = "MarkupMatches(INodeList, INode) correctly diffs markup")]
 	public void Test006()
 		=> Should.Throw<HtmlEqualException>(() => ActualNodeList.MarkupMatches(ExpectedNode));
 
-	[Fact(DisplayName = "MarkupMatches(INode, INodeList) correctly diffs markup")]
+	[UIFact(DisplayName = "MarkupMatches(INode, INodeList) correctly diffs markup")]
 	public void Test007()
 		=> Should.Throw<HtmlEqualException>(() => ActualNode.MarkupMatches(ExpectedNodeList));
 
-	[Fact(DisplayName = "MarkupMatches(IRenderedFragment, RenderFragment) correctly diffs markup")]
+	[UIFact(DisplayName = "MarkupMatches(IRenderedFragment, RenderFragment) correctly diffs markup")]
 	public void Test008()
 		=> Should.Throw<HtmlEqualException>(() => ActualRenderedFragment.MarkupMatches(ExpectedRenderFragment));
 
-	[Fact(DisplayName = "MarkupMatches(INode, RenderFragment) correctly diffs markup")]
+	[UIFact(DisplayName = "MarkupMatches(INode, RenderFragment) correctly diffs markup")]
 	public void Test009()
 		=> Should.Throw<HtmlEqualException>(() => ActualNode.MarkupMatches(ExpectedRenderFragment));
 
-	[Fact(DisplayName = "MarkupMatches(INodeList, RenderFragment) correctly diffs markup")]
+	[UIFact(DisplayName = "MarkupMatches(INodeList, RenderFragment) correctly diffs markup")]
 	public void Test0010()
 		=> Should.Throw<HtmlEqualException>(() => ActualNodeList.MarkupMatches(ExpectedRenderFragment));
 
 	private IRenderedFragment FindAllRenderedFragment => Render(b => b.AddMarkupContent(0, "<div><p><strong>test</strong></p></div>"));
 	private readonly string findAllExpectedRenderFragment = "<p><strong>test</strong></p>";
 
-	[Fact(DisplayName = "MarkupMatches combination works with IRenderedFragment's FindAll extension method")]
+	[UIFact(DisplayName = "MarkupMatches combination works with IRenderedFragment's FindAll extension method")]
 	public void Test011()
 	{
 		FindAllRenderedFragment.FindAll("p").MarkupMatches(findAllExpectedRenderFragment);
 	}
 
-	[Fact(DisplayName = "MarkupMatches combination works with FindAll and FindComponents<T>")]
+	[UIFact(DisplayName = "MarkupMatches combination works with FindAll and FindComponents<T>")]
 	public void Test012()
 	{
 		var cut = RenderComponent<RefToSimple1Child>();
@@ -108,7 +108,7 @@ public class MarkupMatchesAssertExtensionsTest : TestContext
 		cut.FindAll("h1").MarkupMatches(cut.FindComponents<Simple1>());
 	}
 
-	[Fact(DisplayName = "MarkupMatches combination works with FindAll and a markup string")]
+	[UIFact(DisplayName = "MarkupMatches combination works with FindAll and a markup string")]
 	public void Test013()
 	{
 		var cut = RenderComponent<NoArgs>();
@@ -116,7 +116,7 @@ public class MarkupMatchesAssertExtensionsTest : TestContext
 		cut.FindAll("h1").MarkupMatches("<h1>Hello world</h1>");
 	}
 
-	[Fact(DisplayName = "MarkupMatches combination works with Find and FindAll")]
+	[UIFact(DisplayName = "MarkupMatches combination works with Find and FindAll")]
 	public void Test014()
 	{
 		var cut = RenderComponent<TwoChildren>();
@@ -124,7 +124,7 @@ public class MarkupMatchesAssertExtensionsTest : TestContext
 		cut.Find("div").MarkupMatches(cut.FindAll("div"));
 	}
 
-	[Fact(DisplayName = "MarkupMatches correctly ignores scoped CSS attributes")]
+	[UIFact(DisplayName = "MarkupMatches correctly ignores scoped CSS attributes")]
 	public void Test_net5_001()
 	{
 		var cut = RenderComponent<ScopedCssElements>();

--- a/tests/bunit.web.tests/BlazorE2E/ComponentRenderingTest.cs
+++ b/tests/bunit.web.tests/BlazorE2E/ComponentRenderingTest.cs
@@ -23,7 +23,7 @@ public class ComponentRenderingTest : TestContext
 		JSInterop.Mode = JSRuntimeMode.Loose;
 	}
 
-	[Fact]
+	[UIFact]
 	public void CanRenderTextOnlyComponent()
 	{
 		var cut = RenderComponent<TextOnlyComponent>();
@@ -32,7 +32,7 @@ public class ComponentRenderingTest : TestContext
 
 	// This verifies that we've correctly configured the Razor language version via MSBuild.
 	// See #974
-	[Fact]
+	[UIFact]
 	public void CanRenderComponentWithDataDash()
 	{
 		var cut = RenderComponent<DataDashComponent>();
@@ -41,7 +41,7 @@ public class ComponentRenderingTest : TestContext
 		Assert.Equal("17", element.TextContent);
 	}
 
-	[Fact]
+	[UIFact]
 	public void CanRenderComponentWithAttributes()
 	{
 		var cut = RenderComponent<RedTextComponent>();
@@ -51,7 +51,7 @@ public class ComponentRenderingTest : TestContext
 		Assert.Equal("somevalue", styledElement.GetAttribute("customattribute"));
 	}
 
-	[Fact]
+	[UIFact]
 	public void CanTriggerEvents()
 	{
 		// Initial count is zero
@@ -64,7 +64,7 @@ public class ComponentRenderingTest : TestContext
 		Assert.Equal("Current count: 1", countDisplayElement.TextContent);
 	}
 
-	[Fact]
+	[UIFact]
 	[Trait("Category", "async")]
 	public async Task CanTriggerAsyncEventHandlers()
 	{
@@ -81,7 +81,7 @@ public class ComponentRenderingTest : TestContext
 		await cut.WaitForAssertionAsync(() => Assert.Equal("Stopped", stateElement.TextContent));
 	}
 
-	[Fact]
+	[UIFact]
 	[Trait("Category", "sync")]
 	public void CanTriggerAsyncEventHandlers_Sync()
 	{
@@ -98,7 +98,7 @@ public class ComponentRenderingTest : TestContext
 		cut.WaitForAssertion(() => Assert.Equal("Stopped", stateElement.TextContent));
 	}
 
-	[Fact]
+	[UIFact]
 	public void CanTriggerKeyPressEvents()
 	{
 		// List is initially empty
@@ -118,7 +118,7 @@ public class ComponentRenderingTest : TestContext
 			li => Assert.Equal("b", li.TextContent));
 	}
 
-	[Fact]
+	[UIFact]
 	public void CanAddAndRemoveEventHandlersDynamically()
 	{
 		var cut = RenderComponent<CounterComponent>();
@@ -144,7 +144,7 @@ public class ComponentRenderingTest : TestContext
 		Assert.Equal("Current count: 2", countDisplayElement.TextContent);
 	}
 
-	[Fact]
+	[UIFact]
 	public void CanRenderChildComponents()
 	{
 		var cut = RenderComponent<ParentChildComponent>();
@@ -156,14 +156,14 @@ public class ComponentRenderingTest : TestContext
 		Assert.Equal("somevalue", styledElement.GetAttribute("customattribute"));
 	}
 
-	[Fact(DisplayName = "Verifies we can render HTML content as a single block")]
+	[UIFact(DisplayName = "Verifies we can render HTML content as a single block")]
 	public void CanRenderChildContent_StaticHtmlBlock()
 	{
 		var cut = RenderComponent<HtmlBlockChildContent>();
 		Assert.Equal("<p>Some-Static-Text</p>", cut.Find("#foo").InnerHtml);
 	}
 
-	[Fact(DisplayName = "Verifies we can rewrite more complex HTML content into blocks")]
+	[UIFact(DisplayName = "Verifies we can rewrite more complex HTML content into blocks")]
 	public void CanRenderChildContent_MixedHtmlBlock()
 	{
 		var cut = RenderComponent<HtmlMixedChildContent>();
@@ -181,7 +181,7 @@ public class ComponentRenderingTest : TestContext
 		Assert.Equal("But this is static", four.InnerHtml);
 	}
 
-	[Fact(DisplayName = "Verifies we can rewrite HTML blocks with encoded HTML")]
+	[UIFact(DisplayName = "Verifies we can rewrite HTML blocks with encoded HTML")]
 	public void CanRenderChildContent_EncodedHtmlInBlock()
 	{
 		var cut = RenderComponent<HtmlEncodedChildContent>();
@@ -199,7 +199,7 @@ public class ComponentRenderingTest : TestContext
 		Assert.Equal("But this is static", four.InnerHtml);
 	}
 
-	[Fact]
+	[UIFact]
 	public void CanTriggerEventsOnChildComponents()
 	{
 		// Counter is displayed as child component. Initial count is zero.
@@ -211,7 +211,7 @@ public class ComponentRenderingTest : TestContext
 		Assert.Equal("Current count: 1", cut.Find("h1+p").TextContent);
 	}
 
-	[Fact]
+	[UIFact]
 	public void ChildComponentsRerenderWhenPropertiesChanged()
 	{
 		// Count value is displayed in child component with initial value zero
@@ -226,7 +226,7 @@ public class ComponentRenderingTest : TestContext
 		Assert.Equal("1", messageElementInChild.TextContent);
 	}
 
-	[Fact]
+	[UIFact]
 	public void CanAddAndRemoveChildComponentsDynamically()
 	{
 		// Initially there are zero child components
@@ -259,7 +259,7 @@ public class ComponentRenderingTest : TestContext
 			msg => Assert.Equal("Child 3", msg.TextContent));
 	}
 
-	[Fact]
+	[UIFact]
 	public void ChildComponentsNotifiedWhenPropertiesChanged()
 	{
 		// Child component receives notification that lets it compute a property before first render
@@ -276,7 +276,7 @@ public class ComponentRenderingTest : TestContext
 		Assert.Equal("I computed: 202", computedValueElement.TextContent);
 	}
 
-	[Fact]
+	[UIFact]
 	public void CanRenderFragmentsWhilePreservingSurroundingElements()
 	{
 		// Initially, the region isn't shown
@@ -299,7 +299,7 @@ public class ComponentRenderingTest : TestContext
 		Assert.Empty(fragmentElements);
 	}
 
-	[Fact]
+	[UIFact]
 	public void CanUseViewImportsHierarchically()
 	{
 		// The component is able to compile and output these type names only because
@@ -311,7 +311,7 @@ public class ComponentRenderingTest : TestContext
 			elem => Assert.Equal(typeof(System.Configuration.Assemblies.AssemblyHashAlgorithm).FullName, elem.TextContent));
 	}
 
-	[Fact]
+	[UIFact]
 	public void CanRenderSvgWithCorrectNamespace()
 	{
 		var cut = RenderComponent<SvgComponent>();
@@ -327,7 +327,7 @@ public class ComponentRenderingTest : TestContext
 		Assert.Equal("20", svgCircleElement.GetAttribute("r"));
 	}
 
-	[Fact]
+	[UIFact]
 	public void CanRenderSvgChildComponentWithCorrectNamespace()
 	{
 		var cut = RenderComponent<SvgWithChildComponent>();
@@ -339,14 +339,14 @@ public class ComponentRenderingTest : TestContext
 		Assert.NotNull(svgCircleElement);
 	}
 
-	[Fact]
+	[UIFact]
 	public void LogicalElementInsertionWorksHierarchically()
 	{
 		var cut = RenderComponent<LogicalElementInsertionCases>();
 		cut.MarkupMatches("First Second Third");
 	}
 
-	[Fact]
+	[UIFact]
 	public void CanUseJSInteropToReferenceElements()
 	{
 		// NOTE: This test required JS to modify the DOM. Test rewritten to use MockJSRuntime
@@ -374,7 +374,7 @@ public class ComponentRenderingTest : TestContext
 			.Id.ShouldBe(refId);
 	}
 
-	[Fact]
+	[UIFact]
 	public void CanCaptureReferencesToDynamicallyAddedElements()
 	{
 		// NOTE: This test required JS to modify the DOM. Test rewritten to use MockJSRuntime
@@ -426,7 +426,7 @@ public class ComponentRenderingTest : TestContext
 			.Id.ShouldBe(refId);
 	}
 
-	[Fact]
+	[UIFact]
 	public void CanCaptureReferencesToDynamicallyAddedComponents()
 	{
 		var cut = RenderComponent<ComponentRefComponent>();
@@ -457,14 +457,14 @@ public class ComponentRenderingTest : TestContext
 	}
 
 	// Test depends on javascript changing the DOM, thus doesnt make sense in this context.
-	// [Fact]
+	// [UIFact]
 	// public void CanUseJSInteropForRefElementsDuringOnAfterRender()
 	// {
 	//     var cut = RenderComponent<AfterRenderInteropComponent>();
 	//     Assert.Equal("Value set after render", () => Browser.Find("input").GetAttribute("value"));
 	// }
 
-	[Fact]
+	[UIFact]
 	public void CanRenderMarkupBlocks()
 	{
 		var cut = RenderComponent<MarkupBlockComponent>();
@@ -486,7 +486,7 @@ public class ComponentRenderingTest : TestContext
 		Assert.Equal("changed", cut.Find("#dynamic-markup-block span em").TextContent);
 	}
 
-	[Fact]
+	[UIFact]
 	public void CanRenderRazorTemplates()
 	{
 		var cut = RenderComponent<RazorTemplates>();
@@ -500,7 +500,7 @@ public class ComponentRenderingTest : TestContext
 			e => Assert.Equal("#3 - c", e.TextContent));
 	}
 
-	[Fact]
+	[UIFact]
 	public void CanRenderMultipleChildContent()
 	{
 		var cut = RenderComponent<MultipleChildContent>();
@@ -526,7 +526,7 @@ public class ComponentRenderingTest : TestContext
 			e => Assert.Equal("End", e.TextContent));
 	}
 
-	[Fact]
+	[UIFact]
 	[Trait("Category", "async")]
 	public async Task CanAcceptSimultaneousRenderRequests()
 	{
@@ -547,7 +547,7 @@ public class ComponentRenderingTest : TestContext
 			timeout: TimeSpan.FromSeconds(10));
 	}
 
-	[Fact]
+	[UIFact]
 	[Trait("Category", "sync")]
 	public void CanAcceptSimultaneousRenderRequests_Sync()
 	{
@@ -568,7 +568,7 @@ public class ComponentRenderingTest : TestContext
 			timeout: TimeSpan.FromSeconds(10));
 	}
 
-	[Fact]
+	[UIFact]
 	[Trait("Category", "async")]
 	public async Task CanDispatchRenderToSyncContext()
 	{
@@ -580,7 +580,7 @@ public class ComponentRenderingTest : TestContext
 		await cut.WaitForAssertionAsync(() => Assert.Equal("Success (completed synchronously)", result.TextContent.Trim()));
 	}
 
-	[Fact]
+	[UIFact]
 	[Trait("Category", "sync")]
 	public void CanDispatchRenderToSyncContext_Sync()
 	{
@@ -592,7 +592,7 @@ public class ComponentRenderingTest : TestContext
 		cut.WaitForAssertion(() => Assert.Equal("Success (completed synchronously)", result.TextContent.Trim()));
 	}
 
-	[Fact]
+	[UIFact]
 	[Trait("Category", "async")]
 	public async Task CanDoubleDispatchRenderToSyncContext()
 	{
@@ -604,7 +604,7 @@ public class ComponentRenderingTest : TestContext
 		await cut.WaitForAssertionAsync(() => Assert.Equal("Success (completed synchronously)", result.TextContent.Trim()));
 	}
 
-	[Fact]
+	[UIFact]
 	[Trait("Category", "sync")]
 	public void CanDoubleDispatchRenderToSyncContext_Sync()
 	{
@@ -616,7 +616,7 @@ public class ComponentRenderingTest : TestContext
 		cut.WaitForAssertion(() => Assert.Equal("Success (completed synchronously)", result.TextContent.Trim()));
 	}
 
-	[Fact]
+	[UIFact]
 	public void CanUseAddMultipleAttributes()
 	{
 		var cut = RenderComponent<DuplicateAttributesComponent>();
@@ -632,7 +632,7 @@ public class ComponentRenderingTest : TestContext
 		Assert.Equal("unmatched-value", element.GetAttribute("unmatched"));
 	}
 
-	[Fact]
+	[UIFact]
 	public void CanPatchRenderTreeToMatchLatestDOMState()
 	{
 		var cut = RenderComponent<MovingCheckboxesComponent>();
@@ -654,7 +654,7 @@ public class ComponentRenderingTest : TestContext
 		Assert.True(completeLIs[0].QuerySelector(".item-isdone").HasAttribute("checked"));
 	}
 
-	[Fact]
+	[UIFact]
 	[Trait("Category", "async")]
 	public async Task CanHandleRemovedParentObjects()
 	{
@@ -666,7 +666,7 @@ public class ComponentRenderingTest : TestContext
 		cut.FindAll("div").Count.ShouldBe(0);
 	}
 
-	[Fact]
+	[UIFact]
 	[Trait("Category", "sync")]
 	public void CanHandleRemovedParentObjects_Sync()
 	{
@@ -678,7 +678,7 @@ public class ComponentRenderingTest : TestContext
 		cut.FindAll("div").Count.ShouldBe(0);
 	}
 
-	[Fact]
+	[UIFact]
 	[Trait("Category", "async")]
 	public async Task CanHandleRemovedParentObjectsAsync()
 	{
@@ -690,7 +690,7 @@ public class ComponentRenderingTest : TestContext
 		cut.FindAll("div").Count.ShouldBe(0);
 	}
 
-	[Fact]
+	[UIFact]
 	public void EscapableCharactersDontGetEncoded()
 	{
 		var cut = RenderComponent<ComponentWithEscapableCharacters>();
@@ -698,7 +698,7 @@ public class ComponentRenderingTest : TestContext
 		cut.Markup.ShouldBe("<p style=\"url('')\">url('')</p>");
 	}
 
-	[Fact]
+	[UIFact]
 	[Trait("Category", "sync")]
 	public async Task CanHandleRemovedParentObjectsAsync_Sync()
 	{

--- a/tests/bunit.web.tests/ComponentFactories/StubComponentFactoryTest.cs
+++ b/tests/bunit.web.tests/ComponentFactories/StubComponentFactoryTest.cs
@@ -4,11 +4,11 @@ namespace Bunit.ComponentFactories;
 
 public class StubComponentFactoryTest : TestContext
 {
-	[Fact(DisplayName = "AddStub throws if predicate is null")]
+	[UIFact(DisplayName = "AddStub throws if predicate is null")]
 	public void Test101()
 		=> Should.Throw<ArgumentNullException>(() => ComponentFactories.AddStub(componentTypePredicate: default, string.Empty));
 
-	[Fact(DisplayName = "AddStub<T> replaces T with Stub<T>")]
+	[UIFact(DisplayName = "AddStub<T> replaces T with Stub<T>")]
 	public void Test001()
 	{
 		ComponentFactories.AddStub<CompA>();
@@ -18,7 +18,7 @@ public class StubComponentFactoryTest : TestContext
 		cut.HasComponent<Stub<CompA>>().ShouldBeTrue();
 	}
 
-	[Fact(DisplayName = "AddStub<T> replaces U:T with Stub<U>")]
+	[UIFact(DisplayName = "AddStub<T> replaces U:T with Stub<U>")]
 	public void Test002()
 	{
 		ComponentFactories.AddStub<CompA>();
@@ -28,7 +28,7 @@ public class StubComponentFactoryTest : TestContext
 		cut.HasComponent<Stub<CompDerivedA>>().ShouldBeTrue();
 	}
 
-	[Theory(DisplayName = "AddStub(markup) replaces types with markup")]
+	[UITheory(DisplayName = "AddStub(markup) replaces types with markup")]
 	[AutoData]
 	public void Test010(string randomText)
 	{
@@ -40,7 +40,7 @@ public class StubComponentFactoryTest : TestContext
 		cut.MarkupMatches($"<h1>{randomText}</h1>");
 	}
 
-	[Theory(DisplayName = "AddStub(renderFragment) replaces types with markup")]
+	[UITheory(DisplayName = "AddStub(renderFragment) replaces types with markup")]
 	[AutoData]
 	public void Test011(string randomText)
 	{
@@ -52,7 +52,7 @@ public class StubComponentFactoryTest : TestContext
 		cut.MarkupMatches($"<h1>{randomText}</h1>");
 	}
 
-	[Theory(DisplayName = "AddStub<T>(Func<params, string>) replaces types with Stub that output from render fragment")]
+	[UITheory(DisplayName = "AddStub<T>(Func<params, string>) replaces types with Stub that output from render fragment")]
 	[AutoData]
 	public void Test0042(string regularParamValue)
 	{
@@ -64,7 +64,7 @@ public class StubComponentFactoryTest : TestContext
 		cut.MarkupMatches($"<div>{regularParamValue}</div>");
 	}
 
-	[Theory(DisplayName = "AddStub<T>(renderFragment<params>) replaces types with Stub that output from render fragment")]
+	[UITheory(DisplayName = "AddStub<T>(renderFragment<params>) replaces types with Stub that output from render fragment")]
 	[AutoData]
 	public void Test004(string regularParamValue)
 	{
@@ -78,7 +78,7 @@ public class StubComponentFactoryTest : TestContext
 		cut.MarkupMatches($"<div>{regularParamValue}</div>");
 	}
 
-	[Fact(DisplayName = "AddStub(predicate) replaces types that matches predicate")]
+	[UIFact(DisplayName = "AddStub(predicate) replaces types that matches predicate")]
 	public void Test003()
 	{
 		ComponentFactories.AddStub(componentType => componentType == typeof(CompA));
@@ -88,7 +88,7 @@ public class StubComponentFactoryTest : TestContext
 		cut.HasComponent<Stub<CompA>>().ShouldBeTrue();
 	}
 
-	[Theory(DisplayName = "AddStub(predicate, markup) replaces types that matches predicate with markup")]
+	[UITheory(DisplayName = "AddStub(predicate, markup) replaces types that matches predicate with markup")]
 	[AutoData]
 	public void Test023(string randomText)
 	{
@@ -100,7 +100,7 @@ public class StubComponentFactoryTest : TestContext
 		cut.MarkupMatches($"<h1>{randomText}</h1>");
 	}
 
-	[Theory(DisplayName = "AddStub(predicate, markup) replaces types that matches predicate with markup")]
+	[UITheory(DisplayName = "AddStub(predicate, markup) replaces types that matches predicate with markup")]
 	[AutoData]
 	public void Test024(string randomText)
 	{

--- a/tests/bunit.web.tests/EventDispatchExtensions/ClipboardEventDispatchExtensionsTest.cs
+++ b/tests/bunit.web.tests/EventDispatchExtensions/ClipboardEventDispatchExtensionsTest.cs
@@ -4,7 +4,7 @@ public class ClipboardEventDispatchExtensionsTest : EventDispatchExtensionsTest<
 {
 	protected override string ElementName => "textarea";
 
-	[Theory(DisplayName = "Clipboard events are raised correctly through helpers")]
+	[UITheory(DisplayName = "Clipboard events are raised correctly through helpers")]
 	[MemberData(nameof(GetEventHelperMethods), typeof(ClipboardEventDispatchExtensions))]
 	public void CanRaiseEvents(MethodInfo helper)
 	{

--- a/tests/bunit.web.tests/EventDispatchExtensions/DetailsElementEventDispatcherExtensionsTest.cs
+++ b/tests/bunit.web.tests/EventDispatchExtensions/DetailsElementEventDispatcherExtensionsTest.cs
@@ -6,7 +6,7 @@ namespace Bunit.EventDispatchExtensions;
 
 public class DetailsElementEventDispatcherExtensionsTest : TestContext
 {
-	[Fact(DisplayName = "Toggle raises ontoggle events")]
+	[UIFact(DisplayName = "Toggle raises ontoggle events")]
 	public void Test200()
 	{
 		var cut = RenderComponent<ToggleableDetails>();

--- a/tests/bunit.web.tests/EventDispatchExtensions/DragEventDispatchExtensionsTest.cs
+++ b/tests/bunit.web.tests/EventDispatchExtensions/DragEventDispatchExtensionsTest.cs
@@ -4,7 +4,7 @@ public class DragEventDispatchExtensionsTest : EventDispatchExtensionsTest<DragE
 {
 	protected override string ElementName => "textarea";
 
-	[Theory(DisplayName = "Drag events are raised correctly through helpers")]
+	[UITheory(DisplayName = "Drag events are raised correctly through helpers")]
 	[MemberData(nameof(GetEventHelperMethods), typeof(DragEventDispatchExtensions))]
 	public void CanRaiseEvents(MethodInfo helper)
 	{

--- a/tests/bunit.web.tests/EventDispatchExtensions/FocusEventDispatchExtensionsTest.cs
+++ b/tests/bunit.web.tests/EventDispatchExtensions/FocusEventDispatchExtensionsTest.cs
@@ -4,7 +4,7 @@ public class FocusEventDispatchExtensionsTest : EventDispatchExtensionsTest<Focu
 {
 	protected override string ElementName => "p";
 
-	[Theory(DisplayName = "Focus events are raised correctly through helpers")]
+	[UITheory(DisplayName = "Focus events are raised correctly through helpers")]
 	[MemberData(nameof(GetEventHelperMethods), typeof(FocusEventDispatchExtensions))]
 	public void CanRaiseEvents(MethodInfo helper)
 	{

--- a/tests/bunit.web.tests/EventDispatchExtensions/GeneralEventDispatchExtensionsTest.cs
+++ b/tests/bunit.web.tests/EventDispatchExtensions/GeneralEventDispatchExtensionsTest.cs
@@ -1,12 +1,18 @@
 using AngleSharp;
 using AngleSharp.Dom;
 using Bunit.Rendering;
+using Xunit.Abstractions;
 
 namespace Bunit;
 
 public class GeneralEventDispatchExtensionsTest : EventDispatchExtensionsTest<EventArgs>
 {
 	protected override string ElementName => "p";
+
+	public GeneralEventDispatchExtensionsTest(ITestOutputHelper outputHelper)
+	{
+		Services.AddXunitLogger(outputHelper);
+	}
 
 	[Theory(DisplayName = "General events are raised correctly through helpers")]
 	[MemberData(nameof(GetEventHelperMethods), typeof(GeneralEventDispatchExtensions))]

--- a/tests/bunit.web.tests/EventDispatchExtensions/GeneralEventDispatchExtensionsTest.cs
+++ b/tests/bunit.web.tests/EventDispatchExtensions/GeneralEventDispatchExtensionsTest.cs
@@ -14,7 +14,7 @@ public class GeneralEventDispatchExtensionsTest : EventDispatchExtensionsTest<Ev
 		Services.AddXunitLogger(outputHelper);
 	}
 
-	[Theory(DisplayName = "General events are raised correctly through helpers")]
+	[UITheory(DisplayName = "General events are raised correctly through helpers")]
 	[MemberData(nameof(GetEventHelperMethods), typeof(GeneralEventDispatchExtensions))]
 	public void CanRaiseEvents(MethodInfo helper)
 	{
@@ -27,7 +27,7 @@ public class GeneralEventDispatchExtensionsTest : EventDispatchExtensionsTest<Ev
 		VerifyEventRaisesCorrectly(helper, EventArgs.Empty);
 	}
 
-	[Fact(DisplayName = "TriggerEventAsync throws element is null")]
+	[UIFact(DisplayName = "TriggerEventAsync throws element is null")]
 	public void Test001()
 	{
 		IElement elm = default!;
@@ -35,7 +35,7 @@ public class GeneralEventDispatchExtensionsTest : EventDispatchExtensionsTest<Ev
 			.ParamName.ShouldBe("element");
 	}
 
-	[Fact(DisplayName = "TriggerEventAsync throws if element does not contain an attribute with the blazor event-name")]
+	[UIFact(DisplayName = "TriggerEventAsync throws if element does not contain an attribute with the blazor event-name")]
 	public void Test002()
 	{
 		var cut = RenderComponent<Simple1>();
@@ -43,7 +43,7 @@ public class GeneralEventDispatchExtensionsTest : EventDispatchExtensionsTest<Ev
 		Should.Throw<MissingEventHandlerException>(() => cut.Find("h1").Click());
 	}
 
-	[Fact(DisplayName = "TriggerEventAsync throws if element was not rendered through blazor (has a TestRendere in its context)")]
+	[UIFact(DisplayName = "TriggerEventAsync throws if element was not rendered through blazor (has a TestRendere in its context)")]
 	public void Test003()
 	{
 		var elmMock = new Mock<IElement>();
@@ -58,7 +58,7 @@ public class GeneralEventDispatchExtensionsTest : EventDispatchExtensionsTest<Ev
 		Should.Throw<InvalidOperationException>(() => elmMock.Object.TriggerEventAsync("click", EventArgs.Empty));
 	}
 
-	[Fact(DisplayName = "When clicking on an element with an event handler, " +
+	[UIFact(DisplayName = "When clicking on an element with an event handler, " +
 						"event handlers higher up the DOM tree is also triggered")]
 	public void Test100()
 	{
@@ -70,7 +70,7 @@ public class GeneralEventDispatchExtensionsTest : EventDispatchExtensionsTest<Ev
 		cut.Instance.HeaderClickCount.ShouldBe(1);
 	}
 
-	[Fact(DisplayName = "When clicking on an element without an event handler attached, " +
+	[UIFact(DisplayName = "When clicking on an element without an event handler attached, " +
 						"event handlers higher up the DOM tree is triggered")]
 	public void Test101()
 	{
@@ -82,7 +82,7 @@ public class GeneralEventDispatchExtensionsTest : EventDispatchExtensionsTest<Ev
 		cut.Instance.HeaderClickCount.ShouldBe(1);
 	}
 
-	[Theory(DisplayName = "When clicking element with non-bubbling events, the event does not bubble")]
+	[UITheory(DisplayName = "When clicking element with non-bubbling events, the event does not bubble")]
 	[InlineData("onabort")]
 	[InlineData("onblur")]
 	[InlineData("onchange")]
@@ -115,7 +115,7 @@ public class GeneralEventDispatchExtensionsTest : EventDispatchExtensionsTest<Ev
 		cut.Instance.GrandParentTriggerCount.ShouldBe(0);
 	}
 
-	[Fact(DisplayName = "When event has StopPropergation modifier, events does not bubble from target")]
+	[UIFact(DisplayName = "When event has StopPropergation modifier, events does not bubble from target")]
 	public async Task Test111()
 	{
 		var cut = RenderComponent<EventBubbles>(ps => ps
@@ -129,7 +129,7 @@ public class GeneralEventDispatchExtensionsTest : EventDispatchExtensionsTest<Ev
 		cut.Instance.GrandParentTriggerCount.ShouldBe(0);
 	}
 
-	[Fact(DisplayName = "When event has StopPropergation modifier, events does not bubble from parent of target")]
+	[UIFact(DisplayName = "When event has StopPropergation modifier, events does not bubble from parent of target")]
 	public async Task Test112()
 	{
 		var cut = RenderComponent<EventBubbles>(ps => ps
@@ -143,7 +143,7 @@ public class GeneralEventDispatchExtensionsTest : EventDispatchExtensionsTest<Ev
 		cut.Instance.GrandParentTriggerCount.ShouldBe(0);
 	}
 
-	[Theory(DisplayName = "Disabled input elements does not bubble for event type"), PairwiseData]
+	[UITheory(DisplayName = "Disabled input elements does not bubble for event type"), PairwiseData]
 	public async Task Test113(
 		[CombinatorialValues("onclick", "ondblclick", "onmousedown", "onmousemove", "onmouseup")] string eventName,
 		[CombinatorialValues("button", "input", "textarea", "select")] string elementType)
@@ -160,7 +160,7 @@ public class GeneralEventDispatchExtensionsTest : EventDispatchExtensionsTest<Ev
 		cut.Instance.GrandParentTriggerCount.ShouldBe(0);
 	}
 
-	[Theory(DisplayName = "Enabled input elements does not bubble for event type"), PairwiseData]
+	[UITheory(DisplayName = "Enabled input elements does not bubble for event type"), PairwiseData]
 	public async Task Test114(
 		[CombinatorialValues("onclick", "ondblclick", "onmousedown", "onmousemove", "onmouseup")] string eventName,
 		[CombinatorialValues("button", "input", "textarea", "select")] string elementType)
@@ -177,7 +177,7 @@ public class GeneralEventDispatchExtensionsTest : EventDispatchExtensionsTest<Ev
 		cut.Instance.GrandParentTriggerCount.ShouldBe(1);
 	}
 
-	[Fact(DisplayName = "TriggerEvent can trigger custom events")]
+	[UIFact(DisplayName = "TriggerEvent can trigger custom events")]
 	public void Test201()
 	{
 		var cut = RenderComponent<CustomPasteSample>();
@@ -191,7 +191,7 @@ public class GeneralEventDispatchExtensionsTest : EventDispatchExtensionsTest<Ev
 		cut.Find("p:last-child").MarkupMatches("<p>You pasted: FOO</p>");
 	}
 
-	[Fact(DisplayName = "TriggerEventAsync throws NoEventHandlerException when invoked with an unknown event handler ID")]
+	[UIFact(DisplayName = "TriggerEventAsync throws NoEventHandlerException when invoked with an unknown event handler ID")]
 	public void Test300()
 	{
 		var cut = RenderComponent<ClickRemovesEventHandler>();
@@ -201,7 +201,7 @@ public class GeneralEventDispatchExtensionsTest : EventDispatchExtensionsTest<Ev
 		Should.Throw<UnknownEventHandlerIdException>(() => buttons[1].Click());
 	}
 
-	[Fact(DisplayName = "Removed bubbled event handled NoEventHandlerException are ignored")]
+	[UIFact(DisplayName = "Removed bubbled event handled NoEventHandlerException are ignored")]
 	public void Test301()
 	{
 		var cut = RenderComponent<BubbleEventsRemoveTriggers>();
@@ -216,7 +216,7 @@ public class GeneralEventDispatchExtensionsTest : EventDispatchExtensionsTest<Ev
 		cut.Instance.TopDivClicked.ShouldBeTrue();
 	}
 
-	[Theory(DisplayName = "When bubbling event throws, no other event handlers are triggered")]
+	[UITheory(DisplayName = "When bubbling event throws, no other event handlers are triggered")]
 	[AutoData]
 	public void Test302(string exceptionMessage)
 	{
@@ -230,7 +230,7 @@ public class GeneralEventDispatchExtensionsTest : EventDispatchExtensionsTest<Ev
 		cut.Instance.TopDivClicked.ShouldBeFalse();
 	}
 
-	[Theory(DisplayName = "When event handler throws, the exception is passed up to test")]
+	[UITheory(DisplayName = "When event handler throws, the exception is passed up to test")]
 	[AutoData]
 	public void Test303(string exceptionMessage)
 	{
@@ -240,7 +240,7 @@ public class GeneralEventDispatchExtensionsTest : EventDispatchExtensionsTest<Ev
 			.Message.ShouldBe(exceptionMessage);
 	}
 
-	[Fact(DisplayName = "Should handle click event first and submit form afterwards for button")]
+	[UIFact(DisplayName = "Should handle click event first and submit form afterwards for button")]
 	public void Test304()
 	{
 		var cut = RenderComponent<SubmitFormOnClick>();
@@ -251,7 +251,7 @@ public class GeneralEventDispatchExtensionsTest : EventDispatchExtensionsTest<Ev
 		cut.Instance.Clicked.ShouldBeTrue();
 	}
 
-	[Fact(DisplayName = "Should handle click event first and submit form afterwards for input when type button")]
+	[UIFact(DisplayName = "Should handle click event first and submit form afterwards for input when type button")]
 	public void Test305()
 	{
 		var cut = RenderComponent<SubmitFormOnClick>();
@@ -262,7 +262,7 @@ public class GeneralEventDispatchExtensionsTest : EventDispatchExtensionsTest<Ev
 		cut.Instance.Clicked.ShouldBeTrue();
 	}
 
-	[Fact(DisplayName = "Should throw exception when invoking onsubmit from non form")]
+	[UIFact(DisplayName = "Should throw exception when invoking onsubmit from non form")]
 	public void Test306()
 	{
 		var cut = RenderComponent<OnsubmitButton>();
@@ -275,7 +275,7 @@ public class GeneralEventDispatchExtensionsTest : EventDispatchExtensionsTest<Ev
 
 	// Runs the test multiple times to trigger the race condition
 	// reliably.
-	[Theory(DisplayName = "TriggerEventAsync avoids race condition with DOM tree updates")]
+	[UITheory(DisplayName = "TriggerEventAsync avoids race condition with DOM tree updates")]
 	[MemberData(nameof(GetTenNumbers))]
 	[Trait("Category", "async")]
 	public async Task Test400(int i)
@@ -292,7 +292,7 @@ public class GeneralEventDispatchExtensionsTest : EventDispatchExtensionsTest<Ev
 	// Runs the test multiple times to trigger the race condition
 	// reliably.
 	[SuppressMessage("Style", "IDE0060:Remove unused parameter", Justification = "Needed to trigger multiple reruns of test.")]
-	[Theory(DisplayName = "TriggerEventAsync avoids race condition with DOM tree updates")]
+	[UITheory(DisplayName = "TriggerEventAsync avoids race condition with DOM tree updates")]
 	[MemberData(nameof(GetTenNumbers))]
 	[Trait("Category", "sync")]
 	public async Task Test400_Sync(int i)

--- a/tests/bunit.web.tests/EventDispatchExtensions/InputEventDispatchExtensionsTest.cs
+++ b/tests/bunit.web.tests/EventDispatchExtensions/InputEventDispatchExtensionsTest.cs
@@ -11,7 +11,7 @@ public class InputEventDispatchExtensionsTest : EventDispatchExtensionsTest<Chan
 
 	protected override string ElementName => "input";
 
-	[Theory(DisplayName = "Input events are raised correctly through helpers")]
+	[UITheory(DisplayName = "Input events are raised correctly through helpers")]
 	[MemberData(nameof(Helpers))]
 	public void CanRaiseEvents(MethodInfo helper)
 	{
@@ -23,91 +23,91 @@ public class InputEventDispatchExtensionsTest : EventDispatchExtensionsTest<Chan
 		VerifyEventRaisesCorrectly(helper, expected);
 	}
 
-	[Theory(DisplayName = "Change and Input events are raised correctly"), AutoData]
+	[UITheory(DisplayName = "Change and Input events are raised correctly"), AutoData]
 	public void Test000(string value) => VerifySingleBindValue(value);
 
-	[Theory(DisplayName = "Change and Input events are raised correctly"), AutoData]
+	[UITheory(DisplayName = "Change and Input events are raised correctly"), AutoData]
 	public void Test001(string? value)
 	{
 		VerifySingleBindValue(value);
 		VerifySingleBindValue(default(string));
 	}
 
-	[Theory(DisplayName = "Change and Input events are raised correctly"), AutoData]
+	[UITheory(DisplayName = "Change and Input events are raised correctly"), AutoData]
 	public void Test002(bool value) => VerifySingleBindValue(value);
 
-	[Theory(DisplayName = "Change and Input events are raised correctly"), AutoData]
+	[UITheory(DisplayName = "Change and Input events are raised correctly"), AutoData]
 	public void Test003(bool? value)
 	{
 		VerifySingleBindValue(value);
 		VerifySingleBindValue(default(bool));
 	}
 
-	[Theory(DisplayName = "Change and Input events are raised correctly"), AutoData]
+	[UITheory(DisplayName = "Change and Input events are raised correctly"), AutoData]
 	public void Test004(int value) => VerifySingleBindValue(value);
 
-	[Theory(DisplayName = "Change and Input events are raised correctly"), AutoData]
+	[UITheory(DisplayName = "Change and Input events are raised correctly"), AutoData]
 	public void Test005(int? value)
 	{
 		VerifySingleBindValue(value);
 		VerifySingleBindValue(default(int));
 	}
 
-	[Theory(DisplayName = "Change and Input events are raised correctly"), AutoData]
+	[UITheory(DisplayName = "Change and Input events are raised correctly"), AutoData]
 	public void Test006(long value) => VerifySingleBindValue(value);
 
-	[Theory(DisplayName = "Change and Input events are raised correctly"), AutoData]
+	[UITheory(DisplayName = "Change and Input events are raised correctly"), AutoData]
 	public void Test007(long? value)
 	{
 		VerifySingleBindValue(value);
 		VerifySingleBindValue(default(long));
 	}
 
-	[Theory(DisplayName = "Change and Input events are raised correctly"), AutoData]
+	[UITheory(DisplayName = "Change and Input events are raised correctly"), AutoData]
 	public void Test008(short value) => VerifySingleBindValue(value);
 
-	[Theory(DisplayName = "Change and Input events are raised correctly"), AutoData]
+	[UITheory(DisplayName = "Change and Input events are raised correctly"), AutoData]
 	public void Test009(short? value)
 	{
 		VerifySingleBindValue(value);
 		VerifySingleBindValue(default(short));
 	}
 
-	[Theory(DisplayName = "Change and Input events are raised correctly"), AutoData]
+	[UITheory(DisplayName = "Change and Input events are raised correctly"), AutoData]
 	public void Test010(float value) => VerifySingleBindValue(value);
 
-	[Theory(DisplayName = "Change and Input events are raised correctly"), AutoData]
+	[UITheory(DisplayName = "Change and Input events are raised correctly"), AutoData]
 	public void Test011(float? value)
 	{
 		VerifySingleBindValue(value);
 		VerifySingleBindValue(default(float));
 	}
 
-	[Theory(DisplayName = "Change and Input events are raised correctly"), AutoData]
+	[UITheory(DisplayName = "Change and Input events are raised correctly"), AutoData]
 	public void Test012(double value) => VerifySingleBindValue(value);
 
-	[Theory(DisplayName = "Change and Input events are raised correctly"), AutoData]
+	[UITheory(DisplayName = "Change and Input events are raised correctly"), AutoData]
 	public void Test013(double? value)
 	{
 		VerifySingleBindValue(value);
 		VerifySingleBindValue(default(double));
 	}
 
-	[Theory(DisplayName = "Change and Input events are raised correctly"), AutoData]
+	[UITheory(DisplayName = "Change and Input events are raised correctly"), AutoData]
 	public void Test014(decimal value) => VerifySingleBindValue(value);
 
-	[Theory(DisplayName = "Change and Input events are raised correctly"), AutoData]
+	[UITheory(DisplayName = "Change and Input events are raised correctly"), AutoData]
 	public void Test015(decimal? value)
 	{
 		VerifySingleBindValue(value);
 		VerifySingleBindValue(default(decimal));
 	}
 
-	[Theory(DisplayName = "Change and Input events are raised correctly"), AutoData]
+	[UITheory(DisplayName = "Change and Input events are raised correctly"), AutoData]
 	[UseCulture("en-US")]
 	public void Test016(DateTime value) => VerifySingleBindValue(DateTimeWithoutMillisecond(value));
 
-	[Theory(DisplayName = "Change and Input events are raised correctly"), AutoData]
+	[UITheory(DisplayName = "Change and Input events are raised correctly"), AutoData]
 	[UseCulture("en-US")]
 	public void Test017(DateTime? value)
 	{
@@ -115,11 +115,11 @@ public class InputEventDispatchExtensionsTest : EventDispatchExtensionsTest<Chan
 		VerifySingleBindValue(default(DateTime));
 	}
 
-	[Theory(DisplayName = "Change and Input events are raised correctly"), AutoData]
+	[UITheory(DisplayName = "Change and Input events are raised correctly"), AutoData]
 	[UseCulture("en-US")]
 	public void Test018(DateTimeOffset value) => VerifySingleBindValue(DateTimeWithoutMillisecond(value));
 
-	[Theory(DisplayName = "Change and Input events are raised correctly"), AutoData]
+	[UITheory(DisplayName = "Change and Input events are raised correctly"), AutoData]
 	[UseCulture("en-US")]
 	public void Test019(DateTimeOffset? value)
 	{
@@ -127,112 +127,112 @@ public class InputEventDispatchExtensionsTest : EventDispatchExtensionsTest<Chan
 		VerifySingleBindValue(default(DateTimeOffset));
 	}
 
-	[Theory(DisplayName = "Change and Input events are raised correctly"), AutoData]
+	[UITheory(DisplayName = "Change and Input events are raised correctly"), AutoData]
 	public void Test020(Foo value) => VerifySingleBindValue(value);
 
-	[Theory(DisplayName = "Change and Input events are raised correctly"), AutoData]
+	[UITheory(DisplayName = "Change and Input events are raised correctly"), AutoData]
 	public void Test021(Foo? value)
 		=> VerifySingleBindValue(value);
 
-	[Fact(DisplayName = "Change and Input events are raised correctly for null object")]
+	[UIFact(DisplayName = "Change and Input events are raised correctly for null object")]
 	public void Test022()
 		=> VerifySingleBindValue(default(Foo));
 
-	[Theory(DisplayName = "Change and Input events are raised correctly"), AutoData]
+	[UITheory(DisplayName = "Change and Input events are raised correctly"), AutoData]
 	public void Test023(Cars value) => VerifySingleBindValue(value);
 
-	[Theory(DisplayName = "Change and Input events are raised correctly"), AutoData]
+	[UITheory(DisplayName = "Change and Input events are raised correctly"), AutoData]
 	public void Test024(Cars? value)
 	{
 		VerifySingleBindValue(value);
 		VerifySingleBindValue(default(Cars));
 	}
 
-	[Theory(DisplayName = "Change and Input events are raised correctly"), AutoData]
+	[UITheory(DisplayName = "Change and Input events are raised correctly"), AutoData]
 	public void Test100(string[] values) => VerifyMultipleBindValue(values);
 
-	[Theory(DisplayName = "Change and Input events are raised correctly"), AutoData]
+	[UITheory(DisplayName = "Change and Input events are raised correctly"), AutoData]
 	public void Test101(string?[] values)
 	{
 		VerifyMultipleBindValue(values);
 		VerifyMultipleBindValue(new string?[] { default(string), default(string) });
 	}
 
-	[Theory(DisplayName = "Change and Input events are raised correctly"), AutoData]
+	[UITheory(DisplayName = "Change and Input events are raised correctly"), AutoData]
 	public void Test102(bool[] values) => VerifyMultipleBindValue(values);
 
-	[Theory(DisplayName = "Change and Input events are raised correctly"), AutoData]
+	[UITheory(DisplayName = "Change and Input events are raised correctly"), AutoData]
 	public void Test103(bool?[] values)
 	{
 		VerifyMultipleBindValue(values);
 		VerifyMultipleBindValue(new bool?[] { default(bool), default(bool) });
 	}
 
-	[Theory(DisplayName = "Change and Input events are raised correctly"), AutoData]
+	[UITheory(DisplayName = "Change and Input events are raised correctly"), AutoData]
 	public void Test104(int[] value) => VerifyMultipleBindValue(value);
 
-	[Theory(DisplayName = "Change and Input events are raised correctly"), AutoData]
+	[UITheory(DisplayName = "Change and Input events are raised correctly"), AutoData]
 	public void Test105(int?[] values)
 	{
 		VerifyMultipleBindValue(values);
 		VerifyMultipleBindValue(new int?[] { default(int), default(int) });
 	}
 
-	[Theory(DisplayName = "Change and Input events are raised correctly"), AutoData]
+	[UITheory(DisplayName = "Change and Input events are raised correctly"), AutoData]
 	public void Test106(long[] values) => VerifyMultipleBindValue(values);
 
-	[Theory(DisplayName = "Change and Input events are raised correctly"), AutoData]
+	[UITheory(DisplayName = "Change and Input events are raised correctly"), AutoData]
 	public void Test107(long?[] values)
 	{
 		VerifyMultipleBindValue(values);
 		VerifyMultipleBindValue(new long?[] { default(long), default(long) });
 	}
 
-	[Theory(DisplayName = "Change and Input events are raised correctly"), AutoData]
+	[UITheory(DisplayName = "Change and Input events are raised correctly"), AutoData]
 	public void Test108(short[] values) => VerifyMultipleBindValue(values);
 
-	[Theory(DisplayName = "Change and Input events are raised correctly"), AutoData]
+	[UITheory(DisplayName = "Change and Input events are raised correctly"), AutoData]
 	public void Test109(short?[] values)
 	{
 		VerifyMultipleBindValue(values);
 		VerifyMultipleBindValue(new short?[] { default(short), default(short) });
 	}
 
-	[Theory(DisplayName = "Change and Input events are raised correctly"), AutoData]
+	[UITheory(DisplayName = "Change and Input events are raised correctly"), AutoData]
 	public void Test110(float[] values) => VerifyMultipleBindValue(values);
 
-	[Theory(DisplayName = "Change and Input events are raised correctly"), AutoData]
+	[UITheory(DisplayName = "Change and Input events are raised correctly"), AutoData]
 	public void Test111(float?[] values)
 	{
 		VerifyMultipleBindValue(values);
 		VerifyMultipleBindValue(new float?[] { default(float), default(float) });
 	}
 
-	[Theory(DisplayName = "Change and Input events are raised correctly"), AutoData]
+	[UITheory(DisplayName = "Change and Input events are raised correctly"), AutoData]
 	public void Test112(double[] values) => VerifyMultipleBindValue(values);
 
-	[Theory(DisplayName = "Change and Input events are raised correctly"), AutoData]
+	[UITheory(DisplayName = "Change and Input events are raised correctly"), AutoData]
 	public void Test113(double?[] values)
 	{
 		VerifyMultipleBindValue(values);
 		VerifyMultipleBindValue(new double?[] { default(double), default(double) });
 	}
 
-	[Theory(DisplayName = "Change and Input events are raised correctly"), AutoData]
+	[UITheory(DisplayName = "Change and Input events are raised correctly"), AutoData]
 	public void Test114(decimal[] values) => VerifyMultipleBindValue(values);
 
-	[Theory(DisplayName = "Change and Input events are raised correctly"), AutoData]
+	[UITheory(DisplayName = "Change and Input events are raised correctly"), AutoData]
 	public void Test115(decimal?[] values)
 	{
 		VerifyMultipleBindValue(values);
 		VerifyMultipleBindValue(new decimal?[] { default(decimal), default(decimal) });
 	}
 
-	[Theory(DisplayName = "Change and Input events are raised correctly"), AutoData]
+	[UITheory(DisplayName = "Change and Input events are raised correctly"), AutoData]
 	[UseCulture("en-US")]
 	public void Test116(DateTime[] values) => VerifyMultipleBindValue(DateTimeWithoutMillisecond(values));
 
-	[Theory(DisplayName = "Change and Input events are raised correctly"), AutoData]
+	[UITheory(DisplayName = "Change and Input events are raised correctly"), AutoData]
 	[UseCulture("en-US")]
 	public void Test117(DateTime?[] values)
 	{
@@ -240,11 +240,11 @@ public class InputEventDispatchExtensionsTest : EventDispatchExtensionsTest<Chan
 		VerifyMultipleBindValue(new DateTime?[] { default(DateTime), default(DateTime) });
 	}
 
-	[Theory(DisplayName = "Change and Input events are raised correctly"), AutoData]
+	[UITheory(DisplayName = "Change and Input events are raised correctly"), AutoData]
 	[UseCulture("en-US")]
 	public void Test118(DateTimeOffset[] values) => VerifyMultipleBindValue(DateTimeWithoutMillisecond(values));
 
-	[Theory(DisplayName = "Change and Input events are raised correctly"), AutoData]
+	[UITheory(DisplayName = "Change and Input events are raised correctly"), AutoData]
 	[UseCulture("en-US")]
 	public void Test119(DateTimeOffset?[] values)
 	{
@@ -252,10 +252,10 @@ public class InputEventDispatchExtensionsTest : EventDispatchExtensionsTest<Chan
 		VerifyMultipleBindValue(new DateTimeOffset?[] { default(DateTimeOffset), default(DateTimeOffset) });
 	}
 
-	[Theory(DisplayName = "Change and Input events are raised correctly"), AutoData]
+	[UITheory(DisplayName = "Change and Input events are raised correctly"), AutoData]
 	public void Test123(Cars[] values) => VerifyMultipleBindValue(values);
 
-	[Theory(DisplayName = "Change and Input events are raised correctly"), AutoData]
+	[UITheory(DisplayName = "Change and Input events are raised correctly"), AutoData]
 	public void Test124(Cars?[] values)
 	{
 		VerifyMultipleBindValue(values);

--- a/tests/bunit.web.tests/EventDispatchExtensions/KeyTest.cs
+++ b/tests/bunit.web.tests/EventDispatchExtensions/KeyTest.cs
@@ -25,7 +25,7 @@ public class KeyTest
 
 	public static IEnumerable<object[]> KeyboardEventArgsTestData { get; } = GetKeyboardEventArgsTestData();
 
-	[Theory(DisplayName = "Get method with value parameter should return initialized Key object")]
+	[UITheory(DisplayName = "Get method with value parameter should return initialized Key object")]
 	[MemberData(nameof(KeyValueTestData))]
 	public void GetWithValue(string value)
 	{
@@ -38,7 +38,7 @@ public class KeyTest
 		key.CommandKey.ShouldBeFalse();
 	}
 
-	[Theory(DisplayName = "Get method with empty value parameter should throw exception")]
+	[UITheory(DisplayName = "Get method with empty value parameter should throw exception")]
 	[InlineData(null)]
 	[InlineData("")]
 	public void GetWithNullValue(string value)
@@ -46,7 +46,7 @@ public class KeyTest
 		Should.Throw<ArgumentNullException>(() => Key.Get(value));
 	}
 
-	[Theory(DisplayName = "Casting from string should return initialized Key object")]
+	[UITheory(DisplayName = "Casting from string should return initialized Key object")]
 	[MemberData(nameof(KeyValueTestData))]
 	public void CanCastFromString(string value)
 	{
@@ -59,7 +59,7 @@ public class KeyTest
 		key.CommandKey.ShouldBeFalse();
 	}
 
-	[Theory(DisplayName = "Casting from null or empty string throws ArgumentNullException")]
+	[UITheory(DisplayName = "Casting from null or empty string throws ArgumentNullException")]
 	[InlineData(null)]
 	[InlineData("")]
 	public void CastingFromNullStringThrowsException(string value)
@@ -67,7 +67,7 @@ public class KeyTest
 		Should.Throw<ArgumentNullException>(() => (Key)value);
 	}
 
-	[Theory(DisplayName = "Get method with value and code parameters should return initialized Key object")]
+	[UITheory(DisplayName = "Get method with value and code parameters should return initialized Key object")]
 	[InlineData(" ", " ")]
 	[InlineData("x", "x")]
 	[InlineData("A", "A")]
@@ -95,7 +95,7 @@ public class KeyTest
 		key.CommandKey.ShouldBeFalse();
 	}
 
-	[Theory(DisplayName = "Get method with empty value or code should throw exception")]
+	[UITheory(DisplayName = "Get method with empty value or code should throw exception")]
 	[InlineData(null, "")]
 	[InlineData("", null)]
 	[InlineData(null, "t")]
@@ -107,7 +107,7 @@ public class KeyTest
 		Should.Throw<ArgumentNullException>(() => Key.Get(value, code));
 	}
 
-	[Theory(DisplayName = "Get with char value should return initialized Key object")]
+	[UITheory(DisplayName = "Get with char value should return initialized Key object")]
 	[MemberData(nameof(CharTestData))]
 	public void GetFromChar(char value)
 	{
@@ -120,7 +120,7 @@ public class KeyTest
 		key.CommandKey.ShouldBeFalse();
 	}
 
-	[Theory(DisplayName = "Casting from char should return initialized Key object")]
+	[UITheory(DisplayName = "Casting from char should return initialized Key object")]
 	[MemberData(nameof(CharTestData))]
 	public void CanCastFromChar(char value)
 	{
@@ -133,7 +133,7 @@ public class KeyTest
 		key.CommandKey.ShouldBeFalse();
 	}
 
-	[Fact(DisplayName = "Get method returns same instances for predefined keys")]
+	[UIFact(DisplayName = "Get method returns same instances for predefined keys")]
 	public void GetPredefinedKeys()
 	{
 		var keyType = typeof(Key);
@@ -148,7 +148,7 @@ public class KeyTest
 		}
 	}
 
-	[Theory(DisplayName = "Keys with same values should be equal")]
+	[UITheory(DisplayName = "Keys with same values should be equal")]
 	[MemberData(nameof(EqualsTestData))]
 	public void EqualsShouldBeTrueForSameKeys(Key key1, Key key2)
 	{
@@ -162,7 +162,7 @@ public class KeyTest
 		(key2 != key1).ShouldBeFalse();
 	}
 
-	[Theory(DisplayName = "Keys with same values should have same hash code")]
+	[UITheory(DisplayName = "Keys with same values should have same hash code")]
 	[MemberData(nameof(EqualsTestData))]
 	public void SameHashCode(Key key1, Key key2)
 	{
@@ -171,7 +171,7 @@ public class KeyTest
 		hashCode1.ShouldBe(hashCode2);
 	}
 
-	[Fact(DisplayName = "Null keys should be equal")]
+	[UIFact(DisplayName = "Null keys should be equal")]
 	public void NullsAreEqual()
 	{
 		Key? key1 = default;
@@ -182,7 +182,7 @@ public class KeyTest
 		(key2 != key1).ShouldBeFalse();
 	}
 
-	[Theory(DisplayName = "Keys with different values should not be equal")]
+	[UITheory(DisplayName = "Keys with different values should not be equal")]
 	[MemberData(nameof(NonEqualsTestData))]
 	public void EqualsShouldBeFalseForDifferentKeys(Key? key1, Key? key2)
 	{
@@ -205,7 +205,7 @@ public class KeyTest
 	}
 
 	// This may be flaky test. Hash codes can have collisions.
-	[Theory(DisplayName = "Keys with different values should have different hash codes")]
+	[UITheory(DisplayName = "Keys with different values should have different hash codes")]
 	[MemberData(nameof(NonEqualsTestData))]
 	public void DifferentHashCodes(Key? key1, Key? key2)
 	{
@@ -214,14 +214,14 @@ public class KeyTest
 		hashCode1.ShouldNotBe(hashCode2);
 	}
 
-	[Theory(DisplayName = "Key should not be equal to different object type")]
+	[UITheory(DisplayName = "Key should not be equal to different object type")]
 	[MemberData(nameof(KeyAndObjectTestData))]
 	public void KeyShouldBeDifferentFromObject(Key key, object other)
 	{
 		key.Equals(other).ShouldBeFalse();
 	}
 
-	[Theory(DisplayName = "WithControlKey should set ControlKey flag")]
+	[UITheory(DisplayName = "WithControlKey should set ControlKey flag")]
 	[MemberData(nameof(KeyWithModifiersTestData))]
 	public void WithControlKey(Key key, bool flag)
 	{
@@ -235,7 +235,7 @@ public class KeyTest
 		result.CommandKey.ShouldBe(key.CommandKey);
 	}
 
-	[Theory(DisplayName = "WithShiftKey should set ShiftKey flag")]
+	[UITheory(DisplayName = "WithShiftKey should set ShiftKey flag")]
 	[MemberData(nameof(KeyWithModifiersTestData))]
 	public void WithShiftKey(Key key, bool flag)
 	{
@@ -249,7 +249,7 @@ public class KeyTest
 		result.CommandKey.ShouldBe(key.CommandKey);
 	}
 
-	[Theory(DisplayName = "WithAltKey should set AltKey flag")]
+	[UITheory(DisplayName = "WithAltKey should set AltKey flag")]
 	[MemberData(nameof(KeyWithModifiersTestData))]
 	public void WithAltKey(Key key, bool flag)
 	{
@@ -263,7 +263,7 @@ public class KeyTest
 		result.CommandKey.ShouldBe(key.CommandKey);
 	}
 
-	[Theory(DisplayName = "WithCommandKey should set CommandKey flag")]
+	[UITheory(DisplayName = "WithCommandKey should set CommandKey flag")]
 	[MemberData(nameof(KeyWithModifiersTestData))]
 	public void WithCommandKey(Key key, bool flag)
 	{
@@ -277,7 +277,7 @@ public class KeyTest
 		result.CommandKey.ShouldBe(flag);
 	}
 
-	[Theory(DisplayName = "Combine key and key modifier should return key with modifier set")]
+	[UITheory(DisplayName = "Combine key and key modifier should return key with modifier set")]
 	[MemberData(nameof(MainKeyAndModifierKeyTestData))]
 	public void Combine2Keys(Key mainKey, Key keyModifier, bool controlKey, bool shiftKey, bool altKey, bool commandKey)
 	{
@@ -297,7 +297,7 @@ public class KeyTest
 		}
 	}
 
-	[Theory(DisplayName = "Combine key with null should return the same key")]
+	[UITheory(DisplayName = "Combine key with null should return the same key")]
 	[MemberData(nameof(MainKeyToCombineTestData))]
 	public void CombineKeyWithNull(Key key)
 	{
@@ -306,7 +306,7 @@ public class KeyTest
 		(null! + key).ShouldBeSameAs(key);
 	}
 
-	[Theory(DisplayName = "Combine 2 main keys should throw ArgumentException")]
+	[UITheory(DisplayName = "Combine 2 main keys should throw ArgumentException")]
 	[MemberData(nameof(Combine2MainKeysTestData))]
 	public void Combine2MainKeys(Key key1, Key key2)
 	{
@@ -316,7 +316,7 @@ public class KeyTest
 		Should.Throw<ArgumentException>(() => key2 + key1);
 	}
 
-	[Theory(DisplayName = "Can convert to KeyboardEventArgs")]
+	[UITheory(DisplayName = "Can convert to KeyboardEventArgs")]
 	[MemberData(nameof(KeyboardEventArgsTestData))]
 	public void ToKeyboardEventArgs(Key key, string value, string code, bool ctrlKey, bool shiftKey, bool altKey, bool metaKey)
 	{
@@ -331,7 +331,7 @@ public class KeyTest
 		result.Type.ShouldBe(null);
 	}
 
-	[Fact(DisplayName = "Can convert null to KeyboardEventArgs")]
+	[UIFact(DisplayName = "Can convert null to KeyboardEventArgs")]
 	public void NullToKeyboardEventArgs()
 	{
 		Key key = null!;

--- a/tests/bunit.web.tests/EventDispatchExtensions/KeyboardEventDispatchExtensionsTest.cs
+++ b/tests/bunit.web.tests/EventDispatchExtensions/KeyboardEventDispatchExtensionsTest.cs
@@ -6,7 +6,7 @@ public class KeyboardEventDispatchExtensionsTest : EventDispatchExtensionsTest<K
 
 	protected override string ElementName => "input";
 
-	[Theory(DisplayName = "Keyboard events are raised correctly through helpers")]
+	[UITheory(DisplayName = "Keyboard events are raised correctly through helpers")]
 	[MemberData(nameof(Helpers))]
 	public void CanRaiseEvents(MethodInfo helper)
 	{
@@ -26,7 +26,7 @@ public class KeyboardEventDispatchExtensionsTest : EventDispatchExtensionsTest<K
 		VerifyEventRaisesCorrectly(helper, expected);
 	}
 
-	[Fact(DisplayName = "KeyDown event is raised correctly through helper using special key")]
+	[UIFact(DisplayName = "KeyDown event is raised correctly through helper using special key")]
 	public void CanRaiseKeyDownWithCtrlEnter()
 	{
 		var spy = CreateTriggerSpy(ElementName, "onkeydown");
@@ -44,7 +44,7 @@ public class KeyboardEventDispatchExtensionsTest : EventDispatchExtensionsTest<K
 		spy.RaisedEvent.ShouldBeEquivalentTo(expected);
 	}
 
-	[Fact(DisplayName = "KeyDown event is raised correctly through helper using character key")]
+	[UIFact(DisplayName = "KeyDown event is raised correctly through helper using character key")]
 	public void CanRaiseKeyDownWithAKey()
 	{
 		var spy = CreateTriggerSpy(ElementName, "onkeydown");
@@ -61,7 +61,7 @@ public class KeyboardEventDispatchExtensionsTest : EventDispatchExtensionsTest<K
 		spy.RaisedEvent.ShouldBeEquivalentTo(expected);
 	}
 
-	[Fact(DisplayName = "KeyDown event is raised correctly through helper specifying repeat and type")]
+	[UIFact(DisplayName = "KeyDown event is raised correctly through helper specifying repeat and type")]
 	public void CanRaiseKeyDownWithRepeatAndType()
 	{
 		var spy = CreateTriggerSpy(ElementName, "onkeydown");
@@ -81,7 +81,7 @@ public class KeyboardEventDispatchExtensionsTest : EventDispatchExtensionsTest<K
 		spy.RaisedEvent.ShouldBeEquivalentTo(expected);
 	}
 
-	[Fact(DisplayName = "KeyUp event is raised correctly through helper using special key")]
+	[UIFact(DisplayName = "KeyUp event is raised correctly through helper using special key")]
 	public void CanRaiseKeyUpWithShiftSpace()
 	{
 		var spy = CreateTriggerSpy(ElementName, "onkeyup");
@@ -100,7 +100,7 @@ public class KeyboardEventDispatchExtensionsTest : EventDispatchExtensionsTest<K
 		spy.RaisedEvent.ShouldBeEquivalentTo(expected);
 	}
 
-	[Fact(DisplayName = "KeyUp event is raised correctly through helper using character key")]
+	[UIFact(DisplayName = "KeyUp event is raised correctly through helper using character key")]
 	public void CanRaiseKeyUpWithBKey()
 	{
 		var spy = CreateTriggerSpy(ElementName, "onkeyup");
@@ -118,7 +118,7 @@ public class KeyboardEventDispatchExtensionsTest : EventDispatchExtensionsTest<K
 		spy.RaisedEvent.ShouldBeEquivalentTo(expected);
 	}
 
-	[Fact(DisplayName = "KeyUp event is raised correctly through helper specifying repeat and type")]
+	[UIFact(DisplayName = "KeyUp event is raised correctly through helper specifying repeat and type")]
 	public void CanRaiseKeyUpWithWithRepeatAndType()
 	{
 		var spy = CreateTriggerSpy(ElementName, "onkeyup");
@@ -139,7 +139,7 @@ public class KeyboardEventDispatchExtensionsTest : EventDispatchExtensionsTest<K
 		spy.RaisedEvent.ShouldBeEquivalentTo(expected);
 	}
 
-	[Fact(DisplayName = "KeyPress event is raised correctly through helper using special key")]
+	[UIFact(DisplayName = "KeyPress event is raised correctly through helper using special key")]
 	public void CanRaiseKeyPressWithNum8Key()
 	{
 		var spy = CreateTriggerSpy(ElementName, "onkeypress");
@@ -156,7 +156,7 @@ public class KeyboardEventDispatchExtensionsTest : EventDispatchExtensionsTest<K
 		spy.RaisedEvent.ShouldBeEquivalentTo(expected);
 	}
 
-	[Fact(DisplayName = "KeyPress event is raised correctly through helper using character key")]
+	[UIFact(DisplayName = "KeyPress event is raised correctly through helper using character key")]
 	public void CanRaiseKeyPressWith8Key()
 	{
 		var spy = CreateTriggerSpy(ElementName, "onkeypress");
@@ -173,7 +173,7 @@ public class KeyboardEventDispatchExtensionsTest : EventDispatchExtensionsTest<K
 		spy.RaisedEvent.ShouldBeEquivalentTo(expected);
 	}
 
-	[Fact(DisplayName = "KeyPress event is raised correctly through  specifying repeat and type")]
+	[UIFact(DisplayName = "KeyPress event is raised correctly through  specifying repeat and type")]
 	public void CanRaiseKeyPressWithRepeatAndType()
 	{
 		var spy = CreateTriggerSpy(ElementName, "onkeypress");

--- a/tests/bunit.web.tests/EventDispatchExtensions/MediaEventDispatchExtensionsTest.cs
+++ b/tests/bunit.web.tests/EventDispatchExtensions/MediaEventDispatchExtensionsTest.cs
@@ -4,7 +4,7 @@ public class MediaEventDispatchExtensionsTest : EventDispatchExtensionsTest<Even
 {
 	protected override string ElementName => "audio";
 
-	[Theory(DisplayName = "Media events are raised correctly through helpers")]
+	[UITheory(DisplayName = "Media events are raised correctly through helpers")]
 	[MemberData(nameof(GetEventHelperMethods), typeof(MediaEventDispatchExtensions))]
 	public void CanRaiseEvents(MethodInfo helper)
 	{

--- a/tests/bunit.web.tests/EventDispatchExtensions/MouseEventDispatchExtensionsTest.cs
+++ b/tests/bunit.web.tests/EventDispatchExtensions/MouseEventDispatchExtensionsTest.cs
@@ -10,7 +10,7 @@ public class MouseEventDispatchExtensionsTest : EventDispatchExtensionsTest<Mous
 
 	protected override string ElementName => "button";
 
-	[Theory(DisplayName = "Mouse events are raised correctly through helpers")]
+	[UITheory(DisplayName = "Mouse events are raised correctly through helpers")]
 	[MemberData(nameof(Helpers))]
 	public void CanRaiseEvents(MethodInfo helper)
 	{
@@ -37,7 +37,7 @@ public class MouseEventDispatchExtensionsTest : EventDispatchExtensionsTest<Mous
 		//	(nameof(MouseEventDispatchExtensions.DoubleClick), "ondblclick"));
 	}
 
-	[Fact(DisplayName = "Click sets MouseEventArgs.Detail to 1 by default")]
+	[UIFact(DisplayName = "Click sets MouseEventArgs.Detail to 1 by default")]
 	public void Test001()
 	{
 		var spy = CreateTriggerSpy<MouseEventArgs>("button", "onclick");
@@ -47,7 +47,7 @@ public class MouseEventDispatchExtensionsTest : EventDispatchExtensionsTest<Mous
 		spy.RaisedEvent.Detail.ShouldBe(1);
 	}
 
-	[Fact(DisplayName = "DoubleClick sets MouseEventArgs.Detail to 2 by default")]
+	[UIFact(DisplayName = "DoubleClick sets MouseEventArgs.Detail to 2 by default")]
 	public void Test002()
 	{
 		var spy = CreateTriggerSpy<MouseEventArgs>("button", "ondblclick");
@@ -57,7 +57,7 @@ public class MouseEventDispatchExtensionsTest : EventDispatchExtensionsTest<Mous
 		spy.RaisedEvent.Detail.ShouldBe(2);
 	}
 
-	[Fact(DisplayName = "DoubleClick events are raised correctly through helpers")]
+	[UIFact(DisplayName = "DoubleClick events are raised correctly through helpers")]
 	public void Test003()
 	{
 		var expected = new MouseEventArgs
@@ -82,7 +82,7 @@ public class MouseEventDispatchExtensionsTest : EventDispatchExtensionsTest<Mous
 		spy.RaisedEvent.ShouldBe(expected);
 	}
 
-	[Fact(DisplayName = "DoubleClickAsync events are raised correctly through helpers")]
+	[UIFact(DisplayName = "DoubleClickAsync events are raised correctly through helpers")]
 	public void Test004()
 	{
 		var expected = new MouseEventArgs

--- a/tests/bunit.web.tests/EventDispatchExtensions/PointerEventDispatchExtensionsTest.cs
+++ b/tests/bunit.web.tests/EventDispatchExtensions/PointerEventDispatchExtensionsTest.cs
@@ -4,7 +4,7 @@ public class PointerEventDispatchExtensionsTest : EventDispatchExtensionsTest<Po
 {
 	protected override string ElementName => "div";
 
-	[Theory(DisplayName = "Pointer events are raised correctly through helpers")]
+	[UITheory(DisplayName = "Pointer events are raised correctly through helpers")]
 	[MemberData(nameof(GetEventHelperMethods), typeof(PointerEventDispatchExtensions))]
 	public void CanRaiseEvents(MethodInfo helper)
 	{

--- a/tests/bunit.web.tests/EventDispatchExtensions/ProgressEventDispatchExtensionsTest.cs
+++ b/tests/bunit.web.tests/EventDispatchExtensions/ProgressEventDispatchExtensionsTest.cs
@@ -4,7 +4,7 @@ public class ProgressEventDispatchExtensionsTest : EventDispatchExtensionsTest<P
 {
 	protected override string ElementName => "div";
 
-	[Theory(DisplayName = "Progress events are raised correctly through helpers")]
+	[UITheory(DisplayName = "Progress events are raised correctly through helpers")]
 	[MemberData(nameof(GetEventHelperMethods), typeof(ProgressEventDispatchExtensions))]
 	public void CanRaiseEvents(MethodInfo helper)
 	{

--- a/tests/bunit.web.tests/EventDispatchExtensions/TouchEventDispatchExtensionsTest.cs
+++ b/tests/bunit.web.tests/EventDispatchExtensions/TouchEventDispatchExtensionsTest.cs
@@ -4,7 +4,7 @@ public class TouchEventDispatchExtensionsTest : EventDispatchExtensionsTest<Touc
 {
 	protected override string ElementName => "p";
 
-	[Theory(DisplayName = "Touch events are raised correctly through helpers")]
+	[UITheory(DisplayName = "Touch events are raised correctly through helpers")]
 	[MemberData(nameof(GetEventHelperMethods), typeof(TouchEventDispatchExtensions))]
 	public void CanRaiseEvents(MethodInfo helper)
 	{

--- a/tests/bunit.web.tests/EventDispatchExtensions/WheelEventDispatchExtensionsTest.cs
+++ b/tests/bunit.web.tests/EventDispatchExtensions/WheelEventDispatchExtensionsTest.cs
@@ -7,7 +7,7 @@ public class WheelEventDispatchExtensionsTest : EventDispatchExtensionsTest<Whee
 
 	protected override string ElementName => "button";
 
-	[Theory(DisplayName = "Mouse wheel/wheel events are raised correctly through helpers")]
+	[UITheory(DisplayName = "Mouse wheel/wheel events are raised correctly through helpers")]
 	[MemberData(nameof(Helpers))]
 	public void CanRaiseEvents(MethodInfo helper)
 	{

--- a/tests/bunit.web.tests/Extensions/InputFile/InputFileTests.cs
+++ b/tests/bunit.web.tests/Extensions/InputFile/InputFileTests.cs
@@ -8,7 +8,7 @@ using InputFile = Microsoft.AspNetCore.Components.Forms.InputFile;
 
 public class InputFileTests : TestContext
 {
-	[Fact(DisplayName = "InputFile can upload a single string file")]
+	[UIFact(DisplayName = "InputFile can upload a single string file")]
 	public void Test001()
 	{
 		var cut = RenderComponent<InputFileComponent>();
@@ -23,7 +23,7 @@ public class InputFileTests : TestContext
 		cut.Instance.LastChanged.ShouldBe(lastModified);
 	}
 
-	[Fact(DisplayName = "InputFile can upload a single byte file")]
+	[UIFact(DisplayName = "InputFile can upload a single byte file")]
 	public void Test002()
 	{
 		var cut = RenderComponent<InputFileComponent>();
@@ -34,7 +34,7 @@ public class InputFileTests : TestContext
 		cut.Instance.Content.ShouldBe("Hello World");
 	}
 
-	[Fact(DisplayName = "InputFile can upload multiple files")]
+	[UIFact(DisplayName = "InputFile can upload multiple files")]
 	public void Test003()
 	{
 		var cut = RenderComponent<MultipleInputFileComponent>();
@@ -57,7 +57,7 @@ public class InputFileTests : TestContext
 		cut.Instance.Files[1].Type.ShouldBe("unit");
 	}
 
-	[Fact(DisplayName = "UploadFile throws exception when InputFile is null")]
+	[UIFact(DisplayName = "UploadFile throws exception when InputFile is null")]
 	public void Test004()
 	{
 		Action action = () => ((IRenderedComponent<InputFile>)null).UploadFiles();
@@ -65,7 +65,7 @@ public class InputFileTests : TestContext
 		action.ShouldThrow<ArgumentNullException>();
 	}
 
-	[Fact(DisplayName = "Creating InputFileContent with null text throws exception")]
+	[UIFact(DisplayName = "Creating InputFileContent with null text throws exception")]
 	public void Test005()
 	{
 		Action action = () => InputFileContent.CreateFromText(null);
@@ -73,7 +73,7 @@ public class InputFileTests : TestContext
 		action.ShouldThrow<ArgumentNullException>();
 	}
 
-	[Fact(DisplayName = "Creating InputFileContent with null binary throws exception")]
+	[UIFact(DisplayName = "Creating InputFileContent with null binary throws exception")]
 	public void Test006()
 	{
 		Action action = () => InputFileContent.CreateFromBinary(null);
@@ -81,7 +81,7 @@ public class InputFileTests : TestContext
 		action.ShouldThrow<ArgumentNullException>();
 	}
 
-	[Fact(DisplayName = "Upload no files will result in Exception")]
+	[UIFact(DisplayName = "Upload no files will result in Exception")]
 	public void Test007()
 	{
 		var cut = RenderComponent<InputFileComponent>();
@@ -91,7 +91,7 @@ public class InputFileTests : TestContext
 		act.ShouldThrow<ArgumentException>();
 	}
 
-	[Fact(DisplayName = "Setting up InputFile will not overwrite bUnit default")]
+	[UIFact(DisplayName = "Setting up InputFile will not overwrite bUnit default")]
 	public void Test008()
 	{
 		JSInterop.SetupVoid("Blazor._internal.InputFile.init").SetException(new Exception());

--- a/tests/bunit.web.tests/Extensions/RefreshableQueryCollectionTest.cs
+++ b/tests/bunit.web.tests/Extensions/RefreshableQueryCollectionTest.cs
@@ -2,7 +2,7 @@ namespace Bunit;
 
 public class RefreshableQueryCollectionTest : TestContext
 {
-	[Fact(DisplayName = "When the query returns no elements, the collection is empty")]
+	[UIFact(DisplayName = "When the query returns no elements, the collection is empty")]
 	public void Test001()
 	{
 		var cut = RenderComponent<Simple1>();
@@ -12,7 +12,7 @@ public class RefreshableQueryCollectionTest : TestContext
 		sut.ShouldBeEmpty();
 	}
 
-	[Fact(DisplayName = "When the query returns elements, the collection contains those elements")]
+	[UIFact(DisplayName = "When the query returns elements, the collection contains those elements")]
 	public void Test002()
 	{
 		var cut = RenderComponent<Simple1>();
@@ -23,7 +23,7 @@ public class RefreshableQueryCollectionTest : TestContext
 		sut[0].TagName.ShouldBe("H1");
 	}
 
-	[Fact(DisplayName = "When Refresh is called, the query is run again and new elements are made available")]
+	[UIFact(DisplayName = "When Refresh is called, the query is run again and new elements are made available")]
 	public void Test003()
 	{
 		var cut = RenderComponent<ClickAddsLi>();
@@ -36,7 +36,7 @@ public class RefreshableQueryCollectionTest : TestContext
 		sut.Count.ShouldBe(1);
 	}
 
-	[Fact(DisplayName = "Enabling auto refresh automatically refreshes query when the rendered fragment renders and has changes")]
+	[UIFact(DisplayName = "Enabling auto refresh automatically refreshes query when the rendered fragment renders and has changes")]
 	public void Test004()
 	{
 		var cut = RenderComponent<ClickAddsLi>();
@@ -48,7 +48,7 @@ public class RefreshableQueryCollectionTest : TestContext
 		sut.Count.ShouldBe(1);
 	}
 
-	[Fact(DisplayName = "Disabling auto refresh turns off automatic refreshing queries on when rendered fragment changes")]
+	[UIFact(DisplayName = "Disabling auto refresh turns off automatic refreshing queries on when rendered fragment changes")]
 	public void Test005()
 	{
 		var cut = RenderComponent<ClickAddsLi>();

--- a/tests/bunit.web.tests/Extensions/RefreshingWrappedElementTest.cs
+++ b/tests/bunit.web.tests/Extensions/RefreshingWrappedElementTest.cs
@@ -2,7 +2,7 @@ namespace Bunit.Extensions;
 
 public class RefreshingWrappedElementTest : TestContext
 {
-	[Fact(DisplayName = "Find() throws when element doesn't exist in DOM")]
+	[UIFact(DisplayName = "Find() throws when element doesn't exist in DOM")]
 	public void Test001()
 	{
 		var cut = RenderComponent<Markup>(ps => ps.Add(p => p.Base, "None"));
@@ -10,7 +10,7 @@ public class RefreshingWrappedElementTest : TestContext
 		Should.Throw<ElementNotFoundException>(() => cut.Find("div"));
 	}
 
-	[Fact(DisplayName = "Find() returns the single matching element in DOM")]
+	[UIFact(DisplayName = "Find() returns the single matching element in DOM")]
 	public void Test010()
 	{
 		var expected = "<div>foo</div>";
@@ -21,7 +21,7 @@ public class RefreshingWrappedElementTest : TestContext
 		actual.MarkupMatches(expected);
 	}
 
-	[Fact(DisplayName = "Find() returns first matching element in DOM")]
+	[UIFact(DisplayName = "Find() returns first matching element in DOM")]
 	public void Test011()
 	{
 		var expected = "<div>foo</div>";
@@ -35,7 +35,7 @@ public class RefreshingWrappedElementTest : TestContext
 		actual.MarkupMatches(expected);
 	}
 
-	[Fact(DisplayName = "Find() refreshes the found element on re-renders")]
+	[UIFact(DisplayName = "Find() refreshes the found element on re-renders")]
 	public void Test020()
 	{
 		var cut = RenderComponent<Markup>(ps => ps
@@ -55,7 +55,7 @@ public class RefreshingWrappedElementTest : TestContext
 		elm.TextContent.ShouldBe("bar");
 	}
 
-	[Fact(DisplayName = "Found element doesn't throw when it's removed from DOM")]
+	[UIFact(DisplayName = "Found element doesn't throw when it's removed from DOM")]
 	public void Test030()
 	{
 		var cut = RenderComponent<HidesButton>();
@@ -65,7 +65,7 @@ public class RefreshingWrappedElementTest : TestContext
 		Should.NotThrow(() => btn.Click());
 	}
 
-	[Fact(DisplayName = "Found element throws when its properties or methods are used after it's removed from DOM")]
+	[UIFact(DisplayName = "Found element throws when its properties or methods are used after it's removed from DOM")]
 	public void Test031()
 	{
 		var cut = RenderComponent<HidesButton>();

--- a/tests/bunit.web.tests/Extensions/WaitForHelpers/RenderedFragmentWaitForElementsHelperExtensions.Async.Test.cs
+++ b/tests/bunit.web.tests/Extensions/WaitForHelpers/RenderedFragmentWaitForElementsHelperExtensions.Async.Test.cs
@@ -10,7 +10,7 @@ public class RenderedFragmentWaitForElementsHelperExtensionsAsyncTest : TestCont
 		Services.AddXunitLogger(testOutput);
 	}
 
-	[Fact(DisplayName = "WaitForElement waits until cssSelector returns at a element")]
+	[UIFact(DisplayName = "WaitForElement waits until cssSelector returns at a element")]
 	[Trait("Category", "async")]
 	public async Task Test001()
 	{
@@ -22,7 +22,7 @@ public class RenderedFragmentWaitForElementsHelperExtensionsAsyncTest : TestCont
 		elm.MarkupMatches(expectedMarkup);
 	}
 
-	[Fact(DisplayName = "WaitForElement throws exception after timeout when cssSelector does not result in matching element")]
+	[UIFact(DisplayName = "WaitForElement throws exception after timeout when cssSelector does not result in matching element")]
 	[Trait("Category", "async")]
 	public async Task Test002()
 	{
@@ -34,7 +34,7 @@ public class RenderedFragmentWaitForElementsHelperExtensionsAsyncTest : TestCont
 		expected.Message.ShouldStartWith(WaitForElementHelper.TimeoutBeforeFoundMessage);
 	}
 
-	[Fact(DisplayName = "WaitForElements waits until cssSelector returns at least one element")]
+	[UIFact(DisplayName = "WaitForElements waits until cssSelector returns at least one element")]
 	[Trait("Category", "async")]
 	public async Task Test021()
 	{
@@ -46,7 +46,7 @@ public class RenderedFragmentWaitForElementsHelperExtensionsAsyncTest : TestCont
 		elms.MarkupMatches(expectedMarkup);
 	}
 
-	[Fact(DisplayName = "WaitForElements throws exception after timeout when cssSelector does not result in matching elements")]
+	[UIFact(DisplayName = "WaitForElements throws exception after timeout when cssSelector does not result in matching elements")]
 	[Trait("Category", "async")]
 	public async Task Test022()
 	{
@@ -59,7 +59,7 @@ public class RenderedFragmentWaitForElementsHelperExtensionsAsyncTest : TestCont
 		expected.InnerException.ShouldBeNull();
 	}
 
-	[Fact(DisplayName = "WaitForElements with specific count N throws exception after timeout when cssSelector does not result in N matching elements")]
+	[UIFact(DisplayName = "WaitForElements with specific count N throws exception after timeout when cssSelector does not result in N matching elements")]
 	[Trait("Category", "async")]
 	public async Task Test023()
 	{
@@ -72,7 +72,7 @@ public class RenderedFragmentWaitForElementsHelperExtensionsAsyncTest : TestCont
 		expected.InnerException.ShouldBeNull();
 	}
 
-	[Fact(DisplayName = "WaitForElements with specific count N waits until cssSelector returns at exact N elements")]
+	[UIFact(DisplayName = "WaitForElements with specific count N waits until cssSelector returns at exact N elements")]
 	[Trait("Category", "async")]
 	public async Task Test024()
 	{
@@ -84,7 +84,7 @@ public class RenderedFragmentWaitForElementsHelperExtensionsAsyncTest : TestCont
 		elms.MarkupMatches(expectedMarkup);
 	}
 
-	[Fact(DisplayName = "WaitForElements with specific count 0 waits until cssSelector returns at exact zero elements")]
+	[UIFact(DisplayName = "WaitForElements with specific count 0 waits until cssSelector returns at exact zero elements")]
 	[Trait("Category", "async")]
 	public async Task Test025()
 	{

--- a/tests/bunit.web.tests/Extensions/WaitForHelpers/RenderedFragmentWaitForElementsHelperExtensionsTest.cs
+++ b/tests/bunit.web.tests/Extensions/WaitForHelpers/RenderedFragmentWaitForElementsHelperExtensionsTest.cs
@@ -10,7 +10,7 @@ public class RenderedFragmentWaitForElementsHelperExtensionsTest : TestContext
 		Services.AddXunitLogger(testOutput);
 	}
 
-	[Fact(DisplayName = "WaitForElement waits until cssSelector returns at a element")]
+	[UIFact(DisplayName = "WaitForElement waits until cssSelector returns at a element")]
 	[Trait("Category", "sync")]
 	public void Test001()
 	{
@@ -22,7 +22,7 @@ public class RenderedFragmentWaitForElementsHelperExtensionsTest : TestContext
 		elm.MarkupMatches(expectedMarkup);
 	}
 
-	[Fact(DisplayName = "WaitForElement throws exception after timeout when cssSelector does not result in matching element")]
+	[UIFact(DisplayName = "WaitForElement throws exception after timeout when cssSelector does not result in matching element")]
 	[Trait("Category", "sync")]
 	public void Test002()
 	{
@@ -34,7 +34,7 @@ public class RenderedFragmentWaitForElementsHelperExtensionsTest : TestContext
 		expected.Message.ShouldStartWith(WaitForElementHelper.TimeoutBeforeFoundMessage);
 	}
 
-	[Fact(DisplayName = "WaitForElements waits until cssSelector returns at least one element")]
+	[UIFact(DisplayName = "WaitForElements waits until cssSelector returns at least one element")]
 	[Trait("Category", "sync")]
 	public void Test021()
 	{
@@ -46,7 +46,7 @@ public class RenderedFragmentWaitForElementsHelperExtensionsTest : TestContext
 		elms.MarkupMatches(expectedMarkup);
 	}
 
-	[Fact(DisplayName = "WaitForElements throws exception after timeout when cssSelector does not result in matching elements")]
+	[UIFact(DisplayName = "WaitForElements throws exception after timeout when cssSelector does not result in matching elements")]
 	[Trait("Category", "sync")]
 	public void Test022()
 	{
@@ -59,7 +59,7 @@ public class RenderedFragmentWaitForElementsHelperExtensionsTest : TestContext
 		expected.InnerException.ShouldBeNull();
 	}
 
-	[Fact(DisplayName = "WaitForElements with specific count N throws exception after timeout when cssSelector does not result in N matching elements")]
+	[UIFact(DisplayName = "WaitForElements with specific count N throws exception after timeout when cssSelector does not result in N matching elements")]
 	[Trait("Category", "sync")]
 	public void Test023()
 	{
@@ -72,7 +72,7 @@ public class RenderedFragmentWaitForElementsHelperExtensionsTest : TestContext
 		expected.InnerException.ShouldBeNull();
 	}
 
-	[Fact(DisplayName = "WaitForElements with specific count N waits until cssSelector returns at exact N elements")]
+	[UIFact(DisplayName = "WaitForElements with specific count N waits until cssSelector returns at exact N elements")]
 	[Trait("Category", "sync")]
 	public void Test024()
 	{
@@ -84,7 +84,7 @@ public class RenderedFragmentWaitForElementsHelperExtensionsTest : TestContext
 		elms.MarkupMatches(expectedMarkup);
 	}
 
-	[Fact(DisplayName = "WaitForElements with specific count 0 waits until cssSelector returns at exact zero elements")]
+	[UIFact(DisplayName = "WaitForElements with specific count 0 waits until cssSelector returns at exact zero elements")]
 	[Trait("Category", "sync")]
 	public void Test025()
 	{

--- a/tests/bunit.web.tests/JSInterop/BunitJSInteropTest.cs
+++ b/tests/bunit.web.tests/JSInterop/BunitJSInteropTest.cs
@@ -5,7 +5,7 @@ public class BunitJSInteropTest
 {
 	private static BunitJSInterop CreateSut(JSRuntimeMode mode) => new BunitJSInterop { Mode = mode };
 
-	[Fact(DisplayName = "Mock returns default value in loose mode without invocation setup")]
+	[UIFact(DisplayName = "Mock returns default value in loose mode without invocation setup")]
 	public async Task Test001()
 	{
 		var sut = CreateSut(JSRuntimeMode.Loose);
@@ -15,7 +15,7 @@ public class BunitJSInteropTest
 		result.ShouldBe(default);
 	}
 
-	[Fact(DisplayName = "After invocation a invocation should be visible from the Invocations list")]
+	[UIFact(DisplayName = "After invocation a invocation should be visible from the Invocations list")]
 	public void Test002()
 	{
 		var identifier = "fooFunc";
@@ -31,7 +31,7 @@ public class BunitJSInteropTest
 		invocation.CancellationToken.ShouldBe(cts.Token);
 	}
 
-	[Fact(DisplayName = "Mock throws exception when in strict mode and invocation has not been setup")]
+	[UIFact(DisplayName = "Mock throws exception when in strict mode and invocation has not been setup")]
 	public void Test003()
 	{
 		var sut = CreateSut(JSRuntimeMode.Strict);
@@ -49,7 +49,7 @@ public class BunitJSInteropTest
 				x => x.Arguments.ShouldBe(args));
 	}
 
-	[Fact(DisplayName = "All invocations received AFTER a invocation handler " +
+	[UIFact(DisplayName = "All invocations received AFTER a invocation handler " +
 						"has a result set, receives the same result")]
 	public async Task Test005x()
 	{
@@ -68,7 +68,7 @@ public class BunitJSInteropTest
 		(await i2).ShouldBe(expectedResult);
 	}
 
-	[Fact(DisplayName = "All invocations received BEFORE a invocation handler " +
+	[UIFact(DisplayName = "All invocations received BEFORE a invocation handler " +
 						"has a result set, receives the same result")]
 	public async Task Test005()
 	{
@@ -87,7 +87,7 @@ public class BunitJSInteropTest
 		(await i2).ShouldBe(expectedResult);
 	}
 
-	[Fact(DisplayName = "Invocations receive the latest result set in a invocation handler")]
+	[UIFact(DisplayName = "Invocations receive the latest result set in a invocation handler")]
 	public async Task Test006x()
 	{
 		var identifier = "func";
@@ -107,7 +107,7 @@ public class BunitJSInteropTest
 		(await i2).ShouldBe(expectedResult2);
 	}
 
-	[Fact(DisplayName = "A invocation handler can be canceled for any waiting received invocations")]
+	[UIFact(DisplayName = "A invocation handler can be canceled for any waiting received invocations")]
 	public void Test007()
 	{
 		var identifier = "func";
@@ -120,7 +120,7 @@ public class BunitJSInteropTest
 		invocation.IsCanceled.ShouldBeTrue();
 	}
 
-	[Fact(DisplayName = "A invocation handler can be canceled after it has been set to a different result")]
+	[UIFact(DisplayName = "A invocation handler can be canceled after it has been set to a different result")]
 	public void Test107()
 	{
 		var identifier = "func";
@@ -136,7 +136,7 @@ public class BunitJSInteropTest
 		invocation2.IsCanceled.ShouldBeTrue();
 	}
 
-	[Fact(DisplayName = "A invocation handler can throw an exception for any waiting received invocations")]
+	[UIFact(DisplayName = "A invocation handler can throw an exception for any waiting received invocations")]
 	public async Task Test008()
 	{
 		var identifier = "func";
@@ -152,7 +152,7 @@ public class BunitJSInteropTest
 		invocation.IsFaulted.ShouldBeTrue();
 	}
 
-	[Fact(DisplayName = "A invocation handler can throw an exception after it has been set to a different result")]
+	[UIFact(DisplayName = "A invocation handler can throw an exception after it has been set to a different result")]
 	public void Test108()
 	{
 		var identifier = "func";
@@ -169,7 +169,7 @@ public class BunitJSInteropTest
 		invocation2.IsFaulted.ShouldBeTrue();
 	}
 
-	[Fact(DisplayName = "Invocations returns all from a invocation handler")]
+	[UIFact(DisplayName = "Invocations returns all from a invocation handler")]
 	public void Test009()
 	{
 		var identifier = "func";
@@ -185,7 +185,7 @@ public class BunitJSInteropTest
 		invocations[identifier][1].Arguments[0].ShouldBe("second");
 	}
 
-	[Fact(DisplayName = "Arguments used in Setup are matched with invocations")]
+	[UIFact(DisplayName = "Arguments used in Setup are matched with invocations")]
 	public void Test010()
 	{
 		var sut = CreateSut(JSRuntimeMode.Strict);
@@ -202,7 +202,7 @@ public class BunitJSInteropTest
 		invocation.Arguments[1].ShouldBe(42);
 	}
 
-	[Fact(DisplayName = "Argument matcher used in Setup are matched with invocations")]
+	[UIFact(DisplayName = "Argument matcher used in Setup are matched with invocations")]
 	public void Test011()
 	{
 		var sut = CreateSut(JSRuntimeMode.Strict);
@@ -219,7 +219,7 @@ public class BunitJSInteropTest
 		invocation.Arguments[0].ShouldBe(42);
 	}
 
-	[Fact(DisplayName = "SetupVoid returns a invocation handler that does not take a result object")]
+	[UIFact(DisplayName = "SetupVoid returns a invocation handler that does not take a result object")]
 	public async Task Test012()
 	{
 		var identifier = "func";
@@ -234,7 +234,7 @@ public class BunitJSInteropTest
 		invocation.IsCompletedSuccessfully.ShouldBeTrue();
 	}
 
-	[Fact(DisplayName = "Arguments used in SetupVoid are matched with invocations")]
+	[UIFact(DisplayName = "Arguments used in SetupVoid are matched with invocations")]
 	public void Test013()
 	{
 		var sut = CreateSut(JSRuntimeMode.Strict);
@@ -251,7 +251,7 @@ public class BunitJSInteropTest
 		invocation.Arguments[1].ShouldBe(42);
 	}
 
-	[Fact(DisplayName = "Argument matcher used in SetupVoid are matched with invocations")]
+	[UIFact(DisplayName = "Argument matcher used in SetupVoid are matched with invocations")]
 	public void Test014()
 	{
 		var sut = CreateSut(JSRuntimeMode.Strict);
@@ -269,7 +269,7 @@ public class BunitJSInteropTest
 		invocation.Arguments[1].ShouldBe(42);
 	}
 
-	[Fact(DisplayName = "Empty Setup returns the same result for all matching return type invocation")]
+	[UIFact(DisplayName = "Empty Setup returns the same result for all matching return type invocation")]
 	public async Task Test015()
 	{
 		var sut = CreateSut(JSRuntimeMode.Strict);
@@ -286,7 +286,7 @@ public class BunitJSInteropTest
 		(await i2).ShouldBe(expectedResult1);
 	}
 
-	[Fact(DisplayName = "Empty Setup only matches the configured return type")]
+	[UIFact(DisplayName = "Empty Setup only matches the configured return type")]
 	public void Test016()
 	{
 		var sut = CreateSut(JSRuntimeMode.Strict);
@@ -297,7 +297,7 @@ public class BunitJSInteropTest
 		planned.Invocations.Count.ShouldBe(0);
 	}
 
-	[Fact(DisplayName = "Empty Setup allows to return different results by return types")]
+	[UIFact(DisplayName = "Empty Setup allows to return different results by return types")]
 	public async Task Test017()
 	{
 		var sut = CreateSut(JSRuntimeMode.Strict);
@@ -317,7 +317,7 @@ public class BunitJSInteropTest
 		(await i2).ShouldBe(expectedResult2);
 	}
 
-	[Fact(DisplayName = "Empty Setup is only used when there is no handler exist for the invocation identifier")]
+	[UIFact(DisplayName = "Empty Setup is only used when there is no handler exist for the invocation identifier")]
 	public async Task Test018()
 	{
 		var sut = CreateSut(JSRuntimeMode.Strict);
@@ -339,7 +339,7 @@ public class BunitJSInteropTest
 		(await i2).ShouldBe(expectedResult);
 	}
 
-	[Fact(DisplayName = "Empty Setup uses the last set result")]
+	[UIFact(DisplayName = "Empty Setup uses the last set result")]
 	public async Task Test019()
 	{
 		var sut = CreateSut(JSRuntimeMode.Strict);
@@ -358,7 +358,7 @@ public class BunitJSInteropTest
 		(await i1).ShouldBe(expectedResult2);
 	}
 
-	[Fact(DisplayName = "SetupVoid matches all void invocations")]
+	[UIFact(DisplayName = "SetupVoid matches all void invocations")]
 	public async Task Test020()
 	{
 		var identifier = "someFunc";
@@ -376,7 +376,7 @@ public class BunitJSInteropTest
 		handler.Invocations.Count.ShouldBe(1);
 	}
 
-	[Fact(DisplayName = "Empty Setup is not used for invocation with void return types")]
+	[UIFact(DisplayName = "Empty Setup is not used for invocation with void return types")]
 	public void Test021()
 	{
 		var sut = CreateSut(JSRuntimeMode.Strict);
@@ -386,7 +386,7 @@ public class BunitJSInteropTest
 		Should.Throw<JSRuntimeUnhandledInvocationException>(async () => await sut.JSRuntime.InvokeVoidAsync("someFunc"));
 	}
 
-	[Fact(DisplayName = "CatchAll handlers SetupVoid is only used when there is no void handler")]
+	[UIFact(DisplayName = "CatchAll handlers SetupVoid is only used when there is no void handler")]
 	public async Task Test022()
 	{
 		var identifier = "someFunc";
@@ -404,7 +404,7 @@ public class BunitJSInteropTest
 		invocation.IsCompletedSuccessfully.ShouldBeTrue();
 	}
 
-	[Fact(DisplayName = "The last handler matching an invocation receives the invocation")]
+	[UIFact(DisplayName = "The last handler matching an invocation receives the invocation")]
 	public void Test030()
 	{
 		var identifier = "someFunc";
@@ -418,7 +418,7 @@ public class BunitJSInteropTest
 		h2.Invocations.Count.ShouldBe(1);
 	}
 
-	[Fact(DisplayName = "TryGetInvokeHandler returns null when no handlers matches the arguments")]
+	[UIFact(DisplayName = "TryGetInvokeHandler returns null when no handlers matches the arguments")]
 	public void Test040()
 	{
 		var sut = CreateSut(JSRuntimeMode.Loose);
@@ -428,7 +428,7 @@ public class BunitJSInteropTest
 		actual.ShouldBeNull();
 	}
 
-	[Fact(DisplayName = "TryGetInvokeHandler returns the last handler matching the input parameters")]
+	[UIFact(DisplayName = "TryGetInvokeHandler returns the last handler matching the input parameters")]
 	public void Test041()
 	{
 		var sut = CreateSut(JSRuntimeMode.Loose);
@@ -441,7 +441,7 @@ public class BunitJSInteropTest
 		actual.ShouldNotBe(h1);
 	}
 
-	[Fact(DisplayName = "TryGetInvokeVoidHandler can find void-return handlers")]
+	[UIFact(DisplayName = "TryGetInvokeVoidHandler can find void-return handlers")]
 	public void Test042()
 	{
 		var sut = CreateSut(JSRuntimeMode.Loose);
@@ -453,7 +453,7 @@ public class BunitJSInteropTest
 		actual.ShouldBe(expected);
 	}
 
-	[Fact(DisplayName = "Mock returns default value from IJSInProcessRuntime's invoke method in loose mode without invocation setup")]
+	[UIFact(DisplayName = "Mock returns default value from IJSInProcessRuntime's invoke method in loose mode without invocation setup")]
 	public void Test043()
 	{
 		var sut = CreateSut(JSRuntimeMode.Loose);
@@ -463,7 +463,7 @@ public class BunitJSInteropTest
 		result.ShouldBe(default);
 	}
 
-	[Fact(DisplayName = "After IJSInProcessRuntime invocation a invocation should be visible from the Invocations list")]
+	[UIFact(DisplayName = "After IJSInProcessRuntime invocation a invocation should be visible from the Invocations list")]
 	public void Test044()
 	{
 		var identifier = "fooFunc";
@@ -477,7 +477,7 @@ public class BunitJSInteropTest
 		invocation.Arguments.ShouldBe(args);
 	}
 
-	[Fact(DisplayName = "IJSInProcessRuntime invocations receive the result set in a planned invocation")]
+	[UIFact(DisplayName = "IJSInProcessRuntime invocations receive the result set in a planned invocation")]
 	public void Test045()
 	{
 		var identifier = "func";
@@ -493,7 +493,7 @@ public class BunitJSInteropTest
 		i.ShouldBe(expectedResult);
 	}
 
-	[Fact(DisplayName = "Mock throws exception when in strict mode and IJSInProcessRuntime invocation has not been setup")]
+	[UIFact(DisplayName = "Mock throws exception when in strict mode and IJSInProcessRuntime invocation has not been setup")]
 	public void Test046()
 	{
 		var sut = CreateSut(JSRuntimeMode.Strict);
@@ -505,7 +505,7 @@ public class BunitJSInteropTest
 		exception.Invocation.Arguments.ShouldBe(args);
 	}
 
-	[Fact(DisplayName = "Mock throws exception when in strict mode and IJSUnmarshalledRuntime invocation has not been setup with one argument")]
+	[UIFact(DisplayName = "Mock throws exception when in strict mode and IJSUnmarshalledRuntime invocation has not been setup with one argument")]
 	public void Test047()
 	{
 		var sut = CreateSut(JSRuntimeMode.Strict);
@@ -517,7 +517,7 @@ public class BunitJSInteropTest
 		exception.Invocation.Arguments.ShouldBe(args);
 	}
 
-	[Fact(DisplayName = "Mock throws exception when in strict mode and IJSUnmarshalledRuntime invocation has not been setup with two arguments")]
+	[UIFact(DisplayName = "Mock throws exception when in strict mode and IJSUnmarshalledRuntime invocation has not been setup with two arguments")]
 	public void Test048()
 	{
 		var sut = CreateSut(JSRuntimeMode.Strict);
@@ -529,7 +529,7 @@ public class BunitJSInteropTest
 		exception.Invocation.Arguments.ShouldBe(args);
 	}
 
-	[Fact(DisplayName = "Mock throws exception when in strict mode and IJSUnmarshalledRuntime invocation has not been setup with three arguments")]
+	[UIFact(DisplayName = "Mock throws exception when in strict mode and IJSUnmarshalledRuntime invocation has not been setup with three arguments")]
 	public void Test049()
 	{
 		var sut = CreateSut(JSRuntimeMode.Strict);
@@ -541,7 +541,7 @@ public class BunitJSInteropTest
 		exception.Invocation.Arguments.ShouldBe(args);
 	}
 
-	[Fact(DisplayName = "Mock throws exception when in strict mode and IJSUnmarshalledRuntime invocation has not been setup with zero arguments")]
+	[UIFact(DisplayName = "Mock throws exception when in strict mode and IJSUnmarshalledRuntime invocation has not been setup with zero arguments")]
 	public void Test050()
 	{
 		var sut = CreateSut(JSRuntimeMode.Strict);
@@ -552,7 +552,7 @@ public class BunitJSInteropTest
 		exception.Invocation.Arguments.ShouldBeEmpty();
 	}
 
-	[Fact(DisplayName = "An IJSUnmarshalledRuntime invocation should return the correct result when passed one arguments.")]
+	[UIFact(DisplayName = "An IJSUnmarshalledRuntime invocation should return the correct result when passed one arguments.")]
 	public void Test055()
 	{
 		var identifier = "fooFunc";
@@ -567,7 +567,7 @@ public class BunitJSInteropTest
 		actual.ShouldBe(expectedResult);
 	}
 
-	[Fact(DisplayName = "An IJSUnmarshalledRuntime invocation should return the correct result when passed two arguments.")]
+	[UIFact(DisplayName = "An IJSUnmarshalledRuntime invocation should return the correct result when passed two arguments.")]
 	public void Test056()
 	{
 		var identifier = "fooFunc";
@@ -582,7 +582,7 @@ public class BunitJSInteropTest
 		actual.ShouldBe(expectedResult);
 	}
 
-	[Fact(DisplayName = "An IJSUnmarshalledRuntime invocation should return the correct result when passed three arguments.")]
+	[UIFact(DisplayName = "An IJSUnmarshalledRuntime invocation should return the correct result when passed three arguments.")]
 	public void Test057()
 	{
 		var identifier = "fooFunc";
@@ -597,7 +597,7 @@ public class BunitJSInteropTest
 		actual.ShouldBe(expectedResult);
 	}
 
-	[Fact(DisplayName = "An IJSUnmarshalledRuntime invocation should return the correct result when passed zero arguments.")]
+	[UIFact(DisplayName = "An IJSUnmarshalledRuntime invocation should return the correct result when passed zero arguments.")]
 	public void Test058()
 	{
 		var identifier = "fooFunc";
@@ -611,7 +611,7 @@ public class BunitJSInteropTest
 		actual.ShouldBe(expectedResult);
 	}
 
-	[Theory(DisplayName = "When calling InvokeUnmarshalled(identifier), then the invocation should be visible from the Invocations list"), AutoData]
+	[UITheory(DisplayName = "When calling InvokeUnmarshalled(identifier), then the invocation should be visible from the Invocations list"), AutoData]
 	public void Test310(string identifier)
 	{
 		var sut = CreateSut(JSRuntimeMode.Loose);
@@ -629,7 +629,7 @@ public class BunitJSInteropTest
 				invocationMethodName: "InvokeUnmarshalled"));
 	}
 
-	[Theory(DisplayName = "When calling InvokeUnmarshalled(identifier, arg0), then the invocation should be visible from the Invocations list"), AutoData]
+	[UITheory(DisplayName = "When calling InvokeUnmarshalled(identifier, arg0), then the invocation should be visible from the Invocations list"), AutoData]
 	public void Test306(string identifier, string arg0)
 	{
 		var sut = CreateSut(JSRuntimeMode.Loose);
@@ -647,7 +647,7 @@ public class BunitJSInteropTest
 				invocationMethodName: "InvokeUnmarshalled"));
 	}
 
-	[Theory(DisplayName = "When calling InvokeUnmarshalled(identifier, arg0, arg1), then the invocation should be visible from the Invocations list"), AutoData]
+	[UITheory(DisplayName = "When calling InvokeUnmarshalled(identifier, arg0, arg1), then the invocation should be visible from the Invocations list"), AutoData]
 	public void Test307(string identifier, string arg0, string arg1)
 	{
 		var sut = CreateSut(JSRuntimeMode.Loose);
@@ -665,7 +665,7 @@ public class BunitJSInteropTest
 				invocationMethodName: "InvokeUnmarshalled"));
 	}
 
-	[Theory(DisplayName = "When calling InvokeUnmarshalled(identifier, arg0, arg1, arg2), then the invocation should be visible from the Invocations list"), AutoData]
+	[UITheory(DisplayName = "When calling InvokeUnmarshalled(identifier, arg0, arg1, arg2), then the invocation should be visible from the Invocations list"), AutoData]
 	public void Test308(string identifier, string arg0, string arg1, string arg2)
 	{
 		var sut = CreateSut(JSRuntimeMode.Loose);

--- a/tests/bunit.web.tests/JSInterop/BunitJSObjectReferenceTest.cs
+++ b/tests/bunit.web.tests/JSInterop/BunitJSObjectReferenceTest.cs
@@ -16,7 +16,7 @@ public class BunitJSObjectReferenceTest : TestContext
 	private static readonly Type JSVoidResultType =
 			typeof(Microsoft.JSInterop.Infrastructure.IJSVoidResult);
 
-	[Theory(DisplayName = "Calling Setup<JSObjectReference> or Setup<IJSObjectReference> throws")]
+	[UITheory(DisplayName = "Calling Setup<JSObjectReference> or Setup<IJSObjectReference> throws")]
 	[InlineData("import", null)]
 	[InlineData("import", "file.js")]
 	[InlineData("customImport", null)]
@@ -27,20 +27,20 @@ public class BunitJSObjectReferenceTest : TestContext
 		Should.Throw<ArgumentException>(() => JSInterop.Setup<IJSObjectReference>(identifier, arg1));
 	}
 
-	[Theory(DisplayName = "Calling SetupModule(null) or SetupModule(empty string) throws")]
+	[UITheory(DisplayName = "Calling SetupModule(null) or SetupModule(empty string) throws")]
 	[InlineData(null)]
 	[InlineData("")]
 	[InlineData("  ")]
 	public void Test002(string url)
 		=> Should.Throw<ArgumentException>(() => JSInterop.SetupModule(url));
 
-	[Fact(DisplayName = "Calling SetupModule(jsInterop, identifier, invocationMatcher) with any null values throws")]
+	[UIFact(DisplayName = "Calling SetupModule(jsInterop, identifier, invocationMatcher) with any null values throws")]
 	public void Test003()
 	{
 		Should.Throw<ArgumentNullException>(() => default(BunitJSInterop)!.SetupModule("identifier", _ => true));
 	}
 
-	[Fact(DisplayName = "Calling SetupModule(uri) registers handler for module JS Interop")]
+	[UIFact(DisplayName = "Calling SetupModule(uri) registers handler for module JS Interop")]
 	public void Test010()
 	{
 		JSInterop.SetupModule("FOO.js");
@@ -49,7 +49,7 @@ public class BunitJSObjectReferenceTest : TestContext
 			.ShouldBeOfType<JSObjectReferenceInvocationHandler>();
 	}
 
-	[Fact(DisplayName = "Calling SetupModule(invocationMatcher) registers handler for module JS Interop")]
+	[UIFact(DisplayName = "Calling SetupModule(invocationMatcher) registers handler for module JS Interop")]
 	public void Test011()
 	{
 		JSInterop.SetupModule(_ => true);
@@ -58,7 +58,7 @@ public class BunitJSObjectReferenceTest : TestContext
 			.ShouldBeOfType<JSObjectReferenceInvocationHandler>();
 	}
 
-	[Fact(DisplayName = "Calling the catch-all SetupModule() registers handler for module JS Interop")]
+	[UIFact(DisplayName = "Calling the catch-all SetupModule() registers handler for module JS Interop")]
 	public void Test012()
 	{
 		JSInterop.SetupModule();
@@ -67,7 +67,7 @@ public class BunitJSObjectReferenceTest : TestContext
 			.ShouldBeOfType<JSObjectReferenceInvocationHandler>();
 	}
 
-	[Fact(DisplayName = "Calling SetupModule(customImport, args) registers handler for module JS Interop")]
+	[UIFact(DisplayName = "Calling SetupModule(customImport, args) registers handler for module JS Interop")]
 	public void Test013()
 	{
 		JSInterop.SetupModule("foo", Array.Empty<object>());
@@ -76,7 +76,7 @@ public class BunitJSObjectReferenceTest : TestContext
 			.ShouldBeOfType<JSObjectReferenceInvocationHandler>();
 	}
 
-	[Fact(DisplayName = "Handler for specific module name returns IJSObjectReference when receiving matching invocation")]
+	[UIFact(DisplayName = "Handler for specific module name returns IJSObjectReference when receiving matching invocation")]
 	public async Task Test020()
 	{
 		var moduleName = "FOO.js";
@@ -87,7 +87,7 @@ public class BunitJSObjectReferenceTest : TestContext
 		module.ShouldNotBeNull();
 	}
 
-	[Theory(DisplayName = "Handler for specific module name doesn't match other module names")]
+	[UITheory(DisplayName = "Handler for specific module name doesn't match other module names")]
 	[InlineData(null)]
 	[InlineData("")]
 	[InlineData("BAR.js")]
@@ -98,7 +98,7 @@ public class BunitJSObjectReferenceTest : TestContext
 		Should.Throw<JSRuntimeUnhandledInvocationException>(() => JSInterop.JSRuntime.InvokeAsync<IJSObjectReference>("import", requestedRoduleName));
 	}
 
-	[Fact(DisplayName = "Handler for matcher returns IJSObjectReference when receiving matching invocation")]
+	[UIFact(DisplayName = "Handler for matcher returns IJSObjectReference when receiving matching invocation")]
 	public async Task Test022()
 	{
 		var moduleName = "FOO.js";
@@ -109,7 +109,7 @@ public class BunitJSObjectReferenceTest : TestContext
 		module.ShouldBeAssignableTo<IJSObjectReference>();
 	}
 
-	[Fact(DisplayName = "Handler for matcher returns IJSObjectReference when receiving matching invocation")]
+	[UIFact(DisplayName = "Handler for matcher returns IJSObjectReference when receiving matching invocation")]
 	public async Task Test026()
 	{
 		var moduleName = "FOO.js";
@@ -120,7 +120,7 @@ public class BunitJSObjectReferenceTest : TestContext
 		module.ShouldBeAssignableTo<IJSObjectReference>();
 	}
 
-	[Theory(DisplayName = "Catch-all handler returns IJSObjectReference for all non-empty module names")]
+	[UITheory(DisplayName = "Catch-all handler returns IJSObjectReference for all non-empty module names")]
 	[InlineData("import", "FOO.js")]
 	[InlineData("customImport", null)]
 	[InlineData("customImport", "BAR.js")]
@@ -133,7 +133,7 @@ public class BunitJSObjectReferenceTest : TestContext
 		module.ShouldBeAssignableTo<IJSObjectReference>();
 	}
 
-	[Theory(DisplayName = "JSInterop in loose mode returns IJSObjectReference for all non-empty module names without explicit SetupModule call")]
+	[UITheory(DisplayName = "JSInterop in loose mode returns IJSObjectReference for all non-empty module names without explicit SetupModule call")]
 	[InlineData("import", "FOO.js")]
 	[InlineData("customImport", null)]
 	[InlineData("customImport", "BAR.js")]
@@ -146,7 +146,7 @@ public class BunitJSObjectReferenceTest : TestContext
 		module.ShouldBeAssignableTo<IJSObjectReference>();
 	}
 
-	[Fact(DisplayName = "Module JSInterop inherits the root JSInterop's Mode")]
+	[UIFact(DisplayName = "Module JSInterop inherits the root JSInterop's Mode")]
 	public void Test030()
 	{
 		JSInterop.Mode = JSRuntimeMode.Loose;
@@ -156,7 +156,7 @@ public class BunitJSObjectReferenceTest : TestContext
 		JSInterop.SetupModule("foo.js").Mode.ShouldBe(JSInterop.Mode);
 	}
 
-	[Fact(DisplayName = "Changing mode in root JSInterop changes it in module JSInterop when it's not been set explicitly there")]
+	[UIFact(DisplayName = "Changing mode in root JSInterop changes it in module JSInterop when it's not been set explicitly there")]
 	public void Test031()
 	{
 		var moduleJSInterop = JSInterop.SetupModule();
@@ -168,7 +168,7 @@ public class BunitJSObjectReferenceTest : TestContext
 		moduleJSInterop.Mode.ShouldBe(JSInterop.Mode);
 	}
 
-	[Fact(DisplayName = "Changing mode on module JSInterop breaks inherited mode from root JSInterop")]
+	[UIFact(DisplayName = "Changing mode on module JSInterop breaks inherited mode from root JSInterop")]
 	public void Test032()
 	{
 		var moduleJSInterop = JSInterop.SetupModule();
@@ -179,7 +179,7 @@ public class BunitJSObjectReferenceTest : TestContext
 		moduleJSInterop.Mode.ShouldBe(JSRuntimeMode.Strict);
 	}
 
-	[Fact(DisplayName = "InvokeAsync<TValue> on module in loose mode returns default TValue when no matching module JSInterops are registered")]
+	[UIFact(DisplayName = "InvokeAsync<TValue> on module in loose mode returns default TValue when no matching module JSInterops are registered")]
 	public async Task Test040()
 	{
 		JSInterop.Mode = JSRuntimeMode.Loose;
@@ -190,7 +190,7 @@ public class BunitJSObjectReferenceTest : TestContext
 		actual.ShouldBe(default(string));
 	}
 
-	[Fact(DisplayName = "InvokeAsync<IJSObjectReference> calls is registered in the root JSInterop Invocations list only")]
+	[UIFact(DisplayName = "InvokeAsync<IJSObjectReference> calls is registered in the root JSInterop Invocations list only")]
 	public async Task Test050()
 	{
 		var moduleJSInterop = JSInterop.SetupModule("FOO.js");
@@ -206,7 +206,7 @@ public class BunitJSObjectReferenceTest : TestContext
 		moduleJSInterop.Invocations.ShouldBeEmpty();
 	}
 
-	[Fact(DisplayName = "Module.Invocation is registered in both module and root JSInterop")]
+	[UIFact(DisplayName = "Module.Invocation is registered in both module and root JSInterop")]
 	public async Task Test055()
 	{
 		JSInterop.Mode = JSRuntimeMode.Loose;
@@ -224,7 +224,7 @@ public class BunitJSObjectReferenceTest : TestContext
 			.Identifier.ShouldBe("helloWorld");
 	}
 
-	[Fact(DisplayName = "TryGetModuleJSInterop returns registered module handler when called with parameters that the handler matches with")]
+	[UIFact(DisplayName = "TryGetModuleJSInterop returns registered module handler when called with parameters that the handler matches with")]
 	public void Test060()
 	{
 		var expected = JSInterop.SetupModule("FOO.js");
@@ -234,7 +234,7 @@ public class BunitJSObjectReferenceTest : TestContext
 		actual.ShouldBe(expected);
 	}
 
-	[Fact(DisplayName = "TryGetModuleJSInterop returns null when called with parameters that the handler does not matches with")]
+	[UIFact(DisplayName = "TryGetModuleJSInterop returns null when called with parameters that the handler does not matches with")]
 	public void Test061()
 	{
 		JSInterop.SetupModule("FOO.js");
@@ -244,7 +244,7 @@ public class BunitJSObjectReferenceTest : TestContext
 		actual.ShouldBeNull();
 	}
 
-	[Fact(DisplayName = "IJSObjectReference can be cast to IJSInProcessObjectReference")]
+	[UIFact(DisplayName = "IJSObjectReference can be cast to IJSInProcessObjectReference")]
 	public void Test070()
 	{
 		JSInterop.Mode = JSRuntimeMode.Loose;
@@ -254,7 +254,7 @@ public class BunitJSObjectReferenceTest : TestContext
 		jsRuntime.ShouldBeAssignableTo<IJSInProcessObjectReference>();
 	}
 
-	[Fact(DisplayName = "IJSObjectReference can be cast to IJSUnmarshalledObjectReference")]
+	[UIFact(DisplayName = "IJSObjectReference can be cast to IJSUnmarshalledObjectReference")]
 	public void Test071()
 	{
 		JSInterop.Mode = JSRuntimeMode.Loose;
@@ -264,7 +264,7 @@ public class BunitJSObjectReferenceTest : TestContext
 		jsRuntime.ShouldBeAssignableTo<IJSUnmarshalledObjectReference>();
 	}
 
-	[Fact(DisplayName = "IJSInProcessObjectReference-invocations is handled by handlers from BunitJSInterop")]
+	[UIFact(DisplayName = "IJSInProcessObjectReference-invocations is handled by handlers from BunitJSInterop")]
 	public async Task Test080()
 	{
 		JSInterop.Mode = JSRuntimeMode.Loose;
@@ -285,7 +285,7 @@ public class BunitJSObjectReferenceTest : TestContext
 		JSInterop.VerifyInvoke("bar6").Arguments.ShouldBe(new[] { "baz" });
 	}
 
-	[Fact(DisplayName = "IJSUnmarshalledObjectReference-invocations is handled by handlers from BunitJSInterop")]
+	[UIFact(DisplayName = "IJSUnmarshalledObjectReference-invocations is handled by handlers from BunitJSInterop")]
 	public async Task Test081()
 	{
 		JSInterop.Mode = JSRuntimeMode.Loose;
@@ -314,7 +314,7 @@ public class BunitJSObjectReferenceTest : TestContext
 		JSInterop.VerifyInvoke("bar10").Arguments.ShouldBe(new[] { "baz", "boo", "bah" });
 	}
 
-	[Theory(DisplayName = "When calling InvokeUnmarshalled(identifier), then the invocation should be visible from the Invocations list"), AutoData]
+	[UITheory(DisplayName = "When calling InvokeUnmarshalled(identifier), then the invocation should be visible from the Invocations list"), AutoData]
 	public void Test310(string identifier)
 	{
 		JSInterop.Mode = JSRuntimeMode.Loose;
@@ -332,7 +332,7 @@ public class BunitJSObjectReferenceTest : TestContext
 				invocationMethodName: "InvokeUnmarshalled"));
 	}
 
-	[Theory(DisplayName = "When calling InvokeUnmarshalled(identifier, arg0), then the invocation should be visible from the Invocations list"), AutoData]
+	[UITheory(DisplayName = "When calling InvokeUnmarshalled(identifier, arg0), then the invocation should be visible from the Invocations list"), AutoData]
 	public void Test306(string identifier, string arg0)
 	{
 		JSInterop.Mode = JSRuntimeMode.Loose;
@@ -350,7 +350,7 @@ public class BunitJSObjectReferenceTest : TestContext
 				invocationMethodName: "InvokeUnmarshalled"));
 	}
 
-	[Theory(DisplayName = "When calling InvokeUnmarshalled(identifier, arg0, arg1), then the invocation should be visible from the Invocations list"), AutoData]
+	[UITheory(DisplayName = "When calling InvokeUnmarshalled(identifier, arg0, arg1), then the invocation should be visible from the Invocations list"), AutoData]
 	public void Test307(string identifier, string arg0, string arg1)
 	{
 		JSInterop.Mode = JSRuntimeMode.Loose;
@@ -368,7 +368,7 @@ public class BunitJSObjectReferenceTest : TestContext
 				invocationMethodName: "InvokeUnmarshalled"));
 	}
 
-	[Theory(DisplayName = "When calling InvokeUnmarshalled(identifier, arg0, arg1, arg2), then the invocation should be visible from the Invocations list"), AutoData]
+	[UITheory(DisplayName = "When calling InvokeUnmarshalled(identifier, arg0, arg1, arg2), then the invocation should be visible from the Invocations list"), AutoData]
 	public void Test308(string identifier, string arg0, string arg1, string arg2)
 	{
 		JSInterop.Mode = JSRuntimeMode.Loose;
@@ -387,7 +387,7 @@ public class BunitJSObjectReferenceTest : TestContext
 				invocationMethodName: "InvokeUnmarshalled"));
 	}
 
-	[Theory(DisplayName = "When calling InvokeVoidAsync, then the invocation should be visible from the Invocations list"), AutoData]
+	[UITheory(DisplayName = "When calling InvokeVoidAsync, then the invocation should be visible from the Invocations list"), AutoData]
 	public void Test302(string identifier, string[] args, CancellationToken cancellationToken)
 	{
 		JSInterop.Mode = JSRuntimeMode.Loose;
@@ -405,7 +405,7 @@ public class BunitJSObjectReferenceTest : TestContext
 				"InvokeVoidAsync"));
 	}
 
-	[Theory(DisplayName = "When calling InvokeAsync, then the invocation should be visible from the Invocations list"), AutoData]
+	[UITheory(DisplayName = "When calling InvokeAsync, then the invocation should be visible from the Invocations list"), AutoData]
 	public void Test303(string identifier, string[] args, CancellationToken cancellationToken)
 	{
 		JSInterop.Mode = JSRuntimeMode.Loose;
@@ -423,7 +423,7 @@ public class BunitJSObjectReferenceTest : TestContext
 				"InvokeAsync"));
 	}
 
-	[Theory(DisplayName = "When calling InvokeVoid, then the invocation should be visible from the Invocations list"), AutoData]
+	[UITheory(DisplayName = "When calling InvokeVoid, then the invocation should be visible from the Invocations list"), AutoData]
 	public void Test304(string identifier, string[] args)
 	{
 		JSInterop.Mode = JSRuntimeMode.Loose;
@@ -441,7 +441,7 @@ public class BunitJSObjectReferenceTest : TestContext
 				invocationMethodName: "InvokeVoid"));
 	}
 
-	[Theory(DisplayName = "When calling Invoke, then the invocation should be visible from the Invocations list"), AutoData]
+	[UITheory(DisplayName = "When calling Invoke, then the invocation should be visible from the Invocations list"), AutoData]
 	public void Test305(string identifier, string[] args)
 	{
 		JSInterop.Mode = JSRuntimeMode.Loose;

--- a/tests/bunit.web.tests/JSInterop/InvocationHandlers/FocusAsyncInvocationHandlerTest.cs
+++ b/tests/bunit.web.tests/JSInterop/InvocationHandlers/FocusAsyncInvocationHandlerTest.cs
@@ -8,7 +8,7 @@ namespace Bunit.JSInterop.InvocationHandlers;
 
 public class FocusAsyncInvocationHandlerTest : TestContext
 {
-	[Fact(DisplayName = "Can render components that calls FocusAsync")]
+	[UIFact(DisplayName = "Can render components that calls FocusAsync")]
 	public void Test001()
 	{
 		var cut = RenderComponent<FocusingComponent>();
@@ -16,7 +16,7 @@ public class FocusAsyncInvocationHandlerTest : TestContext
 		JSInterop.VerifyFocusAsyncInvoke().Arguments[0].ShouldBeElementReferenceTo(input);
 	}
 
-	[Fact(DisplayName = "Can capture two FocusAsync calls")]
+	[UIFact(DisplayName = "Can capture two FocusAsync calls")]
 	public void Test002()
 	{
 		var cut = RenderComponent<Wrapper>(ps => ps
@@ -30,7 +30,7 @@ public class FocusAsyncInvocationHandlerTest : TestContext
 		invocations[1].Arguments[0].ShouldBeElementReferenceTo(inputs[1]);
 	}
 
-	[Fact(DisplayName = "Will return completed task")]
+	[UIFact(DisplayName = "Will return completed task")]
 	public void Test003()
 	{
 		var cut = RenderComponent<FocusingComponent>();

--- a/tests/bunit.web.tests/JSInterop/InvocationHandlers/FocusOnNavigateHandlerTest.cs
+++ b/tests/bunit.web.tests/JSInterop/InvocationHandlers/FocusOnNavigateHandlerTest.cs
@@ -13,7 +13,7 @@ namespace Bunit.JSInterop.InvocationHandlers;
 
 public class FocusOnNavigateHandlerTest : TestContext
 {
-	[Fact(DisplayName = "Can render components that calls FocusOnNavigate")]
+	[UIFact(DisplayName = "Can render components that calls FocusOnNavigate")]
 	public void Test001()
 	{
 		// <FocusOnNavigate RouteData="@routeData" Selector="h1" />
@@ -30,7 +30,7 @@ public class FocusOnNavigateHandlerTest : TestContext
 			.ShouldBe(focusOnNavigateComponent.Instance.Selector);
 	}
 
-	[Fact(DisplayName = "Will return completed task")]
+	[UIFact(DisplayName = "Will return completed task")]
 	public void Test002()
 	{
 		var cut = RenderComponent<App>(ps => ps

--- a/tests/bunit.web.tests/JSInterop/InvocationHandlers/VirtualizeJSRuntimeInvocationHandlerTest.cs
+++ b/tests/bunit.web.tests/JSInterop/InvocationHandlers/VirtualizeJSRuntimeInvocationHandlerTest.cs
@@ -15,7 +15,7 @@ public class VirtualizeJSRuntimeInvocationHandlerTest : TestContext
 			new object[] { 0 }, new object[] { 7 }, new object[] { 30 }, new object[] { 60 }, new object[] { 100 }, new object[] { 300 }, new object[] { 500 },
 	};
 
-	[Theory(DisplayName = "Can render component using <Virtualize Items> with ChildContent")]
+	[UITheory(DisplayName = "Can render component using <Virtualize Items> with ChildContent")]
 	[MemberData(nameof(ItemsInCollection))]
 	public void Test001(int itemsInDataSource)
 	{
@@ -26,7 +26,7 @@ public class VirtualizeJSRuntimeInvocationHandlerTest : TestContext
 		cut.FindAll("p").Count.ShouldBe(itemsInDataSource);
 	}
 
-	[Theory(DisplayName = "Can render component using <Virtualize Items> with ItemContent")]
+	[UITheory(DisplayName = "Can render component using <Virtualize Items> with ItemContent")]
 	[MemberData(nameof(ItemsInCollection))]
 	public void Test002(int itemsInDataSource)
 	{
@@ -37,7 +37,7 @@ public class VirtualizeJSRuntimeInvocationHandlerTest : TestContext
 		cut.FindAll("p").Count.ShouldBe(itemsInDataSource);
 	}
 
-	[Theory(DisplayName = "Can render component using <Virtualize ItemsProvider> with ChildContent")]
+	[UITheory(DisplayName = "Can render component using <Virtualize ItemsProvider> with ChildContent")]
 	[MemberData(nameof(ItemsInCollection))]
 	public void Test010(int itemsInDataSource)
 	{
@@ -48,7 +48,7 @@ public class VirtualizeJSRuntimeInvocationHandlerTest : TestContext
 		cut.FindAll("p").Count.ShouldBe(itemsInDataSource);
 	}
 
-	[Theory(DisplayName = "Can render component using <Virtualize ItemsProvider> with ItemContent")]
+	[UITheory(DisplayName = "Can render component using <Virtualize ItemsProvider> with ItemContent")]
 	[MemberData(nameof(ItemsInCollection))]
 	public void Test011(int itemsInDataSource)
 	{
@@ -70,7 +70,7 @@ public class VirtualizeJSRuntimeInvocationHandlerTest : TestContext
 				new object[] { x[0], 1_000_000, 1_000_000 },
 		}).SelectMany(x => x);
 
-	[Theory(DisplayName = "Can render component using <Virtualize Items> and different ItemSize and OverscanCount")]
+	[UITheory(DisplayName = "Can render component using <Virtualize Items> and different ItemSize and OverscanCount")]
 	[MemberData(nameof(ItemCountItemSizeOverscanCount))]
 	public void Test030(int itemsInDataSource, float itemSize, int overscanCount)
 	{
@@ -83,7 +83,7 @@ public class VirtualizeJSRuntimeInvocationHandlerTest : TestContext
 		cut.FindAll("p").Count.ShouldBe(itemsInDataSource);
 	}
 
-	[Theory(DisplayName = "Can render placeholder from <Virtualize ItemsProvider, Placeholder>")]
+	[UITheory(DisplayName = "Can render placeholder from <Virtualize ItemsProvider, Placeholder>")]
 	[MemberData(nameof(ItemsInCollection))]
 	public void Test040(int itemsInDataSource)
 	{

--- a/tests/bunit.web.tests/JSInterop/JSRuntimeInvocationTest.cs
+++ b/tests/bunit.web.tests/JSInterop/JSRuntimeInvocationTest.cs
@@ -31,7 +31,7 @@ public class JSRuntimeInvocationTest
 		yield return new object[] { i1, i9, false };
 	}
 
-	[Theory(DisplayName = "Equals operator works as expected")]
+	[UITheory(DisplayName = "Equals operator works as expected")]
 	[MemberData(nameof(GetEqualsTestData))]
 	public void Test002(JSRuntimeInvocation left, JSRuntimeInvocation right, bool expectedResult)
 	{
@@ -43,20 +43,20 @@ public class JSRuntimeInvocationTest
 		right.Equals((object)left).ShouldBe(expectedResult);
 	}
 
-	[Fact(DisplayName = "Equals operator works as expected with non compatible types")]
+	[UIFact(DisplayName = "Equals operator works as expected with non compatible types")]
 	public void Test003()
 	{
 		default(JSRuntimeInvocation).Equals(new object()).ShouldBeFalse();
 	}
 
-	[Theory(DisplayName = "GetHashCode returns same result for equal JSRuntimeInvocations")]
+	[UITheory(DisplayName = "GetHashCode returns same result for equal JSRuntimeInvocations")]
 	[MemberData(nameof(GetEqualsTestData))]
 	public void Test004(JSRuntimeInvocation left, JSRuntimeInvocation right, bool expectedResult)
 	{
 		left.GetHashCode().Equals(right.GetHashCode()).ShouldBe(expectedResult);
 	}
 
-	[Theory(DisplayName = "When result type is object, then IsVoidResultInvocation is true"), AutoData]
+	[UITheory(DisplayName = "When result type is object, then IsVoidResultInvocation is true"), AutoData]
 	public void Test005(string identifier)
 	{
 		var sut = new JSRuntimeInvocation(
@@ -69,7 +69,7 @@ public class JSRuntimeInvocationTest
 		sut.IsVoidResultInvocation.ShouldBeTrue();
 	}
 
-	[Theory(DisplayName = "When result type is not object, then IsVoidResultInvocation is false"), AutoData]
+	[UITheory(DisplayName = "When result type is not object, then IsVoidResultInvocation is false"), AutoData]
 	public void Test006(string identifier)
 	{
 		var sut = new JSRuntimeInvocation(

--- a/tests/bunit.web.tests/JSInterop/JSRuntimeUnhandledInvocationExceptionTest.cs
+++ b/tests/bunit.web.tests/JSInterop/JSRuntimeUnhandledInvocationExceptionTest.cs
@@ -19,7 +19,7 @@ public class JSRuntimeUnhandledInvocationExceptionTest
 			$"instance is returned from calling SetupModule on a BunitJSInterop instance.{Environment.NewLine}";
 	}
 
-	[Theory(DisplayName = "Message prints correctly with void return type")]
+	[UITheory(DisplayName = "Message prints correctly with void return type")]
 	[InlineAutoData("InvokeVoidAsync")]
 	[InlineAutoData("InvokeVoid")]
 	public void Test001(string identifier, string invocationMethodName)
@@ -33,7 +33,7 @@ public class JSRuntimeUnhandledInvocationExceptionTest
 		Assert.Equal(expectedErrorMessage, sut.Message);
 	}
 
-	[Theory(DisplayName = "Message prints correctly with non-primitive return type")]
+	[UITheory(DisplayName = "Message prints correctly with non-primitive return type")]
 	[InlineAutoData("InvokeAsync")]
 	[InlineAutoData("InvokeUnmarshalled")]
 	public void Test002(string identifier, string invocationMethodName)
@@ -48,7 +48,7 @@ public class JSRuntimeUnhandledInvocationExceptionTest
 		Assert.Equal(expectedErrorMessage, sut.Message);
 	}
 
-	[Theory(DisplayName = "Message prints correctly with primitive return type")]
+	[UITheory(DisplayName = "Message prints correctly with primitive return type")]
 	[InlineData(typeof(bool), "bool")]
 	[InlineData(typeof(byte), "byte")]
 	[InlineData(typeof(sbyte), "sbyte")]
@@ -74,7 +74,7 @@ public class JSRuntimeUnhandledInvocationExceptionTest
 		Assert.Equal(expectedErrorMessage, sut.Message);
 	}
 
-	[Theory(DisplayName = "Message prints correctly with void return type and string argument")]
+	[UITheory(DisplayName = "Message prints correctly with void return type and string argument")]
 	[InlineAutoData("InvokeVoidAsync")]
 	[InlineAutoData("InvokeVoid")]
 	public void Test011(string identifier, string arg0, string invocationMethodName)
@@ -90,7 +90,7 @@ public class JSRuntimeUnhandledInvocationExceptionTest
 		Assert.Equal(expectedErrorMessage, sut.Message);
 	}
 
-	[Theory(DisplayName = "Message prints correctly with void return type and multiple string arguments")]
+	[UITheory(DisplayName = "Message prints correctly with void return type and multiple string arguments")]
 	[InlineAutoData("InvokeVoidAsync")]
 	[InlineAutoData("InvokeVoid")]
 	public void Test012(string identifier, string arg0, string arg1, string invocationMethodName)
@@ -106,7 +106,7 @@ public class JSRuntimeUnhandledInvocationExceptionTest
 		Assert.Equal(expectedErrorMessage, sut.Message);
 	}
 
-	[Theory(DisplayName = "Message prints correctly with void return type and multiple non-string arguments")]
+	[UITheory(DisplayName = "Message prints correctly with void return type and multiple non-string arguments")]
 	[InlineAutoData("InvokeVoidAsync")]
 	[InlineAutoData("InvokeVoid")]
 	public void Test013(string identifier, bool arg0, object arg1, string invocationMethodName)
@@ -122,7 +122,7 @@ public class JSRuntimeUnhandledInvocationExceptionTest
 		Assert.Equal(expectedErrorMessage, sut.Message);
 	}
 
-	[Theory(DisplayName = "Message prints correctly with void return type and null argument")]
+	[UITheory(DisplayName = "Message prints correctly with void return type and null argument")]
 	[InlineAutoData("InvokeVoidAsync")]
 	[InlineAutoData("InvokeVoid")]
 	public void Test014(string identifier, string invocationMethodName)
@@ -138,7 +138,7 @@ public class JSRuntimeUnhandledInvocationExceptionTest
 		Assert.Equal(expectedErrorMessage, sut.Message);
 	}
 
-	[Theory(DisplayName = "Message prints correctly with return type and string argument")]
+	[UITheory(DisplayName = "Message prints correctly with return type and string argument")]
 	[AutoData]
 	public void Test021(string identifier, string arg0)
 	{
@@ -155,7 +155,7 @@ public class JSRuntimeUnhandledInvocationExceptionTest
 		Assert.Equal(expectedErrorMessage, sut.Message);
 	}
 
-	[Theory(DisplayName = "Message prints correctly with void return type and multiple string arguments")]
+	[UITheory(DisplayName = "Message prints correctly with void return type and multiple string arguments")]
 	[AutoData]
 	public void Test022(string identifier, string arg0, string arg1)
 	{
@@ -172,7 +172,7 @@ public class JSRuntimeUnhandledInvocationExceptionTest
 		Assert.Equal(expectedErrorMessage, sut.Message);
 	}
 
-	[Theory(DisplayName = "Message prints correctly with void return type and multiple non-string arguments")]
+	[UITheory(DisplayName = "Message prints correctly with void return type and multiple non-string arguments")]
 	[AutoData]
 	public void Test023(string identifier, bool arg0, object arg1)
 	{
@@ -189,7 +189,7 @@ public class JSRuntimeUnhandledInvocationExceptionTest
 		Assert.Equal(expectedErrorMessage, sut.Message);
 	}
 
-	[Theory(DisplayName = "Message prints correctly with void return type and null argument")]
+	[UITheory(DisplayName = "Message prints correctly with void return type and null argument")]
 	[AutoData]
 	public void Test024(string identifier)
 	{
@@ -206,7 +206,7 @@ public class JSRuntimeUnhandledInvocationExceptionTest
 		Assert.Equal(expectedErrorMessage, sut.Message);
 	}
 
-	[Theory(DisplayName = "Message prints generic arguments of InvokeUnmarshalled with one argument correctly")]
+	[UITheory(DisplayName = "Message prints generic arguments of InvokeUnmarshalled with one argument correctly")]
 	[AutoData]
 	public void Test031(string identifier, Dummy1 arg0)
 	{
@@ -223,7 +223,7 @@ public class JSRuntimeUnhandledInvocationExceptionTest
 		Assert.Equal(expectedErrorMessage, sut.Message);
 	}
 
-	[Theory(DisplayName = "Message prints generic arguments of InvokeUnmarshalled with two arguments correctly")]
+	[UITheory(DisplayName = "Message prints generic arguments of InvokeUnmarshalled with two arguments correctly")]
 	[AutoData]
 	public void Test032(string identifier, Dummy1 arg0, Dummy2 arg1)
 	{
@@ -240,7 +240,7 @@ public class JSRuntimeUnhandledInvocationExceptionTest
 		Assert.Equal(expectedErrorMessage, sut.Message);
 	}
 
-	[Theory(DisplayName = "Message prints generic arguments of InvokeUnmarshalled with three arguments correctly")]
+	[UITheory(DisplayName = "Message prints generic arguments of InvokeUnmarshalled with three arguments correctly")]
 	[AutoData]
 	public void Test033(string identifier, Dummy1 arg0, Dummy2 arg1, Dummy3 arg2)
 	{
@@ -257,7 +257,7 @@ public class JSRuntimeUnhandledInvocationExceptionTest
 		Assert.Equal(expectedErrorMessage, sut.Message);
 	}
 
-	[Theory(DisplayName = "Message prints generic arguments of InvokeUnmarshalled with primitive arguments correctly")]
+	[UITheory(DisplayName = "Message prints generic arguments of InvokeUnmarshalled with primitive arguments correctly")]
 	[AutoData]
 	public void Test034(string identifier, int arg0)
 	{
@@ -274,7 +274,7 @@ public class JSRuntimeUnhandledInvocationExceptionTest
 		Assert.Equal(expectedErrorMessage, sut.Message);
 	}
 
-	[Theory(DisplayName = "Message prints generic arguments as '?' of InvokeUnmarshalled when matching argument is null")]
+	[UITheory(DisplayName = "Message prints generic arguments as '?' of InvokeUnmarshalled when matching argument is null")]
 	[AutoData]
 	public void Test035(string identifier)
 	{
@@ -291,7 +291,7 @@ public class JSRuntimeUnhandledInvocationExceptionTest
 		Assert.Equal(expectedErrorMessage, sut.Message);
 	}
 
-	[Theory(DisplayName = "Message prints correctly when trying to import an unconfigured module")]
+	[UITheory(DisplayName = "Message prints correctly when trying to import an unconfigured module")]
 	[AutoData]
 	public void Test036(string moduleName)
 	{

--- a/tests/bunit.web.tests/Rendering/BunitHtmlParserTest.cs
+++ b/tests/bunit.web.tests/Rendering/BunitHtmlParserTest.cs
@@ -30,13 +30,13 @@ public class BunitHtmlParserTest
 	public static readonly IEnumerable<object[]> BodyHtmlAndSpecialElements = BodyHtmlElements.Concat(
 		new[] { "html", "head", "body", }.Select(x => new[] { x }));
 
-	[Fact(DisplayName = "Parse() called with null")]
+	[UIFact(DisplayName = "Parse() called with null")]
 	public void ParseCalledWithNull()
 	{
 		Should.Throw<ArgumentNullException>(() => Parser.Parse(null!));
 	}
 
-	[Theory(DisplayName = "Parse() called with text only")]
+	[UITheory(DisplayName = "Parse() called with text only")]
 	[InlineData("  ")]
 	[InlineData("FOO BAR")]
 	public void ParseWithWhitespaceOnly(string text)
@@ -46,7 +46,7 @@ public class BunitHtmlParserTest
 		actual.ShouldHaveSingleItem().TextContent.ShouldBe(text);
 	}
 
-	[Theory(DisplayName = "Parse() passed <TAG id=TAG>")]
+	[UITheory(DisplayName = "Parse() passed <TAG id=TAG>")]
 	[MemberData(nameof(BodyHtmlAndSpecialElements))]
 	public void Test001(string elementName)
 	{
@@ -55,7 +55,7 @@ public class BunitHtmlParserTest
 		VerifyElementParsedWithId(elementName, actual);
 	}
 
-	[Theory(DisplayName = "Parse() passed <TAG> with whitespace before")]
+	[UITheory(DisplayName = "Parse() passed <TAG> with whitespace before")]
 	[MemberData(nameof(BodyHtmlElements))]
 	public void Test002(string elementName)
 	{
@@ -64,7 +64,7 @@ public class BunitHtmlParserTest
 		VerifyElementParsedWithId(elementName, actual);
 	}
 
-	[Theory(DisplayName = "Parse() passed <TAG>")]
+	[UITheory(DisplayName = "Parse() passed <TAG>")]
 	[MemberData(nameof(BodyHtmlElements))]
 	public void Test003(string elementName)
 	{
@@ -75,7 +75,7 @@ public class BunitHtmlParserTest
 			.NodeName.ShouldBe(elementName, StringCompareShould.IgnoreCase);
 	}
 
-	[Theory(DisplayName = "Parse() passed <TAG/>")]
+	[UITheory(DisplayName = "Parse() passed <TAG/>")]
 	[MemberData(nameof(BodyHtmlElements))]
 	public void Test004(string elementName)
 	{
@@ -86,7 +86,7 @@ public class BunitHtmlParserTest
 			.NodeName.ShouldBe(elementName, StringCompareShould.IgnoreCase);
 	}
 
-	[Theory(DisplayName = "Parse() passed <TAG ...")]
+	[UITheory(DisplayName = "Parse() passed <TAG ...")]
 	[MemberData(nameof(BodyHtmlElements))]
 	public void Test005(string elementName)
 	{
@@ -97,7 +97,7 @@ public class BunitHtmlParserTest
 			.TextContent.ShouldBe(" ");
 	}
 
-	[Theory(DisplayName = "Parse() passed <TAG .../")]
+	[UITheory(DisplayName = "Parse() passed <TAG .../")]
 	[MemberData(nameof(BodyHtmlElements))]
 	public void Test006(string elementName)
 	{

--- a/tests/bunit.web.tests/Rendering/Internal/HtmlizerTests.cs
+++ b/tests/bunit.web.tests/Rendering/Internal/HtmlizerTests.cs
@@ -2,7 +2,7 @@ namespace Bunit.Rendering.Internal;
 
 public class HtmlizerTests : TestContext
 {
-	[Theory(DisplayName = "Htmlizer correctly prefixed stopPropagation and preventDefault attributes")]
+	[UITheory(DisplayName = "Htmlizer correctly prefixed stopPropagation and preventDefault attributes")]
 	[InlineData(false, true)]
 	[InlineData(true, false)]
 	[InlineData(true, true)]
@@ -19,7 +19,7 @@ public class HtmlizerTests : TestContext
 		button.HasAttribute(Htmlizer.ToBlazorAttribute("onclick:preventDefault")).ShouldBe(preventDefault);
 	}
 
-	[Fact(DisplayName = "Blazor ElementReferences are included in rendered markup")]
+	[UIFact(DisplayName = "Blazor ElementReferences are included in rendered markup")]
 	public void Test001()
 	{
 		var cut = RenderComponent<Htmlizer01Component>();
@@ -29,7 +29,7 @@ public class HtmlizerTests : TestContext
 		elmRefValue.ShouldBe(cut.Instance.ButtomElmRef.Id);
 	}
 
-	[Fact(DisplayName = "Blazor ElementReferences start in markup on rerenders")]
+	[UIFact(DisplayName = "Blazor ElementReferences start in markup on rerenders")]
 	public void Test003()
 	{
 		var cut = RenderComponent<Htmlizer01Component>();
@@ -40,7 +40,7 @@ public class HtmlizerTests : TestContext
 		cut.Find("button").HasAttribute("blazor:elementreference").ShouldBeTrue();
 	}
 
-	[Theory(DisplayName = "IsBlazorAttribute correctly identifies Blazor attributes")]
+	[UITheory(DisplayName = "IsBlazorAttribute correctly identifies Blazor attributes")]
 	[InlineData("b-twl12ishk1=\"\"")]
 	[InlineData("blazor:onclick=\"1\"")]
 	[InlineData("blazor:__internal_stopPropagation_onclick=\"\"")]

--- a/tests/bunit.web.tests/Rendering/RenderedComponentTest.cs
+++ b/tests/bunit.web.tests/Rendering/RenderedComponentTest.cs
@@ -4,7 +4,7 @@ namespace Bunit;
 
 public class RenderedComponentTest : TestContext
 {
-	[Fact(DisplayName = "Call to Render() results in a render of component")]
+	[UIFact(DisplayName = "Call to Render() results in a render of component")]
 	public void Test001()
 	{
 		var cut = RenderComponent<Wrapper>(parameters => parameters.AddChildContent("<div>"));
@@ -15,7 +15,7 @@ public class RenderedComponentTest : TestContext
 		cut.RenderCount.ShouldBe(initialRenderCount + 1);
 	}
 
-	[Fact(DisplayName = "Call to SetParametersAndRender(builder) provides the parameters to component")]
+	[UIFact(DisplayName = "Call to SetParametersAndRender(builder) provides the parameters to component")]
 	public void Test004()
 	{
 		var cut = RenderComponent<Wrapper>(parameters => parameters.AddChildContent("<div>"));
@@ -25,7 +25,7 @@ public class RenderedComponentTest : TestContext
 		cut.Find("p").ShouldNotBeNull();
 	}
 
-	[Fact(DisplayName = "Call to SetParametersAndRender(params) provides the parameters to component")]
+	[UIFact(DisplayName = "Call to SetParametersAndRender(params) provides the parameters to component")]
 	public void Test0041()
 	{
 		var cut = RenderComponent<Wrapper>(parameters => parameters.AddChildContent("<div>"));
@@ -35,7 +35,7 @@ public class RenderedComponentTest : TestContext
 		cut.Find("p").ShouldNotBeNull();
 	}
 
-	[Fact(DisplayName = "Trying to set CascadingValue during SetParametersAndRender throws")]
+	[UIFact(DisplayName = "Trying to set CascadingValue during SetParametersAndRender throws")]
 	public void Test003()
 	{
 		// arrange
@@ -46,7 +46,7 @@ public class RenderedComponentTest : TestContext
 		Should.Throw<InvalidOperationException>(() => cut.SetParametersAndRender(ps => ps.Add(p => p.NamedCascadingValue, 1337)));
 	}
 
-	[Fact(DisplayName = "Getting Instance from a RenderedComponent based on a disposed component throws")]
+	[UIFact(DisplayName = "Getting Instance from a RenderedComponent based on a disposed component throws")]
 	public void Test020()
 	{
 		var cut = RenderComponent<ToggleChildComponent>(ps => ps.Add(p => p.ShowChild, true));

--- a/tests/bunit.web.tests/Rendering/RenderedFragmentTest.cs
+++ b/tests/bunit.web.tests/Rendering/RenderedFragmentTest.cs
@@ -10,14 +10,14 @@ public class RenderedFragmentTest : TestContext
 		Services.AddXunitLogger(output);
 	}
 
-	[Fact(DisplayName = "Find throws an exception if no element matches the css selector")]
+	[UIFact(DisplayName = "Find throws an exception if no element matches the css selector")]
 	public void Test001()
 	{
 		var cut = RenderComponent<Wrapper>();
 		Should.Throw<ElementNotFoundException>(() => cut.Find("div"));
 	}
 
-	[Fact(DisplayName = "Find returns expected element that matches the css selector")]
+	[UIFact(DisplayName = "Find returns expected element that matches the css selector")]
 	public void Test002()
 	{
 		var cut = RenderComponent<Wrapper>(x => x.AddChildContent("<div>"));
@@ -25,7 +25,7 @@ public class RenderedFragmentTest : TestContext
 		result.ShouldNotBeNull();
 	}
 
-	[Fact(DisplayName = "Nodes should return new instance " +
+	[UIFact(DisplayName = "Nodes should return new instance " +
 						"when a event handler trigger has caused changes to DOM tree")]
 	public void Test006()
 	{
@@ -37,7 +37,7 @@ public class RenderedFragmentTest : TestContext
 		Assert.NotSame(initialNodes, cut.Nodes);
 	}
 
-	[Fact(DisplayName = "Nodes should return new instance " +
+	[UIFact(DisplayName = "Nodes should return new instance " +
 						"when a nested component has caused the DOM tree to change")]
 	public void Test007()
 	{
@@ -52,7 +52,7 @@ public class RenderedFragmentTest : TestContext
 		Assert.NotSame(initialNodes, cut.Nodes);
 	}
 
-	[Fact(DisplayName = "Nodes should return the same instance " +
+	[UIFact(DisplayName = "Nodes should return the same instance " +
 						"when a re-render does not causes the DOM to change")]
 	public void Test008()
 	{
@@ -65,7 +65,7 @@ public class RenderedFragmentTest : TestContext
 		Assert.Same(initialNodes, cut.Nodes);
 	}
 
-	[Fact(DisplayName = "Changes to event handler should return a new instance of DOM tree")]
+	[UIFact(DisplayName = "Changes to event handler should return a new instance of DOM tree")]
 	public void Test009()
 	{
 		var cut = RenderComponent<ToggleClickHandler>();
@@ -80,7 +80,7 @@ public class RenderedFragmentTest : TestContext
 		cut.Instance.Counter.ShouldBe(1);
 	}
 
-	[Fact(DisplayName = "FindComponent<TComponent> returns component from first branch of tree in first depth first search")]
+	[UIFact(DisplayName = "FindComponent<TComponent> returns component from first branch of tree in first depth first search")]
 	public void Test100()
 	{
 		var wrapper = RenderComponent<TwoComponentWrapper>(builder => builder
@@ -95,7 +95,7 @@ public class RenderedFragmentTest : TestContext
 		cut.Instance.Header.ShouldBe("First");
 	}
 
-	[Fact(DisplayName = "FindComponent<TComponent> finds components when first tree branch is empty")]
+	[UIFact(DisplayName = "FindComponent<TComponent> finds components when first tree branch is empty")]
 	public void Test101()
 	{
 		var wrapper = RenderComponent<TwoComponentWrapper>(builder => builder
@@ -108,7 +108,7 @@ public class RenderedFragmentTest : TestContext
 		cut.Instance.Header.ShouldBe("Second");
 	}
 
-	[Fact(DisplayName = "GetComponent throws when component of requested type is not in the render tree")]
+	[UIFact(DisplayName = "GetComponent throws when component of requested type is not in the render tree")]
 	public void Test102()
 	{
 		var wrapper = RenderComponent<Wrapper>();
@@ -116,7 +116,7 @@ public class RenderedFragmentTest : TestContext
 		Should.Throw<ComponentNotFoundException>(() => wrapper.FindComponent<Simple1>());
 	}
 
-	[Fact(DisplayName = "GetComponents returns all components of requested type using a depth first order")]
+	[UIFact(DisplayName = "GetComponents returns all components of requested type using a depth first order")]
 	public void Test103()
 	{
 		var wrapper = RenderComponent<TwoComponentWrapper>(builder => builder
@@ -133,7 +133,7 @@ public class RenderedFragmentTest : TestContext
 		cuts[1].Instance.Header.ShouldBe("Second");
 	}
 
-	[Fact(DisplayName = "Render events for non-rendered sub components are not emitted")]
+	[UIFact(DisplayName = "Render events for non-rendered sub components are not emitted")]
 	public void Test010()
 	{
 		var wrapper = RenderComponent<TwoComponentWrapper>(parameters => parameters
@@ -160,7 +160,7 @@ public class RenderedFragmentTest : TestContext
 		second.RenderCount.ShouldBe(2);
 	}
 
-	[Fact(DisplayName = "Getting Markup from a RenderedFragment based on a disposed component throws")]
+	[UIFact(DisplayName = "Getting Markup from a RenderedFragment based on a disposed component throws")]
 	public void Test020()
 	{
 		var cut = RenderComponent<ToggleChildComponent>(ps => ps.Add(p => p.ShowChild, true));

--- a/tests/bunit.web.tests/TestContextTest.cs
+++ b/tests/bunit.web.tests/TestContextTest.cs
@@ -4,19 +4,19 @@ namespace Bunit;
 
 public class TestContextTest : TestContext
 {
-	[Fact(DisplayName = "The test service provider should register a placeholder HttpClient which throws exceptions")]
+	[UIFact(DisplayName = "The test service provider should register a placeholder HttpClient which throws exceptions")]
 	public void Test024()
 	{
 		Should.Throw<MissingMockHttpClientException>(() => RenderComponent<SimpleWithHttpClient>());
 	}
 
-	[Fact(DisplayName = "The test service provider should register a placeholder IStringLocalizer which throws exceptions")]
+	[UIFact(DisplayName = "The test service provider should register a placeholder IStringLocalizer which throws exceptions")]
 	public void Test026()
 	{
 		Should.Throw<MissingMockStringLocalizationException>(() => RenderComponent<SimpleUsingLocalizer>());
 	}
 
-	[Fact(DisplayName = "Render() renders fragment inside RenderTree")]
+	[UIFact(DisplayName = "Render() renders fragment inside RenderTree")]
 	public void Test030()
 	{
 		RenderTree.Add<CascadingValue<string>>(ps => ps.Add(p => p.Value, "FOO"));
@@ -32,7 +32,7 @@ public class TestContextTest : TestContext
 			.ShouldBe("FOO");
 	}
 
-	[Fact(DisplayName = "Render<TComponent>() renders fragment inside RenderTreee")]
+	[UIFact(DisplayName = "Render<TComponent>() renders fragment inside RenderTreee")]
 	public void Test031()
 	{
 		RenderTree.Add<CascadingValue<string>>(ps => ps.Add(p => p.Value, "FOO"));
@@ -47,7 +47,7 @@ public class TestContextTest : TestContext
 			.ShouldBe("FOO");
 	}
 
-	[Fact(DisplayName = "RenderComponent<TComponent>(builder) renders TComponent inside RenderTreee")]
+	[UIFact(DisplayName = "RenderComponent<TComponent>(builder) renders TComponent inside RenderTreee")]
 	public void Test032()
 	{
 		RenderTree.Add<CascadingValue<string>>(ps => ps.Add(p => p.Value, "FOO"));
@@ -58,7 +58,7 @@ public class TestContextTest : TestContext
 			.ShouldBe("FOO");
 	}
 
-	[Fact(DisplayName = "RenderComponent<TComponent>(factories) renders TComponent inside RenderTreee")]
+	[UIFact(DisplayName = "RenderComponent<TComponent>(factories) renders TComponent inside RenderTreee")]
 	public void Test033()
 	{
 		RenderTree.Add<CascadingValue<string>>(ps => ps.Add(p => p.Value, "FOO"));
@@ -69,7 +69,7 @@ public class TestContextTest : TestContext
 			.ShouldBe("FOO");
 	}
 
-	[Fact(DisplayName = "Can raise events from markup rendered with TestContext")]
+	[UIFact(DisplayName = "Can raise events from markup rendered with TestContext")]
 	public void Test040()
 	{
 		Should.NotThrow(() => RenderComponent<ClickCounter>().Find("button").Click());

--- a/tests/bunit.web.tests/TestDoubles/Authorization/AuthorizationTest.cs
+++ b/tests/bunit.web.tests/TestDoubles/Authorization/AuthorizationTest.cs
@@ -4,7 +4,7 @@ namespace Bunit.TestDoubles.Authorization;
 
 public class AuthorizationTest : TestContext
 {
-	[Fact(DisplayName = "AuthorizeView with unauthenticated user")]
+	[UIFact(DisplayName = "AuthorizeView with unauthenticated user")]
 	public void Test001()
 	{
 		// Arrange
@@ -17,7 +17,7 @@ public class AuthorizationTest : TestContext
 		cut.MarkupMatches("Not authorized?");
 	}
 
-	[Fact(DisplayName = "AuthorizeView with authenticated and authorized user")]
+	[UIFact(DisplayName = "AuthorizeView with authenticated and authorized user")]
 	public void Test002()
 	{
 		// arrange
@@ -31,7 +31,7 @@ public class AuthorizationTest : TestContext
 		cut.MarkupMatches("Authorized!");
 	}
 
-	[Fact(DisplayName = "AuthorizeView with authenticated but unauthorized user")]
+	[UIFact(DisplayName = "AuthorizeView with authenticated but unauthorized user")]
 	public void Test003()
 	{
 		// arrange
@@ -45,7 +45,7 @@ public class AuthorizationTest : TestContext
 		cut.MarkupMatches("Not authorized?");
 	}
 
-	[Fact(DisplayName = "AuthorizeView switch from unauthorized to authorized.")]
+	[UIFact(DisplayName = "AuthorizeView switch from unauthorized to authorized.")]
 	[Trait("Category", "async")]
 	public async Task Test004()
 	{
@@ -65,7 +65,7 @@ public class AuthorizationTest : TestContext
 		await cut.WaitForAssertionAsync(() => cut.MarkupMatches("Authorized!"));
 	}
 
-	[Fact(DisplayName = "AuthorizeView switch from unauthorized to authorized.")]
+	[UIFact(DisplayName = "AuthorizeView switch from unauthorized to authorized.")]
 	[Trait("Category", "sync")]
 	public void Test004_Sync()
 	{
@@ -85,7 +85,7 @@ public class AuthorizationTest : TestContext
 		cut.WaitForAssertion(() => cut.MarkupMatches("Authorized!"));
 	}
 
-	[Fact(DisplayName = "AuthorizeView switch from authorized to unauthorized.")]
+	[UIFact(DisplayName = "AuthorizeView switch from authorized to unauthorized.")]
 	public void Test005()
 	{
 		// arrange
@@ -105,7 +105,7 @@ public class AuthorizationTest : TestContext
 		cut.MarkupMatches("Not authorized?");
 	}
 
-	[Fact(DisplayName = "AuthorizeView rendering without authorization services registered")]
+	[UIFact(DisplayName = "AuthorizeView rendering without authorization services registered")]
 	public void Test006()
 	{
 		// act
@@ -116,7 +116,7 @@ public class AuthorizationTest : TestContext
 		Assert.Equal("https://bunit.egilhansen.com/docs/test-doubles/faking-auth", ex.HelpLink);
 	}
 
-	[Fact(DisplayName = "AuthorizeView with set policy with authenticated and authorized user")]
+	[UIFact(DisplayName = "AuthorizeView with set policy with authenticated and authorized user")]
 	public void Test007()
 	{
 		// arrange
@@ -130,7 +130,7 @@ public class AuthorizationTest : TestContext
 		cut.MarkupMatches("Authorized for content viewers.");
 	}
 
-	[Fact(DisplayName = "AuthorizeView without policy set")]
+	[UIFact(DisplayName = "AuthorizeView without policy set")]
 	public void Test008()
 	{
 		// arrange
@@ -144,7 +144,7 @@ public class AuthorizationTest : TestContext
 		cut.MarkupMatches(string.Empty);
 	}
 
-	[Fact(DisplayName = "AuthorizeView with wrong policy set")]
+	[UIFact(DisplayName = "AuthorizeView with wrong policy set")]
 	public void Test0081()
 	{
 		// arrange
@@ -158,7 +158,7 @@ public class AuthorizationTest : TestContext
 		cut.MarkupMatches(string.Empty);
 	}
 
-	[Fact(DisplayName = "SimpleAuthViewWithRole with set role")]
+	[UIFact(DisplayName = "SimpleAuthViewWithRole with set role")]
 	public void Test009()
 	{
 		// arrange
@@ -172,7 +172,7 @@ public class AuthorizationTest : TestContext
 		cut.MarkupMatches("Authorized content for admins.");
 	}
 
-	[Fact(DisplayName = "AuthorizeView without set role")]
+	[UIFact(DisplayName = "AuthorizeView without set role")]
 	public void Test010()
 	{
 		// arrange
@@ -186,7 +186,7 @@ public class AuthorizationTest : TestContext
 		cut.MarkupMatches(string.Empty);
 	}
 
-	[Fact(DisplayName = "AuthorizeView with wrong role set")]
+	[UIFact(DisplayName = "AuthorizeView with wrong role set")]
 	public void Test011()
 	{
 		// arrange
@@ -200,7 +200,7 @@ public class AuthorizationTest : TestContext
 		cut.MarkupMatches(string.Empty);
 	}
 
-	[Fact(DisplayName = "AuthorizeView in authorizing state")]
+	[UIFact(DisplayName = "AuthorizeView in authorizing state")]
 	public void Test012()
 	{
 		// arrange
@@ -214,7 +214,7 @@ public class AuthorizationTest : TestContext
 		cut.MarkupMatches("Authorizing...");
 	}
 
-	[Fact(DisplayName = "AuthorizeView with claims")]
+	[UIFact(DisplayName = "AuthorizeView with claims")]
 	public void Test013()
 	{
 		// arrange
@@ -234,7 +234,7 @@ public class AuthorizationTest : TestContext
 								<div>Id: {userId}</div>");
 	}
 
-	[Fact(DisplayName = "AuthorizeView without defined claims")]
+	[UIFact(DisplayName = "AuthorizeView without defined claims")]
 	public void Test014()
 	{
 		// arrange
@@ -249,7 +249,7 @@ public class AuthorizationTest : TestContext
 								<div>Name: TestUser</div>");
 	}
 
-	[Fact(DisplayName = "IsInRole can resolve role assigned to auth context")]
+	[UIFact(DisplayName = "IsInRole can resolve role assigned to auth context")]
 	public void Test020()
 	{
 		var role = "myTestRole";
@@ -262,7 +262,7 @@ public class AuthorizationTest : TestContext
 		cut.MarkupMatches("<p>True</p>");
 	}
 
-	[Fact(DisplayName = "SimpleAuthViewWithCustomAuthType with set auth type")]
+	[UIFact(DisplayName = "SimpleAuthViewWithCustomAuthType with set auth type")]
 	public void Test021()
 	{
 		// arrange
@@ -277,7 +277,7 @@ public class AuthorizationTest : TestContext
 		cut.MarkupMatches("<p>Authorized content with custom auth type.</p>");
 	}
 
-	[Fact(DisplayName = "SimpleAuthViewWithCustomAuthType without set auth type")]
+	[UIFact(DisplayName = "SimpleAuthViewWithCustomAuthType without set auth type")]
 	public void Test022()
 	{
 		// arrange

--- a/tests/bunit.web.tests/TestDoubles/Authorization/FakeAuthenticationStateProviderTest.cs
+++ b/tests/bunit.web.tests/TestDoubles/Authorization/FakeAuthenticationStateProviderTest.cs
@@ -2,7 +2,7 @@ namespace Bunit.TestDoubles.Authorization;
 
 public class FakeAuthenticationStateProviderTest
 {
-	[Fact(DisplayName = "Create authenticated AuthenticationState")]
+	[UIFact(DisplayName = "Create authenticated AuthenticationState")]
 	public async Task Test001()
 	{
 		// arrange
@@ -19,7 +19,7 @@ public class FakeAuthenticationStateProviderTest
 		Assert.True(authState?.User?.Identity?.IsAuthenticated);
 	}
 
-	[Fact(DisplayName = "Create unauthenticated AuthenticationState")]
+	[UIFact(DisplayName = "Create unauthenticated AuthenticationState")]
 	public async Task Test002()
 	{
 		// act
@@ -33,7 +33,7 @@ public class FakeAuthenticationStateProviderTest
 		Assert.False(authState?.User?.Identity?.IsAuthenticated);
 	}
 
-	[Fact(DisplayName = "Switch AuthenticationState from unauthenticated to authenticated.")]
+	[UIFact(DisplayName = "Switch AuthenticationState from unauthenticated to authenticated.")]
 	public async Task Test003()
 	{
 		// arrange

--- a/tests/bunit.web.tests/TestDoubles/Authorization/FakeAuthorizationPolicyProviderTest.cs
+++ b/tests/bunit.web.tests/TestDoubles/Authorization/FakeAuthorizationPolicyProviderTest.cs
@@ -4,7 +4,7 @@ namespace Bunit.TestDoubles.Authorization;
 
 public class FakeAuthorizationPolicyProviderTest
 {
-	[Fact(DisplayName = "Get default policy from PolicyProvider.")]
+	[UIFact(DisplayName = "Get default policy from PolicyProvider.")]
 	public async Task Test001()
 	{
 		// arrange
@@ -20,7 +20,7 @@ public class FakeAuthorizationPolicyProviderTest
 		Assert.IsType<DenyAnonymousAuthorizationRequirement>(policy.Requirements[0]);
 	}
 
-	[Fact(DisplayName = "Get fallback policy from PolicyProvider.")]
+	[UIFact(DisplayName = "Get fallback policy from PolicyProvider.")]
 	public async Task Test002()
 	{
 		// arrange
@@ -33,7 +33,7 @@ public class FakeAuthorizationPolicyProviderTest
 		Assert.Null(policy);
 	}
 
-	[Fact(DisplayName = "Get policy based on name from PolicyProvider.")]
+	[UIFact(DisplayName = "Get policy based on name from PolicyProvider.")]
 	public async Task Test003()
 	{
 		// arrange
@@ -51,7 +51,7 @@ public class FakeAuthorizationPolicyProviderTest
 		Assert.IsType<TestPolicyRequirement>(policy?.Requirements?[0]);
 	}
 
-	[Fact(DisplayName = "Get policy based on name not in the PolicyProvider.")]
+	[UIFact(DisplayName = "Get policy based on name not in the PolicyProvider.")]
 	public async Task Test004()
 	{
 		// arrange
@@ -69,7 +69,7 @@ public class FakeAuthorizationPolicyProviderTest
 		Assert.IsType<TestPolicyRequirement>(policy?.Requirements?[0]);
 	}
 
-	[Fact(DisplayName = "Set Policies with empty scheme name.")]
+	[UIFact(DisplayName = "Set Policies with empty scheme name.")]
 	public void Test006()
 	{
 		// arrange

--- a/tests/bunit.web.tests/TestDoubles/Authorization/FakeAuthorizationServiceTest.cs
+++ b/tests/bunit.web.tests/TestDoubles/Authorization/FakeAuthorizationServiceTest.cs
@@ -5,7 +5,7 @@ namespace Bunit.TestDoubles.Authorization;
 
 public class FakeAuthorizationServiceTest
 {
-	[Fact(DisplayName = "Get AuthorizeAsync with an authorized result.")]
+	[UIFact(DisplayName = "Get AuthorizeAsync with an authorized result.")]
 	public async Task Test002()
 	{
 		// arrange
@@ -21,7 +21,7 @@ public class FakeAuthorizationServiceTest
 		Assert.False(result.Succeeded);
 	}
 
-	[Fact(DisplayName = "Get AuthorizeAsync with an authorized result.")]
+	[UIFact(DisplayName = "Get AuthorizeAsync with an authorized result.")]
 	public async Task Test003()
 	{
 		// arrange
@@ -37,7 +37,7 @@ public class FakeAuthorizationServiceTest
 		Assert.True(result.Succeeded);
 	}
 
-	[Fact(DisplayName = "Get AuthorizeAsync with policy name.")]
+	[UIFact(DisplayName = "Get AuthorizeAsync with policy name.")]
 	public async Task Test004()
 	{
 		// arrange
@@ -52,7 +52,7 @@ public class FakeAuthorizationServiceTest
 		Assert.False(result.Succeeded);
 	}
 
-	[Fact(DisplayName = "Get exception from invoking placeholder AuthorizationService methods.")]
+	[UIFact(DisplayName = "Get exception from invoking placeholder AuthorizationService methods.")]
 	public async Task Test005()
 	{
 		// arrange
@@ -68,7 +68,7 @@ public class FakeAuthorizationServiceTest
 		Assert.Equal("IAuthorizationService", ex.ServiceName);
 	}
 
-	[Fact(DisplayName = "Get exception from invoking placeholder AuthorizationService methods.")]
+	[UIFact(DisplayName = "Get exception from invoking placeholder AuthorizationService methods.")]
 	public async Task Test006()
 	{
 		// arrange

--- a/tests/bunit.web.tests/TestDoubles/Authorization/TestAuthorizationContextTest.cs
+++ b/tests/bunit.web.tests/TestDoubles/Authorization/TestAuthorizationContextTest.cs
@@ -2,7 +2,7 @@ namespace Bunit.TestDoubles.Authorization;
 
 public class TestAuthorizationContextTest : TestContext
 {
-	[Fact(DisplayName = "Register Authorization services with unauthenticated user.")]
+	[UIFact(DisplayName = "Register Authorization services with unauthenticated user.")]
 	public void Test003()
 	{
 		// act
@@ -15,7 +15,7 @@ public class TestAuthorizationContextTest : TestContext
 		Assert.Empty(authContext.Policies);
 	}
 
-	[Fact(DisplayName = "Register Authorization services with authorizing state.")]
+	[UIFact(DisplayName = "Register Authorization services with authorizing state.")]
 	public void Test0031()
 	{
 		// act
@@ -29,7 +29,7 @@ public class TestAuthorizationContextTest : TestContext
 		Assert.Empty(authContext.Policies);
 	}
 
-	[Fact(DisplayName = "Register Authorization services with authenticated but unauthorized user.")]
+	[UIFact(DisplayName = "Register Authorization services with authenticated but unauthorized user.")]
 	public void Test002()
 	{
 		// act
@@ -43,7 +43,7 @@ public class TestAuthorizationContextTest : TestContext
 		Assert.Empty(authContext.Policies);
 	}
 
-	[Fact(DisplayName = "Register Authorization services with authenticated and authorized user")]
+	[UIFact(DisplayName = "Register Authorization services with authenticated and authorized user")]
 	public void Test0010()
 	{
 		// act
@@ -57,7 +57,7 @@ public class TestAuthorizationContextTest : TestContext
 		Assert.Empty(authContext.Policies);
 	}
 
-	[Fact(DisplayName = "Register Authorization services with authenticated and authorized user and role.")]
+	[UIFact(DisplayName = "Register Authorization services with authenticated and authorized user and role.")]
 	public void Test001()
 	{
 		// act
@@ -72,7 +72,7 @@ public class TestAuthorizationContextTest : TestContext
 		Assert.Empty(authContext.Policies);
 	}
 
-	[Fact(DisplayName = "Register Authorization services with authenticated and authorized user and policy.")]
+	[UIFact(DisplayName = "Register Authorization services with authenticated and authorized user and policy.")]
 	public void Test0011()
 	{
 		// act

--- a/tests/bunit.web.tests/TestDoubles/Components/CapturedParameterViewTest.cs
+++ b/tests/bunit.web.tests/TestDoubles/Components/CapturedParameterViewTest.cs
@@ -2,21 +2,21 @@ namespace Bunit.TestDoubles.Components;
 
 public class CapturedParameterViewTest
 {
-	[Fact(DisplayName = "Get(paramterSelector) throws if selector is null")]
+	[UIFact(DisplayName = "Get(paramterSelector) throws if selector is null")]
 	public void Test010()
 	{
 		var sut = CapturedParameterView<AllTypesOfParams<string>>.Empty;
 		Should.Throw<ArgumentNullException>(() => sut.Get<string>(parameterSelector: default));
 	}
 
-	[Fact(DisplayName = "Get(parameterSelector) throws if method is selected")]
+	[UIFact(DisplayName = "Get(parameterSelector) throws if method is selected")]
 	public void Test011()
 	{
 		var sut = CapturedParameterView<AllTypesOfParams<string>>.Empty;
 		Should.Throw<ArgumentException>(() => sut.Get(x => x.DummyMethod()));
 	}
 
-	[Fact(DisplayName = "Get(parameterSelector) throws if non-parameter property is selected")]
+	[UIFact(DisplayName = "Get(parameterSelector) throws if non-parameter property is selected")]
 	public void Test012()
 	{
 		var sut = CapturedParameterView<AllTypesOfParams<string>>.Empty;
@@ -24,14 +24,14 @@ public class CapturedParameterViewTest
 		Should.Throw<ArgumentException>(() => sut.Get(x => x.JSRuntime));
 	}
 
-	[Fact(DisplayName = "Get(parameterSelector) throws if selected parameter was not added to parameter view")]
+	[UIFact(DisplayName = "Get(parameterSelector) throws if selected parameter was not added to parameter view")]
 	public void Test013()
 	{
 		var sut = CapturedParameterView<AllTypesOfParams<string>>.Empty;
 		Should.Throw<ParameterNotFoundException>(() => sut.Get(x => x.RegularParam));
 	}
 
-	[Fact(DisplayName = "Get(parameterSelector) throws if selected parameter is not the expected type")]
+	[UIFact(DisplayName = "Get(parameterSelector) throws if selected parameter is not the expected type")]
 	public void Test014()
 	{
 		var sut = CapturedParameterView<AllTypesOfParams<string>>.From(
@@ -42,7 +42,7 @@ public class CapturedParameterViewTest
 		Should.Throw<InvalidCastException>(() => sut.Get(x => x.ChildContent));
 	}
 
-	[Theory(DisplayName = "Get(paramterSelector) returns value of selected parameter")]
+	[UITheory(DisplayName = "Get(paramterSelector) returns value of selected parameter")]
 	[AutoData]
 	public void Test020(string regularParam)
 	{
@@ -54,7 +54,7 @@ public class CapturedParameterViewTest
 		sut.Get(x => x.RegularParam).ShouldBe(regularParam);
 	}
 
-	[Fact(DisplayName = "GetParameter(paramterSelector) returns null when null was passed to selected parameter")]
+	[UIFact(DisplayName = "GetParameter(paramterSelector) returns null when null was passed to selected parameter")]
 	public void Test021()
 	{
 		var sut = CapturedParameterView<AllTypesOfParams<string>>.From(

--- a/tests/bunit.web.tests/TestDoubles/Components/ComponentDoubleBaseTest.cs
+++ b/tests/bunit.web.tests/TestDoubles/Components/ComponentDoubleBaseTest.cs
@@ -6,7 +6,7 @@ public class ComponentDoubleBaseTest : TestContext
 		where TComponent : IComponent
 	{ }
 
-	[Theory(DisplayName = "Double captures unmatched parameters")]
+	[UITheory(DisplayName = "Double captures unmatched parameters")]
 	[AutoData]
 	public void Test022(string attrName, string attrValue)
 	{

--- a/tests/bunit.web.tests/TestDoubles/Components/StubTest.cs
+++ b/tests/bunit.web.tests/TestDoubles/Components/StubTest.cs
@@ -2,7 +2,7 @@ namespace Bunit.TestDoubles.Components;
 
 public class StubTest : TestContext
 {
-	[Fact(DisplayName = "Stub<TComponent> renders nothing without a replacement template")]
+	[UIFact(DisplayName = "Stub<TComponent> renders nothing without a replacement template")]
 	public void Test001()
 	{
 		var cut = RenderComponent<Stub<Simple1>>();
@@ -10,7 +10,7 @@ public class StubTest : TestContext
 		cut.Nodes.Length.ShouldBe(0);
 	}
 
-	[Theory(DisplayName = "Stub<TComponent> captures parameters passed to TComponent")]
+	[UITheory(DisplayName = "Stub<TComponent> captures parameters passed to TComponent")]
 	[AutoData]
 	public void Test002(string header, string attrValue)
 	{

--- a/tests/bunit.web.tests/TestDoubles/FakeSignOutSessionStateManagerTest.cs
+++ b/tests/bunit.web.tests/TestDoubles/FakeSignOutSessionStateManagerTest.cs
@@ -15,7 +15,7 @@ public class FakeSignOutSessionStateManagerTest : TestContext
 			.ShouldBeTrue();
 	}
 
-	[Fact]
+	[UIFact]
 	public void ShouldReturnSignOutStateOnValidateSignOutState()
 	{
 		var cut = new FakeSignOutSessionStateManager(Mock.Of<IJSRuntime>());

--- a/tests/bunit.web.tests/TestDoubles/FakeWebAssemblyHostEnvironmentTest.cs
+++ b/tests/bunit.web.tests/TestDoubles/FakeWebAssemblyHostEnvironmentTest.cs
@@ -2,7 +2,7 @@ namespace Bunit.TestDoubles;
 
 public class FakeWebAssemblyHostEnvironmentTest : TestContext
 {
-	[Fact]
+	[UIFact]
 	public void ShouldSayHelloToDevelopers()
 	{
 		var hostEnvironment = Services.GetRequiredService<FakeWebAssemblyHostEnvironment>();
@@ -14,7 +14,7 @@ public class FakeWebAssemblyHostEnvironmentTest : TestContext
 		cut.Find("p").MarkupMatches($"<p>Hello Developers. The base URL is: /</p>");
 	}
 
-	[Fact]
+	[UIFact]
 	public void ShouldUseCorrectBaseAddress()
 	{
 		var hostEnvironment = Services.GetRequiredService<FakeWebAssemblyHostEnvironment>();

--- a/tests/bunit.web.tests/TestDoubles/NavigationManager/FakeNavigationInterceptionTest.cs
+++ b/tests/bunit.web.tests/TestDoubles/NavigationManager/FakeNavigationInterceptionTest.cs
@@ -2,7 +2,7 @@ namespace Bunit.TestDoubles;
 
 public class FakeNavigationInterceptionTest
 {
-	[Fact(DisplayName = "EnableNavigationInterceptionAsync returns completed task")]
+	[UIFact(DisplayName = "EnableNavigationInterceptionAsync returns completed task")]
 	public void Test001()
 	{
 		new FakeNavigationInterception()
@@ -11,7 +11,7 @@ public class FakeNavigationInterceptionTest
 			.ShouldBeTrue();
 	}
 
-	[Fact(DisplayName = "FakeNavigationInterception is registered as the default INavigationInterception")]
+	[UIFact(DisplayName = "FakeNavigationInterception is registered as the default INavigationInterception")]
 	public void Test002()
 	{
 		using var ctx = new TestContext();

--- a/tests/bunit.web.tests/TestDoubles/NavigationManager/FakeNavigationManagerTest.cs
+++ b/tests/bunit.web.tests/TestDoubles/NavigationManager/FakeNavigationManagerTest.cs
@@ -10,7 +10,7 @@ public class FakeNavigationManagerTest : TestContext
 	private FakeNavigationManager CreateFakeNavigationManager()
 		=> Services.GetRequiredService<FakeNavigationManager>();
 
-	[Fact(DisplayName = "TestContext.Services has NavigationManager registered by default as FakeNavigationManager")]
+	[UIFact(DisplayName = "TestContext.Services has NavigationManager registered by default as FakeNavigationManager")]
 	public void Test001()
 	{
 		var nm = Services.GetService<NavigationManager>();
@@ -21,7 +21,7 @@ public class FakeNavigationManagerTest : TestContext
 		nm.ShouldBe(fnm);
 	}
 
-	[Fact(DisplayName = "FakeNavigationManager.BaseUrl is set to http://localhost/")]
+	[UIFact(DisplayName = "FakeNavigationManager.BaseUrl is set to http://localhost/")]
 	public void Test002()
 	{
 		var sut = CreateFakeNavigationManager();
@@ -29,7 +29,7 @@ public class FakeNavigationManagerTest : TestContext
 		sut.BaseUri.ShouldBe("http://localhost/");
 	}
 
-	[Theory(DisplayName = "NavigateTo with relative URI converts it to absolute and sets the Uri property ")]
+	[UITheory(DisplayName = "NavigateTo with relative URI converts it to absolute and sets the Uri property ")]
 	[InlineData("")]
 	[InlineData("/")]
 	[InlineData("/foo")]
@@ -43,7 +43,7 @@ public class FakeNavigationManagerTest : TestContext
 		sut.Uri.ShouldBe(expectedUri.ToString());
 	}
 
-	[Theory(DisplayName = "NavigateTo with absolute URI sets the Uri property")]
+	[UITheory(DisplayName = "NavigateTo with absolute URI sets the Uri property")]
 	[InlineData("http://localhost")]
 	[InlineData("http://localhost/")]
 	[InlineData("http://localhost/foo")]
@@ -57,7 +57,7 @@ public class FakeNavigationManagerTest : TestContext
 		sut.Uri.ShouldBe(expectedUri.OriginalString);
 	}
 
-	[Fact(DisplayName = "NavigateTo raises the NotifyLocationChanged")]
+	[UIFact(DisplayName = "NavigateTo raises the NotifyLocationChanged")]
 	public void Test005()
 	{
 		// arrange
@@ -80,7 +80,7 @@ public class FakeNavigationManagerTest : TestContext
 		}
 	}
 
-	[Fact(DisplayName = "LocationChanged is raised on the test renderer's dispatcher")]
+	[UIFact(DisplayName = "LocationChanged is raised on the test renderer's dispatcher")]
 	public void Test006()
 	{
 		var sut = CreateFakeNavigationManager();
@@ -91,7 +91,7 @@ public class FakeNavigationManagerTest : TestContext
 		cut.Find("p").MarkupMatches($"<p>{sut.BaseUri}foo</p>");
 	}
 
-	[Fact(DisplayName = "Uri should not be unescaped")]
+	[UIFact(DisplayName = "Uri should not be unescaped")]
 	public void Test007()
 	{
 		var sut = CreateFakeNavigationManager();
@@ -101,7 +101,7 @@ public class FakeNavigationManagerTest : TestContext
 		sut.Uri.ShouldEndWith("with%20whitespace");
 	}
 
-	[Theory(DisplayName = "NavigateTo(uri, forceLoad, replaceHistoryEntry) is saved in history")]
+	[UITheory(DisplayName = "NavigateTo(uri, forceLoad, replaceHistoryEntry) is saved in history")]
 	[InlineData("/uri", false, false)]
 	[InlineData("/uri", true, false)]
 	[InlineData("/uri", false, true)]
@@ -123,7 +123,7 @@ public class FakeNavigationManagerTest : TestContext
 #endif
 	}
 
-	[Fact(DisplayName = "NavigateTo with replaceHistoryEntry true replaces previous history entry")]
+	[UIFact(DisplayName = "NavigateTo with replaceHistoryEntry true replaces previous history entry")]
 	public void Test201()
 	{
 		var sut = CreateFakeNavigationManager();
@@ -142,7 +142,7 @@ public class FakeNavigationManagerTest : TestContext
 #endif
 	}
 
-	[Fact(DisplayName = "Navigate to an external url should set BaseUri")]
+	[UIFact(DisplayName = "Navigate to an external url should set BaseUri")]
 	public void Test008()
 	{
 		const string externalUri = "https://bunit.dev/docs/getting-started/index.html";
@@ -154,7 +154,7 @@ public class FakeNavigationManagerTest : TestContext
 		sut.Uri.ShouldBe(externalUri);
 	}
 
-	[Fact(DisplayName = "Navigate to external url should not invoke LocationChanged event")]
+	[UIFact(DisplayName = "Navigate to external url should not invoke LocationChanged event")]
 	public void Test009()
 	{
 		var locationChangedInvoked = false;
@@ -168,7 +168,7 @@ public class FakeNavigationManagerTest : TestContext
 	}
 
 #if NET7_0_OR_GREATER
-	[Fact(DisplayName = "When component provides NavigationLock, FakeNavigationManager should intercept calls")]
+	[UIFact(DisplayName = "When component provides NavigationLock, FakeNavigationManager should intercept calls")]
 	public void Test010()
 	{
 		var fakeNavigationManager = CreateFakeNavigationManager();
@@ -180,7 +180,7 @@ public class FakeNavigationManagerTest : TestContext
 		fakeNavigationManager.History.Single().State.ShouldBe(NavigationState.Prevented);
 	}
 
-	[Fact(DisplayName = "Intercepting external url's should work")]
+	[UIFact(DisplayName = "Intercepting external url's should work")]
 	public void Test011()
 	{
 		var fakeNavigationManager = CreateFakeNavigationManager();
@@ -191,7 +191,7 @@ public class FakeNavigationManagerTest : TestContext
 		fakeNavigationManager.History.ShouldNotBeEmpty();
 	}
 
-	[Fact(DisplayName = "Exception while intercepting is set on FakeNaviationManager")]
+	[UIFact(DisplayName = "Exception while intercepting is set on FakeNaviationManager")]
 	public void Test012()
 	{
 		var fakeNavigationManager = CreateFakeNavigationManager();
@@ -204,7 +204,7 @@ public class FakeNavigationManagerTest : TestContext
 		entry.State.ShouldBe(NavigationState.Faulted);
 	}
 
-	[Fact(DisplayName = "StateFromJson deserialize InteractiveRequestOptions")]
+	[UIFact(DisplayName = "StateFromJson deserialize InteractiveRequestOptions")]
 	public void Test013()
 	{
 		var fakeNavigationManager = CreateFakeNavigationManager();
@@ -224,7 +224,7 @@ public class FakeNavigationManagerTest : TestContext
 		libraryName.ShouldBe("bunit");
 	}
 
-	[Fact(DisplayName = "Given no content in state then StateFromJson throws")]
+	[UIFact(DisplayName = "Given no content in state then StateFromJson throws")]
 	public void Test014()
 	{
 		var fakeNavigationManager = CreateFakeNavigationManager();
@@ -234,7 +234,7 @@ public class FakeNavigationManagerTest : TestContext
 			() => fakeNavigationManager.History.Last().StateFromJson<InteractiveRequestOptions>());
 	}
 
-	[Fact(DisplayName = "StateFromJson with invalid json throws")]
+	[UIFact(DisplayName = "StateFromJson with invalid json throws")]
 	public void Test015()
 	{
 		var fakeNavigationManager = CreateFakeNavigationManager();

--- a/tests/bunit.web.tests/V2/Renderer/BunitRendererTest.cs
+++ b/tests/bunit.web.tests/V2/Renderer/BunitRendererTest.cs
@@ -1,5 +1,0 @@
-namespace Bunit.V2.Renderer;
-public class BunitRendererTest
-{
-
-}

--- a/tests/bunit.web.tests/V2/Renderer/BunitRendererTest.cs
+++ b/tests/bunit.web.tests/V2/Renderer/BunitRendererTest.cs
@@ -1,0 +1,5 @@
+namespace Bunit.V2.Renderer;
+public class BunitRendererTest
+{
+
+}

--- a/tests/bunit.web.tests/V2/SyncContextTests.cs
+++ b/tests/bunit.web.tests/V2/SyncContextTests.cs
@@ -1,0 +1,48 @@
+using AngleSharp.Dom;
+using Bunit.TestAssets.BlazorE2E;
+using Microsoft.Extensions.Logging;
+using Serilog;
+using Serilog.Events;
+using Xunit.Abstractions;
+
+namespace Bunit.V2;
+
+public class BunitContextTests : BunitContext
+{
+	private static ILoggerFactory CreateXunitLoggerFactory(ITestOutputHelper outputHelper)
+	{
+		var serilogLogger = new LoggerConfiguration()
+			.MinimumLevel.Verbose()
+			.Enrich.With(new ThreadIDEnricher())
+			.WriteTo.TestOutput(
+				testOutputHelper: outputHelper,
+				restrictedToMinimumLevel: LogEventLevel.Verbose,
+				outputTemplate: ThreadIDEnricher.DefaultConsoleOutputTemplate)
+			.CreateLogger();
+
+		return new LoggerFactory().AddSerilog(serilogLogger, dispose: true);
+	}
+
+	public BunitContextTests(ITestOutputHelper outputHelper)
+		: base(CreateXunitLoggerFactory(outputHelper))
+	{
+	}
+
+	[Fact]
+	public async Task CanAcceptSimultaneousRenderRequests()
+	{
+		var expectedOutput = string.Join(
+			string.Empty,
+			Enumerable.Range(0, 100).Select(_ => "😊"));
+
+		var cut = await RenderAsync<ConcurrentRenderParent>();
+
+		await cut.OnAfterRenderAsync(
+			() =>
+			{
+				Logger.LogInformation("Checking concurrent-render-output");
+				Assert.Equal(expectedOutput, cut.Nodes.GetElementById("concurrent-render-output").TextContent.Trim());
+			},
+			timeout: TimeSpan.FromMilliseconds(2000));
+	}
+}

--- a/tests/bunit.web.tests/V2/SyncContextTests.cs
+++ b/tests/bunit.web.tests/V2/SyncContextTests.cs
@@ -24,12 +24,12 @@ public class BunitContextTests : BunitContext
 		return new LoggerFactory().AddSerilog(serilogLogger, dispose: true);
 	}
 
-	public BunitContextTests(ITestOutputHelper outputHelper)
-		: base(CreateXunitLoggerFactory(outputHelper))
-	{
-	}
+	////public BunitContextTests(ITestOutputHelper outputHelper)
+	////	: base(CreateXunitLoggerFactory(outputHelper))
+	////{
+	////}
 
-	[Fact]
+	[UIFact]
 	public async Task Can_accept_simultaneous_render_requests()
 	{
 		var expectedOutput = string.Join(
@@ -47,7 +47,7 @@ public class BunitContextTests : BunitContext
 			timeout: TimeSpan.FromMilliseconds(2000));
 	}
 
-	[Theory]
+	[UITheory]
 	[InlineData(0)]
 	[InlineData(1)]
 	[InlineData(2)]

--- a/tests/bunit.web.tests/bunit.web.tests.csproj
+++ b/tests/bunit.web.tests/bunit.web.tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
+<Project Sdk="Microsoft.NET.Sdk.Razor">
 
 	<PropertyGroup>
 		<TargetFrameworks>net6.0;net7.0</TargetFrameworks>

--- a/tests/bunit.web.tests/bunit.web.tests.csproj
+++ b/tests/bunit.web.tests/bunit.web.tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Razor">
+﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
 	<PropertyGroup>
 		<TargetFrameworks>net6.0;net7.0</TargetFrameworks>


### PR DESCRIPTION
This is an attempt at using the test frameworks synchronization context to update the state of rendered components/rendered fragments and run any "wait for" logic in that context too.

I am not sure this will solve the problems we're seeing, but my current theory is that it will ensure that assertions are run on the same thread/core.

I also included an experimental v2 renderer and bunit (test) context. 

NOT ready for merging.