### PR TITLE
refactor: Use WaitAsync logic for >net6.0

### DIFF
--- a/.github/workflows/verification.yml
+++ b/.github/workflows/verification.yml
@@ -63,10 +63,10 @@ jobs:
 
       - name: 🧪 Run unit tests (async)
         run: |
-          dotnet test --filter Category!=sync -c release --blame-hang-timeout 15s --blame-hang-dump-type full --blame-crash-dump-type full
+          dotnet test --filter Category!=sync -c release
       - name: 🧪 Run unit tests (sync)
         run: |
-          dotnet test --filter Category!=async -c release --blame-hang-timeout 15s --blame-hang-dump-type full --blame-crash-dump-type full
+          dotnet test --filter Category!=async -c release
       - name: 📛 Upload hang- and crash-dumps on test failure
         if: failure()
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
Use the `WaitAsync` logic for `net6.0` and above otherwise, we use a "better" handling, which closes the `Task.Delay` via a `CancellationToken`.