### PR TITLE
refactor: Implemented analyzer suggestions and smaller refactorings

### DIFF
--- a/src/bunit.core/Extensions/WaitForHelpers/RenderedFragmentWaitForHelperExtensions.cs
+++ b/src/bunit.core/Extensions/WaitForHelpers/RenderedFragmentWaitForHelperExtensions.cs
@@ -28,14 +28,9 @@ public static class RenderedFragmentWaitForHelperExtensions
 		{
 			waiter.WaitTask.GetAwaiter().GetResult();
 		}
-		catch (Exception e)
+		catch (AggregateException e) when (e.InnerExceptions.Count == 1)
 		{
-			if (e is AggregateException aggregateException && aggregateException.InnerExceptions.Count == 1)
-			{
-				ExceptionDispatchInfo.Capture(aggregateException.InnerExceptions[0]).Throw();
-			}
-
-			throw;
+			ExceptionDispatchInfo.Capture(e.InnerExceptions[0]).Throw();
 		}
 	}
 
@@ -76,14 +71,9 @@ public static class RenderedFragmentWaitForHelperExtensions
 		{
 			waiter.WaitTask.GetAwaiter().GetResult();
 		}
-		catch (Exception e)
+		catch (AggregateException e) when (e.InnerExceptions.Count == 1)
 		{
-			if (e is AggregateException aggregateException && aggregateException.InnerExceptions.Count == 1)
-			{
-				ExceptionDispatchInfo.Capture(aggregateException.InnerExceptions[0]).Throw();
-			}
-
-			throw;
+			ExceptionDispatchInfo.Capture(e.InnerExceptions[0]).Throw();
 		}
 	}
 

--- a/src/bunit.core/Rendering/RootRenderTree.cs
+++ b/src/bunit.core/Rendering/RootRenderTree.cs
@@ -7,7 +7,9 @@ namespace Bunit.Rendering;
 /// Components added to the render tree must have either a <c>ChildContent</c> or
 /// <c>Body</c> parameter.
 /// </summary>
+#pragma warning disable CA1710 // RootRenderTree to end in either 'Collection' or 'Dictionary', 'Set', 'Stack','Queue'
 public sealed class RootRenderTree : IReadOnlyCollection<RootRenderTreeRegistration>
+#pragma warning restore CA1710
 {
 	private readonly List<RootRenderTreeRegistration> registrations = new();
 

--- a/src/bunit.core/Rendering/RootRenderTree.cs
+++ b/src/bunit.core/Rendering/RootRenderTree.cs
@@ -7,9 +7,8 @@ namespace Bunit.Rendering;
 /// Components added to the render tree must have either a <c>ChildContent</c> or
 /// <c>Body</c> parameter.
 /// </summary>
-#pragma warning disable CA1710 // RootRenderTree to end in either 'Collection' or 'Dictionary', 'Set', 'Stack','Queue'
+[SuppressMessage("Naming", "CA1710:Identifiers should have correct suffix", Justification = "A tree is a collection by default.")]
 public sealed class RootRenderTree : IReadOnlyCollection<RootRenderTreeRegistration>
-#pragma warning restore CA1710
 {
 	private readonly List<RootRenderTreeRegistration> registrations = new();
 

--- a/src/bunit.core/StringSyntaxAttribute.cs
+++ b/src/bunit.core/StringSyntaxAttribute.cs
@@ -2,7 +2,8 @@
 namespace System.Diagnostics.CodeAnalysis;
 
 /// <summary>Fake version of the StringSyntaxAttribute, which was introduced in .NET 7</summary>
-[AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Field | AttributeTargets.Property, AllowMultiple = false, Inherited = false)]
+[AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Field | AttributeTargets.Property)]
+[SuppressMessage("Design", "CA1019:Define accessors for attribute arguments", Justification = "The sole purpose is to have the same public surface as the class in .NET7 and above.")]
 public sealed class StringSyntaxAttribute : Attribute
 {
 	/// <summary>

--- a/src/bunit.web/Asserting/DiffAssertExtensions.cs
+++ b/src/bunit.web/Asserting/DiffAssertExtensions.cs
@@ -18,11 +18,11 @@ public static class DiffAssertExtensions
 	{
 		if (diffs is null)
 			throw new ArgumentNullException(nameof(diffs));
-		var diffsList = diffs.ToList();
-		if (diffsList.Count != 1)
-			throw new ActualExpectedAssertException(diffsList.Count.ToString(CultureInfo.InvariantCulture), "1", "Actual changes", "Expected changes", "There were more than one change");
+		var diffsArray = diffs.ToArray();
+		if (diffsArray.Length != 1)
+			throw new ActualExpectedAssertException(diffsArray.Length.ToString(CultureInfo.InvariantCulture), "1", "Actual changes", "Expected changes", "There were more than one change");
 
-		return diffsList.First();
+		return diffsArray.First();
 	}
 
 	/// <summary>
@@ -39,12 +39,12 @@ public static class DiffAssertExtensions
 		if (diffInspectors is null)
 			throw new ArgumentNullException(nameof(diffInspectors));
 
-		var diffsList = diffs.ToList();
-		if (diffsList.Count != diffInspectors.Length)
-			throw new ActualExpectedAssertException(diffsList.Count.ToString(CultureInfo.InvariantCulture), diffInspectors.Length.ToString(CultureInfo.InvariantCulture), "Actual changes", "Expected changes", "The actual number of changes does not match the expected.");
+		var diffsArray = diffs.ToArray();
+		if (diffsArray.Length != diffInspectors.Length)
+			throw new ActualExpectedAssertException(diffsArray.Length.ToString(CultureInfo.InvariantCulture), diffInspectors.Length.ToString(CultureInfo.InvariantCulture), "Actual changes", "Expected changes", "The actual number of changes does not match the expected.");
 
 		var index = 0;
-		foreach (var diff in diffsList)
+		foreach (var diff in diffsArray)
 		{
 			diffInspectors[index](diff);
 			index++;

--- a/src/bunit.web/Asserting/DiffAssertExtensions.cs
+++ b/src/bunit.web/Asserting/DiffAssertExtensions.cs
@@ -18,11 +18,14 @@ public static class DiffAssertExtensions
 	{
 		if (diffs is null)
 			throw new ArgumentNullException(nameof(diffs));
-		var diffsArray = diffs.ToArray();
-		if (diffsArray.Length != 1)
-			throw new ActualExpectedAssertException(diffsArray.Length.ToString(CultureInfo.InvariantCulture), "1", "Actual changes", "Expected changes", "There were more than one change");
 
-		return diffsArray.First();
+		return diffs.FirstOrDefault()
+			?? throw new ActualExpectedAssertException(
+				actual: "0",
+				expected: "1",
+				actualText: "Actual changes",
+				expectedText: "Expected changes",
+				message: "There were more than one change");
 	}
 
 	/// <summary>
@@ -39,15 +42,26 @@ public static class DiffAssertExtensions
 		if (diffInspectors is null)
 			throw new ArgumentNullException(nameof(diffInspectors));
 
-		var diffsArray = diffs.ToArray();
-		if (diffsArray.Length != diffInspectors.Length)
-			throw new ActualExpectedAssertException(diffsArray.Length.ToString(CultureInfo.InvariantCulture), diffInspectors.Length.ToString(CultureInfo.InvariantCulture), "Actual changes", "Expected changes", "The actual number of changes does not match the expected.");
-
-		var index = 0;
-		foreach (var diff in diffsArray)
+		var diffCount = 0;
+		foreach (var diff in diffs)
 		{
-			diffInspectors[index](diff);
-			index++;
+			if (diffCount >= diffInspectors.Length)
+			{
+				break;
+			}
+
+			diffInspectors[diffCount](diff);
+			diffCount++;
+		}
+
+		if (diffCount != diffInspectors.Length)
+		{
+			throw new ActualExpectedAssertException(
+				actual: diffCount.ToString(CultureInfo.InvariantCulture),
+				expected: diffInspectors.Length.ToString(CultureInfo.InvariantCulture),
+				actualText: "Actual changes",
+				expectedText: "Expected changes",
+				message: "The actual number of changes does not match the expected.");
 		}
 	}
 }

--- a/src/bunit.web/Asserting/DiffAssertExtensions.cs
+++ b/src/bunit.web/Asserting/DiffAssertExtensions.cs
@@ -19,13 +19,17 @@ public static class DiffAssertExtensions
 		if (diffs is null)
 			throw new ArgumentNullException(nameof(diffs));
 
-		return diffs.FirstOrDefault()
-			?? throw new ActualExpectedAssertException(
-				actual: "0",
+		var diffsArray = diffs.ToArray();
+
+		if (diffsArray.Length != 1)
+			throw new ActualExpectedAssertException(
+				actual: diffsArray.Length.ToString(CultureInfo.InvariantCulture),
 				expected: "1",
 				actualText: "Actual changes",
 				expectedText: "Expected changes",
 				message: "There were more than one change");
+
+		return diffsArray.First();
 	}
 
 	/// <summary>
@@ -42,26 +46,21 @@ public static class DiffAssertExtensions
 		if (diffInspectors is null)
 			throw new ArgumentNullException(nameof(diffInspectors));
 
-		var diffCount = 0;
-		foreach (var diff in diffs)
-		{
-			if (diffCount >= diffInspectors.Length)
-			{
-				break;
-			}
+		var diffsArray = diffs.ToArray();
 
-			diffInspectors[diffCount](diff);
-			diffCount++;
-		}
-
-		if (diffCount != diffInspectors.Length)
-		{
+		if (diffsArray.Length != diffInspectors.Length)
 			throw new ActualExpectedAssertException(
-				actual: diffCount.ToString(CultureInfo.InvariantCulture),
+				actual: diffsArray.Length.ToString(CultureInfo.InvariantCulture),
 				expected: diffInspectors.Length.ToString(CultureInfo.InvariantCulture),
 				actualText: "Actual changes",
 				expectedText: "Expected changes",
 				message: "The actual number of changes does not match the expected.");
+
+		var index = 0;
+		foreach (var diff in diffsArray)
+		{
+			diffInspectors[index](diff);
+			index++;
 		}
 	}
 }

--- a/src/bunit.web/Asserting/DiffAssertExtensions.cs
+++ b/src/bunit.web/Asserting/DiffAssertExtensions.cs
@@ -18,10 +18,11 @@ public static class DiffAssertExtensions
 	{
 		if (diffs is null)
 			throw new ArgumentNullException(nameof(diffs));
-		if (diffs.Take(2).Count() != 1) // Optimized way of writing "diffs.Count() != 1"
-			throw new ActualExpectedAssertException(diffs.Count().ToString(CultureInfo.InvariantCulture), "1", "Actual changes", "Expected changes", "There were more than one change");
+		var diffsList = diffs.ToList();
+		if (diffsList.Count != 1)
+			throw new ActualExpectedAssertException(diffsList.Count.ToString(CultureInfo.InvariantCulture), "1", "Actual changes", "Expected changes", "There were more than one change");
 
-		return diffs.First();
+		return diffsList.First();
 	}
 
 	/// <summary>
@@ -38,11 +39,12 @@ public static class DiffAssertExtensions
 		if (diffInspectors is null)
 			throw new ArgumentNullException(nameof(diffInspectors));
 
-		if (diffs.Take(diffInspectors.Length + 1).Count() != diffInspectors.Length) // Optimized way of writing "diffs.Count() != diffInspectors.Length"
-			throw new ActualExpectedAssertException(diffs.Count().ToString(CultureInfo.InvariantCulture), diffInspectors.Length.ToString(CultureInfo.InvariantCulture), "Actual changes", "Expected changes", "The actual number of changes does not match the expected.");
+		var diffsList = diffs.ToList();
+		if (diffsList.Count != diffInspectors.Length)
+			throw new ActualExpectedAssertException(diffsList.Count.ToString(CultureInfo.InvariantCulture), diffInspectors.Length.ToString(CultureInfo.InvariantCulture), "Actual changes", "Expected changes", "The actual number of changes does not match the expected.");
 
-		int index = 0;
-		foreach (var diff in diffs)
+		var index = 0;
+		foreach (var diff in diffsList)
 		{
 			diffInspectors[index](diff);
 			index++;

--- a/src/bunit.web/Extensions/WaitForHelpers/RenderedFragmentWaitForHelperExtensions.cs
+++ b/src/bunit.web/Extensions/WaitForHelpers/RenderedFragmentWaitForHelperExtensions.cs
@@ -159,13 +159,11 @@ public static class RenderedFragmentWaitForHelperExtensions
 		{
 			return waiter.WaitTask.GetAwaiter().GetResult();
 		}
-		catch (Exception e)
+		catch (AggregateException e) when (e.InnerExceptions.Count == 1)
 		{
-			if (e is AggregateException aggregateException && aggregateException.InnerExceptions.Count == 1)
-			{
-				ExceptionDispatchInfo.Capture(aggregateException.InnerExceptions[0]).Throw();
-			}
+			ExceptionDispatchInfo.Capture(e.InnerExceptions[0]).Throw();
 
+			// Unreachable code
 			throw;
 		}
 	}
@@ -189,13 +187,11 @@ public static class RenderedFragmentWaitForHelperExtensions
 		{
 			return waiter.WaitTask.GetAwaiter().GetResult();
 		}
-		catch (Exception e)
+		catch (AggregateException e) when (e.InnerExceptions.Count == 1)
 		{
-			if (e is AggregateException aggregateException && aggregateException.InnerExceptions.Count == 1)
-			{
-				ExceptionDispatchInfo.Capture(aggregateException.InnerExceptions[0]).Throw();
-			}
+			ExceptionDispatchInfo.Capture(e.InnerExceptions[0]).Throw();
 
+			// Unreachable code
 			throw;
 		}
 	}

--- a/src/bunit.web/JSInterop/JSRuntimeInvocationDictionary.cs
+++ b/src/bunit.web/JSInterop/JSRuntimeInvocationDictionary.cs
@@ -15,12 +15,7 @@ public sealed class JSRuntimeInvocationDictionary : IReadOnlyCollection<JSRuntim
 	/// </summary>
 	/// <param name="identifier">The identifier to get invocations for.</param>
 	/// <returns>An <see cref="IReadOnlyList{JSRuntimeInvocation}"/>.</returns>
-	public IReadOnlyList<JSRuntimeInvocation> this[string identifier]
-	{
-		get => invocations.ContainsKey(identifier)
-			? invocations[identifier]
-			: Array.Empty<JSRuntimeInvocation>();
-	}
+	public IReadOnlyList<JSRuntimeInvocation> this[string identifier] => invocations.TryGetValue(identifier, out var value) ? value : Array.Empty<JSRuntimeInvocation>();
 
 	/// <summary>
 	/// Gets a read only collection of all the identifiers used in invocations in this dictionary.

--- a/src/bunit.web/TestDoubles/Authorization/FakeAuthorizationService.cs
+++ b/src/bunit.web/TestDoubles/Authorization/FakeAuthorizationService.cs
@@ -66,17 +66,18 @@ public class FakeAuthorizationService : IAuthorizationService
 
 		AuthorizationResult result;
 
-		if (requirements.All(p => p is DenyAnonymousAuthorizationRequirement))
+		var requirementsList = requirements.ToList();
+		if (requirementsList.All(p => p is DenyAnonymousAuthorizationRequirement))
 		{
 			result = (currentState == AuthorizationState.Authorized) ? AuthorizationResult.Success() : AuthorizationResult.Failed();
 		}
-		else if (requirements.All(p => p is RolesAuthorizationRequirement))
+		else if (requirementsList.All(p => p is RolesAuthorizationRequirement))
 		{
-			result = VerifyRequiredRoles(requirements);
+			result = VerifyRequiredRoles(requirementsList);
 		}
 		else if (supportedPolicies is not null)
 		{
-			result = VerifyRequiredPolicies(requirements);
+			result = VerifyRequiredPolicies(requirementsList);
 		}
 		else
 		{
@@ -110,28 +111,21 @@ public class FakeAuthorizationService : IAuthorizationService
 			return AuthorizationResult.Failed();
 		}
 
-		foreach (IAuthorizationRequirement req in requirements)
-		{
-			if (req is TestPolicyRequirement testReq && supportedPolicies.Contains(testReq.PolicyName, StringComparer.Ordinal))
-				return AuthorizationResult.Success();
-		}
-
-		return AuthorizationResult.Failed();
+		return requirements.OfType<TestPolicyRequirement>().Any(req => supportedPolicies.Contains(req.PolicyName, StringComparer.Ordinal))
+			? AuthorizationResult.Success()
+			: AuthorizationResult.Failed();
 	}
 
 	private AuthorizationResult VerifyRequiredRoles(IEnumerable<IAuthorizationRequirement> requirements)
 	{
-		AuthorizationResult result = AuthorizationResult.Failed();
-		foreach (IAuthorizationRequirement req in requirements)
+		var result = AuthorizationResult.Failed();
+		foreach (var req in requirements.OfType<RolesAuthorizationRequirement>())
 		{
-			if (req is RolesAuthorizationRequirement testReq)
+			var rolesFound = req.AllowedRoles.Intersect(supportedRoles, StringComparer.Ordinal);
+			if (rolesFound.Any())
 			{
-				IEnumerable<string> rolesFound = testReq.AllowedRoles.Intersect(supportedRoles, StringComparer.Ordinal);
-				if (rolesFound.Any())
-				{
-					result = AuthorizationResult.Success();
-					break;
-				}
+				result = AuthorizationResult.Success();
+				break;
 			}
 		}
 

--- a/src/bunit.web/TestDoubles/Authorization/FakeAuthorizationService.cs
+++ b/src/bunit.web/TestDoubles/Authorization/FakeAuthorizationService.cs
@@ -66,18 +66,18 @@ public class FakeAuthorizationService : IAuthorizationService
 
 		AuthorizationResult result;
 
-		var requirementsList = requirements.ToList();
-		if (requirementsList.All(p => p is DenyAnonymousAuthorizationRequirement))
+		var requirementsArray = requirements.ToArray();
+		if (requirementsArray.All(p => p is DenyAnonymousAuthorizationRequirement))
 		{
 			result = (currentState == AuthorizationState.Authorized) ? AuthorizationResult.Success() : AuthorizationResult.Failed();
 		}
-		else if (requirementsList.All(p => p is RolesAuthorizationRequirement))
+		else if (requirementsArray.All(p => p is RolesAuthorizationRequirement))
 		{
-			result = VerifyRequiredRoles(requirementsList);
+			result = VerifyRequiredRoles(requirementsArray);
 		}
 		else if (supportedPolicies is not null)
 		{
-			result = VerifyRequiredPolicies(requirementsList);
+			result = VerifyRequiredPolicies(requirementsArray);
 		}
 		else
 		{

--- a/src/bunit.web/TestDoubles/Authorization/FakeAuthorizationService.cs
+++ b/src/bunit.web/TestDoubles/Authorization/FakeAuthorizationService.cs
@@ -69,7 +69,9 @@ public class FakeAuthorizationService : IAuthorizationService
 		var requirementsArray = requirements.ToArray();
 		if (requirementsArray.All(p => p is DenyAnonymousAuthorizationRequirement))
 		{
-			result = (currentState == AuthorizationState.Authorized) ? AuthorizationResult.Success() : AuthorizationResult.Failed();
+			result = currentState == AuthorizationState.Authorized
+				? AuthorizationResult.Success()
+				: AuthorizationResult.Failed();
 		}
 		else if (requirementsArray.All(p => p is RolesAuthorizationRequirement))
 		{
@@ -104,7 +106,7 @@ public class FakeAuthorizationService : IAuthorizationService
 		return AuthorizeAsync(user, resource, requirements);
 	}
 
-	private AuthorizationResult VerifyRequiredPolicies(IEnumerable<IAuthorizationRequirement> requirements)
+	private AuthorizationResult VerifyRequiredPolicies(IReadOnlyCollection<IAuthorizationRequirement> requirements)
 	{
 		if (supportedPolicies.IsNullOrEmpty() || requirements.IsNullOrEmpty())
 		{
@@ -116,7 +118,7 @@ public class FakeAuthorizationService : IAuthorizationService
 			: AuthorizationResult.Failed();
 	}
 
-	private AuthorizationResult VerifyRequiredRoles(IEnumerable<IAuthorizationRequirement> requirements)
+	private AuthorizationResult VerifyRequiredRoles(IReadOnlyCollection<IAuthorizationRequirement> requirements)
 	{
 		var result = AuthorizationResult.Failed();
 		foreach (var req in requirements.OfType<RolesAuthorizationRequirement>())

--- a/tests/bunit.core.tests/ComponentFactories/GenericComponentFactoryTest.cs
+++ b/tests/bunit.core.tests/ComponentFactories/GenericComponentFactoryTest.cs
@@ -25,7 +25,7 @@ public class GenericComponentFactoryTest : TestContext
 		cut.MarkupMatches(@"<div id=""ref-status"">Has ref = True</div>");
 	}
 
-	private class FakeSimple1 : Simple1
+	private sealed class FakeSimple1 : Simple1
 	{
 		protected override void OnInitialized() { }
 		protected override Task OnInitializedAsync() => Task.CompletedTask;

--- a/tests/bunit.core.tests/ComponentParameterCollectionBuilderTests.cs
+++ b/tests/bunit.core.tests/ComponentParameterCollectionBuilderTests.cs
@@ -720,9 +720,9 @@ public partial class ComponentParameterCollectionBuilderTests : TestContext
 		public void SomeMethod() { }
 	}
 
-	private class NoParams : ComponentBase { }
-	private class NonChildContentParameter : ComponentBase { public RenderFragment? ChildContent { get; set; } }
-	private class InhertedParams : Params { }
+	private sealed class NoParams : ComponentBase { }
+	private sealed class NonChildContentParameter : ComponentBase { public RenderFragment? ChildContent { get; set; } }
+	private sealed class InhertedParams : Params { }
 	private abstract class ParamsBase<T> : ComponentBase
 	{
 		public abstract T Value { get; set; }
@@ -733,21 +733,21 @@ public partial class ComponentParameterCollectionBuilderTests : TestContext
 		[Parameter] public override bool? Value { get; set; }
 	}
 
-	private class InheritedParamsWithoutOverride : InheritedParamsWithOverride
+	private sealed class InheritedParamsWithoutOverride : InheritedParamsWithOverride
 	{ }
 
-	private class TemplatedChildContent : ComponentBase
+	private sealed class TemplatedChildContent : ComponentBase
 	{
 		[Parameter] public RenderFragment<string>? ChildContent { get; set; }
 	}
 
-	private class NoTwoWayBind : ComponentBase
+	private sealed class NoTwoWayBind : ComponentBase
 	{
 		[Parameter]
 		public string Value { get; set; }
 	}
 
-	private class InvalidTwoWayBind : ComponentBase
+	private sealed class InvalidTwoWayBind : ComponentBase
 	{
 		[Parameter]
 		public string Value { get; set; }
@@ -755,13 +755,13 @@ public partial class ComponentParameterCollectionBuilderTests : TestContext
 		public EventCallback<string> ValueChanged { get; set; }
 	}
 
-	private class ComponentWithCascadingParameter : ComponentBase
+	private sealed class ComponentWithCascadingParameter : ComponentBase
 	{
 		[CascadingParameter] public string Value { get; set; } = string.Empty;
 		[Parameter] public EventCallback<string> ValueChanged { get; set; }
 	}
 
-	private class ValidNamesComponent : ComponentBase
+	private sealed class ValidNamesComponent : ComponentBase
 	{
 		[Parameter] public DateTime LastChanged { get; set; }
 		[Parameter] public EventCallback<DateTime> LastChangedChanged { get; set; }

--- a/tests/bunit.core.tests/ComponentParameterCollectionTest.cs
+++ b/tests/bunit.core.tests/ComponentParameterCollectionTest.cs
@@ -335,7 +335,7 @@ public class ComponentParameterCollectionTest : TestContext
 		Should.Throw<ArgumentException>(() => sut.ToRenderFragment<Params>());
 	}
 
-	private class Params : ComponentBase
+	private sealed class Params : ComponentBase
 	{
 		public const string TemplateContent = "FOO";
 

--- a/tests/bunit.core.tests/ComponentParameterFactoryTest.cs
+++ b/tests/bunit.core.tests/ComponentParameterFactoryTest.cs
@@ -263,7 +263,7 @@ public class ComponentParameterFactoryTest
 		renderedFragment.Markup.ShouldBe(nameof(TestComponent) + EXPECTED);
 	}
 
-	private class TestComponent : ComponentBase
+	private sealed class TestComponent : ComponentBase
 	{
 		[Parameter] public string? Input { get; set; }
 		[Parameter] public RenderFragment<string>? Template { get; set; }

--- a/tests/bunit.core.tests/Extensions/WaitForHelpers/RenderedFragmentWaitForHelperExtensionsTest.cs
+++ b/tests/bunit.core.tests/Extensions/WaitForHelpers/RenderedFragmentWaitForHelperExtensionsTest.cs
@@ -129,7 +129,7 @@ public class RenderedFragmentWaitForHelperExtensionsTest : TestContext
 			() => cut.WaitForState(() => false, TimeSpan.FromSeconds(5)));
 	}
 
-	internal class ThrowsAfterAsyncOperation : ComponentBase
+	private sealed class ThrowsAfterAsyncOperation : ComponentBase
 	{
 		protected override async Task OnInitializedAsync()
 		{

--- a/tests/bunit.core.tests/Rendering/RootRenderTreeTest.cs
+++ b/tests/bunit.core.tests/Rendering/RootRenderTreeTest.cs
@@ -144,7 +144,7 @@ public class RootRenderTreeTest : TestContext
 			x => x.ComponentType.ShouldBe(typeof(CascadingValue<int>)));
 	}
 
-	private class LayoutComponent : LayoutComponentBase
+	private sealed class LayoutComponent : LayoutComponentBase
 	{
 		[Parameter] public string Value { get; set; } = "LAYOUT VALUE";
 		[Parameter] public string? Name { get; set; }
@@ -160,7 +160,7 @@ public class RootRenderTreeTest : TestContext
 		}
 	}
 
-	private class InnerComponent : ComponentBase
+	private sealed class InnerComponent : ComponentBase
 	{
 		[CascadingParameter] public string LayoutValue { get; set; } = string.Empty;
 
@@ -172,7 +172,7 @@ public class RootRenderTreeTest : TestContext
 		}
 	}
 
-	private class MultipleParametersInnerComponent : ComponentBase
+	private sealed class MultipleParametersInnerComponent : ComponentBase
 	{
 		[CascadingParameter] public string StringValue { get; set; } = string.Empty;
 		[CascadingParameter] public int IntValue { get; set; }

--- a/tests/bunit.core.tests/Rendering/TestRendererTest.cs
+++ b/tests/bunit.core.tests/Rendering/TestRendererTest.cs
@@ -422,20 +422,20 @@ public partial class TestRendererTest : TestContext
 		Renderer.UnhandledException.Result.ShouldBeOfType<InvalidOperationException>();
 	}
 
-	internal class NoChildNoParams : ComponentBase
+	internal sealed class NoChildNoParams : ComponentBase
 	{
 		public const string MARKUP = "hello world";
 		protected override void BuildRenderTree(RenderTreeBuilder builder) => builder.AddMarkupContent(0, MARKUP);
 	}
 
-	internal class ThrowsDuringSetParams : ComponentBase
+	internal sealed class ThrowsDuringSetParams : ComponentBase
 	{
 		public static readonly InvalidOperationException EXCEPTION = new("THROWS ON PURPOSE");
 
 		public override Task SetParametersAsync(ParameterView parameters) => throw EXCEPTION;
 	}
 
-	internal class HasParams : ComponentBase
+	internal sealed class HasParams : ComponentBase
 	{
 		[Parameter] public string? Value { get; set; }
 		[Parameter] public RenderFragment? ChildContent { get; set; }
@@ -447,7 +447,7 @@ public partial class TestRendererTest : TestContext
 		}
 	}
 
-	internal class RenderTrigger : ComponentBase
+	internal sealed class RenderTrigger : ComponentBase
 	{
 		[Parameter] public string? Value { get; set; }
 
@@ -465,7 +465,7 @@ public partial class TestRendererTest : TestContext
 		}
 	}
 
-	internal class ToggleChild : ComponentBase
+	internal sealed class ToggleChild : ComponentBase
 	{
 		private bool showing = true;
 
@@ -484,7 +484,7 @@ public partial class TestRendererTest : TestContext
 		}
 	}
 
-	internal class SyncOperationThrows : ComponentBase
+	internal sealed class SyncOperationThrows : ComponentBase
 	{
 		public bool AwaitDone { get; private set; }
 
@@ -494,7 +494,7 @@ public partial class TestRendererTest : TestContext
 		internal sealed class SyncOperationThrowsException : Exception { }
 	}
 
-	internal class AsyncOperationThrows : ComponentBase
+	internal sealed class AsyncOperationThrows : ComponentBase
 	{
 		[Parameter] public Task Awaitable { get; set; }
 
@@ -506,7 +506,7 @@ public partial class TestRendererTest : TestContext
 		internal sealed class AsyncOperationThrowsException : Exception { }
 	}
 
-	internal class AsyncAfterRenderThrows : ComponentBase
+	internal sealed class AsyncAfterRenderThrows : ComponentBase
 	{
 		[Inject] private IJSRuntime JSRuntime { get; set; }
 

--- a/tests/bunit.core.tests/TestServiceProviderTest.cs
+++ b/tests/bunit.core.tests/TestServiceProviderTest.cs
@@ -264,30 +264,30 @@ public partial class TestServiceProviderTest
 		result.ShouldNotBeNull();
 	}
 
-	private class DummyService { }
+	private sealed class DummyService { }
 
-	private class AnotherDummyService { }
+	private sealed class AnotherDummyService { }
 
-	private class OneMoreDummyService { }
+	private sealed class OneMoreDummyService { }
 
-	private class DummyServiceWithDependencyOnAnotherDummyService
+	private sealed class DummyServiceWithDependencyOnAnotherDummyService
 	{
 		public DummyServiceWithDependencyOnAnotherDummyService(AnotherDummyService anotherDummyService)
 		{
 		}
 	}
 
-	private class FallbackServiceProvider : IServiceProvider
+	private sealed class FallbackServiceProvider : IServiceProvider
 	{
 		public object GetService(Type serviceType) => new DummyService();
 	}
 
-	private class AnotherFallbackServiceProvider : IServiceProvider
+	private sealed class AnotherFallbackServiceProvider : IServiceProvider
 	{
 		public object GetService(Type serviceType) => new AnotherDummyService();
 	}
 
-	private class DummyComponentWhichRequiresDummyService : ComponentBase
+	private sealed class DummyComponentWhichRequiresDummyService : ComponentBase
 	{
 		[Inject] public DummyService Service { get; set; }
 	}

--- a/tests/bunit.testassets/AssertExtensions/TaskAssertionExtensions.cs
+++ b/tests/bunit.testassets/AssertExtensions/TaskAssertionExtensions.cs
@@ -7,7 +7,7 @@ public static class TaskAssertionExtensions
 #if NET6_0_OR_GREATER
 		await task.WaitAsync(timeout);
 #else
-		var cts = new CancellationTokenSource();
+		using var cts = new CancellationTokenSource();
         var delayTask = Task.Delay(timeout, cts.Token);
         if (task != await Task.WhenAny(task, delayTask))
             throw new TimeoutException();

--- a/tests/bunit.testassets/Serilog.Sinks.XUnit/TestOutputSink.cs
+++ b/tests/bunit.testassets/Serilog.Sinks.XUnit/TestOutputSink.cs
@@ -6,7 +6,7 @@ using Xunit.Sdk;
 
 namespace Serilog.Sinks.XUnit;
 
-internal class TestOutputSink : ILogEventSink
+internal sealed class TestOutputSink : ILogEventSink
 {
 	private readonly IMessageSink messageSink;
 	private readonly ITestOutputHelper testOutputHelper;

--- a/tests/bunit.testassets/ServiceCollectionLoggingExtensions.cs
+++ b/tests/bunit.testassets/ServiceCollectionLoggingExtensions.cs
@@ -18,7 +18,8 @@ public static class ServiceCollectionLoggingExtensions
 			.WriteTo.TestOutput(
 				testOutputHelper: outputHelper,
 				restrictedToMinimumLevel: LogEventLevel.Verbose,
-				outputTemplate: ThreadIDEnricher.DefaultConsoleOutputTemplate)
+				outputTemplate: ThreadIDEnricher.DefaultConsoleOutputTemplate,
+				formatProvider: CultureInfo.InvariantCulture)
 			.CreateLogger();
 
 		services.AddSingleton<ILoggerFactory>(new LoggerFactory().AddSerilog(serilogLogger, dispose: true));
@@ -26,7 +27,7 @@ public static class ServiceCollectionLoggingExtensions
 		return services;
 	}
 
-	private class ThreadIDEnricher : ILogEventEnricher
+	private sealed class ThreadIDEnricher : ILogEventEnricher
 	{
 		internal const string DefaultConsoleOutputTemplate = "{Timestamp:yyyy-MM-dd HH:mm:ss} ({ThreadID}) [{Level}] {Message}{NewLine}{Exception}";
 

--- a/tests/bunit.web.testcomponents.tests/RazorTesting/FixtureBaseTest.cs
+++ b/tests/bunit.web.testcomponents.tests/RazorTesting/FixtureBaseTest.cs
@@ -2,7 +2,7 @@ namespace Bunit.RazorTesting;
 
 public class FixtureBaseTest : TestContext
 {
-	private class FixtureComponent : FixtureBase<FixtureComponent>
+	private sealed class FixtureComponent : FixtureBase<FixtureComponent>
 	{
 		protected override Task RunAsync() => RunAsync(this);
 	}

--- a/tests/bunit.web.tests/ComponentFactories/StubComponentFactoryTest.cs
+++ b/tests/bunit.web.tests/ComponentFactories/StubComponentFactoryTest.cs
@@ -114,7 +114,7 @@ public class StubComponentFactoryTest : TestContext
 	}
 
 	private class CompA : ComponentBase { }
-	private class CompDerivedA : CompA { }
+	private sealed class CompDerivedA : CompA { }
 }
 
 #endif

--- a/tests/bunit.web.tests/Extensions/InputFile/InputFileTests.cs
+++ b/tests/bunit.web.tests/Extensions/InputFile/InputFileTests.cs
@@ -103,7 +103,7 @@ public class InputFileTests : TestContext
 		act.ShouldNotThrow();
 	}
 
-	private class InputFileComponent : ComponentBase
+	private sealed class InputFileComponent : ComponentBase
 	{
 		public string? Filename { get; private set; }
 		public string? Content { get; private set; }
@@ -132,7 +132,7 @@ public class InputFileTests : TestContext
 		}
 	}
 
-	private class MultipleInputFileComponent : ComponentBase
+	private sealed class MultipleInputFileComponent : ComponentBase
 	{
 		public readonly List<File> Files = new();
 
@@ -158,7 +158,7 @@ public class InputFileTests : TestContext
 			}
 		}
 
-		public record File(string Filename, string FileContent, DateTimeOffset LastChanged, long Size, string Type);
+		public sealed record File(string Filename, string FileContent, DateTimeOffset LastChanged, long Size, string Type);
 	}
 }
 #endif

--- a/tests/bunit.web.tests/Extensions/RefreshingWrappedElementTest.cs
+++ b/tests/bunit.web.tests/Extensions/RefreshingWrappedElementTest.cs
@@ -76,7 +76,7 @@ public class RefreshingWrappedElementTest : TestContext
 		Should.Throw<ElementRemovedFromDomException>(() => btn.TextContent);
 	}
 
-	private class Markup : ComponentBase
+	private sealed class Markup : ComponentBase
 	{
 		[Parameter] public string Base { get; set; } = string.Empty;
 		[Parameter] public string? Optional { get; set; }

--- a/tests/bunit.web.tests/JSInterop/InvocationHandlers/FocusAsyncInvocationHandlerTest.cs
+++ b/tests/bunit.web.tests/JSInterop/InvocationHandlers/FocusAsyncInvocationHandlerTest.cs
@@ -38,7 +38,7 @@ public class FocusAsyncInvocationHandlerTest : TestContext
 		Assert.True(cut.Instance.AfterFirstRender);
 	}
 
-	private class FocusingComponent : ComponentBase
+	private sealed class FocusingComponent : ComponentBase
 	{
 		private ElementReference elmRef;
 		internal bool AfterFirstRender { get; private set; }

--- a/tests/bunit.web.tests/JSInterop/InvocationHandlers/FocusOnNavigateHandlerTest.cs
+++ b/tests/bunit.web.tests/JSInterop/InvocationHandlers/FocusOnNavigateHandlerTest.cs
@@ -43,7 +43,7 @@ public class FocusOnNavigateHandlerTest : TestContext
 		Assert.True(focusOnNavigateComponent.Instance.AfterFirstRender);
 	}
 
-	private class FocusOnNavigateInternal : FocusOnNavigate
+	private sealed class FocusOnNavigateInternal : FocusOnNavigate
 	{
 		internal bool AfterFirstRender { get; private set; }
 		protected override async Task OnAfterRenderAsync(bool firstRender)

--- a/tests/bunit.web.tests/Rendering/Internal/HtmlizerTests.cs
+++ b/tests/bunit.web.tests/Rendering/Internal/HtmlizerTests.cs
@@ -40,7 +40,7 @@ public partial class HtmlizerTests : TestContext
 		cut.Find("button").HasAttribute("blazor:elementreference").ShouldBeTrue();
 	}
 
-	private class Htmlizer01Component : ComponentBase
+	private sealed class Htmlizer01Component : ComponentBase
 	{
 		public ElementReference ButtomElmRef { get; set; }
 

--- a/tests/bunit.web.tests/TestContextTest.cs
+++ b/tests/bunit.web.tests/TestContextTest.cs
@@ -75,7 +75,7 @@ public partial class TestContextTest : TestContext
 		Should.NotThrow(() => RenderComponent<ClickCounter>().Find("button").Click());
 	}
 
-	private class ReceivesCascadingValue : ComponentBase
+	private sealed class ReceivesCascadingValue : ComponentBase
 	{
 		[CascadingParameter] public string? Value { get; set; }
 

--- a/tests/bunit.web.tests/TestDoubles/Components/ComponentDoubleBaseTest.cs
+++ b/tests/bunit.web.tests/TestDoubles/Components/ComponentDoubleBaseTest.cs
@@ -3,7 +3,7 @@ namespace Bunit.TestDoubles.Components;
 
 public class ComponentDoubleBaseTest : TestContext
 {
-	private class ComponentDouble<TComponent> : ComponentDoubleBase<TComponent>
+	private sealed class ComponentDouble<TComponent> : ComponentDoubleBase<TComponent>
 		where TComponent : IComponent
 	{ }
 

--- a/tests/bunit.web.tests/TestDoubles/NavigationManager/FakeNavigationManagerTest.cs
+++ b/tests/bunit.web.tests/TestDoubles/NavigationManager/FakeNavigationManagerTest.cs
@@ -263,7 +263,7 @@ public class FakeNavigationManagerTest : TestContext
 			() => fakeNavigationManager.History.Last().StateFromJson<InteractiveRequestOptions>());
 	}
 
-	private class InterceptNavigateToCounterComponent : ComponentBase
+	private sealed class InterceptNavigateToCounterComponent : ComponentBase
 	{
 		protected override void BuildRenderTree(RenderTreeBuilder builder)
 		{
@@ -293,7 +293,7 @@ public class FakeNavigationManagerTest : TestContext
 		[Inject] private NavigationManager NavigationManager { get; set; } = default!;
 	}
 
-	public class GotoExternalResourceComponent : ComponentBase
+	private sealed class GotoExternalResourceComponent : ComponentBase
 	{
 		protected override void BuildRenderTree(RenderTreeBuilder builder)
 		{
@@ -312,7 +312,7 @@ public class FakeNavigationManagerTest : TestContext
 		[Inject] private NavigationManager NavigationManager { get; set; } = default!;
 	}
 
-	private class ThrowsExceptionInInterceptNavigationComponent : ComponentBase
+	private sealed class ThrowsExceptionInInterceptNavigationComponent : ComponentBase
 	{
 		protected override void BuildRenderTree(RenderTreeBuilder builder)
 		{


### PR DESCRIPTION
This PR was meant to fix some of the new analyzers shipped with `net7.0` that got activated with `7.0.1`.

## What did I do?
 * Made internal/private types sealed
 * When `IEnumerable` was enumerated multiple times, I created a `List`
 * Simplified some exception handling
 * Simplified some `foreach` loops