### PR TITLE
feat: WaitFor methods exceptions include the number of times a check …

### DIFF
--- a/src/bunit.core/Extensions/WaitForHelpers/WaitForFailedException.cs
+++ b/src/bunit.core/Extensions/WaitForHelpers/WaitForFailedException.cs
@@ -1,3 +1,5 @@
+using System.ComponentModel;
+
 namespace Bunit.Extensions.WaitForHelpers;
 
 /// <summary>
@@ -9,8 +11,13 @@ public sealed class WaitForFailedException : Exception
 	/// <summary>
 	/// Initializes a new instance of the <see cref="WaitForFailedException"/> class.
 	/// </summary>
-	public WaitForFailedException(string? errorMessage, int checkCount, Exception? innerException = null)
-		: base((errorMessage ?? string.Empty) + $" Check count: {checkCount}", innerException)
+	public WaitForFailedException(string? errorMessage, Exception? innerException = null)
+		: base(errorMessage ?? string.Empty, innerException)
+	{
+	}
+
+	internal WaitForFailedException(string errorMessage, int checkCount, int totalRenderCount, Exception? innerException = null)
+		: base(errorMessage + $" Check count: {checkCount}. Total render count: {totalRenderCount}.", innerException)
 	{
 	}
 

--- a/src/bunit.core/Extensions/WaitForHelpers/WaitForFailedException.cs
+++ b/src/bunit.core/Extensions/WaitForHelpers/WaitForFailedException.cs
@@ -16,8 +16,8 @@ public sealed class WaitForFailedException : Exception
 	{
 	}
 
-	internal WaitForFailedException(string errorMessage, int checkCount, int totalRenderCount, Exception? innerException = null)
-		: base(errorMessage + $" Check count: {checkCount}. Total render count: {totalRenderCount}.", innerException)
+	internal WaitForFailedException(string errorMessage, int checkCount, int componentRenderCount, int totalRenderCount, Exception? innerException = null)
+		: base(errorMessage + $" Check count: {checkCount}. Component render count: {componentRenderCount}. Total render count: {totalRenderCount}.", innerException)
 	{
 	}
 

--- a/src/bunit.core/Extensions/WaitForHelpers/WaitForFailedException.cs
+++ b/src/bunit.core/Extensions/WaitForHelpers/WaitForFailedException.cs
@@ -9,8 +9,8 @@ public sealed class WaitForFailedException : Exception
 	/// <summary>
 	/// Initializes a new instance of the <see cref="WaitForFailedException"/> class.
 	/// </summary>
-	public WaitForFailedException(string? errorMessage, Exception? innerException = null)
-		: base(errorMessage ?? string.Empty, innerException)
+	public WaitForFailedException(string? errorMessage, int checkCount, Exception? innerException = null)
+		: base((errorMessage ?? string.Empty) + $" Check count: {checkCount}", innerException)
 	{
 	}
 

--- a/src/bunit.core/Extensions/WaitForHelpers/WaitForHelper.cs
+++ b/src/bunit.core/Extensions/WaitForHelpers/WaitForHelper.cs
@@ -60,7 +60,13 @@ public abstract class WaitForHelper<T> : IDisposable
 		timer = new Timer(_ =>
 		{
 			logger.LogWaiterTimedOut(renderedFragment.ComponentId);
-			checkPassedCompletionSource.TrySetException(new WaitForFailedException(TimeoutErrorMessage ?? string.Empty, checkCount, renderer.RenderCount, capturedException));
+			checkPassedCompletionSource.TrySetException(
+				new WaitForFailedException(
+					TimeoutErrorMessage ?? string.Empty,
+					checkCount,
+					renderedFragment.RenderCount,
+					renderer.RenderCount,
+					capturedException));
 		});
 		WaitTask = CreateWaitTask();
 		timer.Change(GetRuntimeTimeout(timeout), Timeout.InfiniteTimeSpan);
@@ -166,7 +172,12 @@ public abstract class WaitForHelper<T> : IDisposable
 			if (StopWaitingOnCheckException)
 			{
 				checkPassedCompletionSource.TrySetException(
-					new WaitForFailedException(CheckThrowErrorMessage ?? string.Empty, checkCount, renderer.RenderCount, capturedException));
+					new WaitForFailedException(
+						CheckThrowErrorMessage ?? string.Empty,
+						checkCount,
+						renderedFragment.RenderCount,
+						renderer.RenderCount,
+						capturedException));
 				Dispose();
 			}
 		}

--- a/src/bunit.core/Rendering/TestRenderer.cs
+++ b/src/bunit.core/Rendering/TestRenderer.cs
@@ -22,6 +22,11 @@ public class TestRenderer : Renderer, ITestRenderer
 	public override Dispatcher Dispatcher { get; } = Dispatcher.CreateDefault();
 
 	/// <summary>
+	/// Gets the number of render cycles that has been performed.
+	/// </summary>
+	internal int RenderCount { get; private set; }
+
+	/// <summary>
 	/// Initializes a new instance of the <see cref="TestRenderer"/> class.
 	/// </summary>
 	public TestRenderer(IRenderedComponentActivator renderedComponentActivator, TestServiceProvider services, ILoggerFactory loggerFactory)
@@ -151,6 +156,8 @@ public class TestRenderer : Renderer, ITestRenderer
 	{
 		logger.LogNewRenderBatchReceived();
 
+		RenderCount++;
+		
 		var renderEvent = new RenderEvent(renderBatch, new RenderTreeFrameDictionary());
 
 		// removes disposed components

--- a/tests/bunit.core.tests/Extensions/WaitForHelpers/RenderedFragmentWaitForHelperExtensionsTest.cs
+++ b/tests/bunit.core.tests/Extensions/WaitForHelpers/RenderedFragmentWaitForHelperExtensionsTest.cs
@@ -36,7 +36,7 @@ public class RenderedFragmentWaitForHelperExtensionsTest : TestContext
 		var expected = Should.Throw<WaitForFailedException>(() =>
 			cut.WaitForAssertion(() => cut.Markup.ShouldBeEmpty(), TimeSpan.FromMilliseconds(10)));
 
-		expected.Message.ShouldBe(WaitForAssertionHelper.TimeoutMessage);
+		expected.Message.ShouldStartWith(WaitForAssertionHelper.TimeoutMessage);
 	}
 
 	[Fact(DisplayName = "WaitForState throws exception after timeout")]
@@ -47,7 +47,7 @@ public class RenderedFragmentWaitForHelperExtensionsTest : TestContext
 		var expected = Should.Throw<WaitForFailedException>(() =>
 			cut.WaitForState(() => string.IsNullOrEmpty(cut.Markup), TimeSpan.FromMilliseconds(100)));
 
-		expected.Message.ShouldBe(WaitForStateHelper.TimeoutBeforePassMessage);
+		expected.Message.ShouldStartWith(WaitForStateHelper.TimeoutBeforePassMessage);
 	}
 
 	[Fact(DisplayName = "WaitForState throws exception if statePredicate throws on a later render")]
@@ -66,7 +66,7 @@ public class RenderedFragmentWaitForHelperExtensionsTest : TestContext
 				return false;
 			}));
 
-		expected.Message.ShouldBe(WaitForStateHelper.ExceptionInPredicateMessage);
+		expected.Message.ShouldStartWith(WaitForStateHelper.ExceptionInPredicateMessage);
 		expected.InnerException.ShouldBeOfType<InvalidOperationException>()
 			.Message.ShouldBe(expectedInnerMessage);
 	}

--- a/tests/bunit.core.tests/TestContextBaseTest.net5.cs
+++ b/tests/bunit.core.tests/TestContextBaseTest.net5.cs
@@ -66,7 +66,7 @@ public partial class TestContextBaseTest : TestContext
 
 		DisposeComponents();
 
-		await wasDisposedTask.ShouldCompleteWithin(TimeSpan.FromMilliseconds(100));
+		await wasDisposedTask.ShouldCompleteWithin(TimeSpan.FromSeconds(1));
 	}
 
 	[Fact(DisplayName = "DisposeComponents should dispose components added via ComponentFactory")]

--- a/tests/bunit.web.tests/BlazorE2E/ComponentRenderingTest.cs
+++ b/tests/bunit.web.tests/BlazorE2E/ComponentRenderingTest.cs
@@ -544,7 +544,7 @@ public class ComponentRenderingTest : TestContext
 
 		await cut.WaitForAssertionAsync(
 			() => Assert.Equal(expectedOutput, outputElement.TextContent.Trim()),
-			timeout: TimeSpan.FromMilliseconds(2000));
+			timeout: TimeSpan.FromSeconds(10));
 	}
 
 	[Fact]
@@ -565,7 +565,7 @@ public class ComponentRenderingTest : TestContext
 
 		cut.WaitForAssertion(
 			() => Assert.Equal(expectedOutput, outputElement.TextContent.Trim()),
-			timeout: TimeSpan.FromMilliseconds(2000));
+			timeout: TimeSpan.FromSeconds(10));
 	}
 
 	[Fact]

--- a/tests/bunit.web.tests/Extensions/WaitForHelpers/RenderedFragmentWaitForElementsHelperExtensions.Async.Test.cs
+++ b/tests/bunit.web.tests/Extensions/WaitForHelpers/RenderedFragmentWaitForElementsHelperExtensions.Async.Test.cs
@@ -31,7 +31,7 @@ public class RenderedFragmentWaitForElementsHelperExtensionsAsyncTest : TestCont
 		var expected = await Should.ThrowAsync<WaitForFailedException>(async () =>
 			await cut.WaitForElementAsync("#notHereElm", TimeSpan.FromMilliseconds(10)));
 
-		expected.Message.ShouldBe(WaitForElementHelper.TimeoutBeforeFoundMessage);
+		expected.Message.ShouldStartWith(WaitForElementHelper.TimeoutBeforeFoundMessage);
 	}
 
 	[Fact(DisplayName = "WaitForElements waits until cssSelector returns at least one element")]
@@ -55,7 +55,7 @@ public class RenderedFragmentWaitForElementsHelperExtensionsAsyncTest : TestCont
 		var expected = await Should.ThrowAsync<WaitForFailedException>(async () =>
 			await cut.WaitForElementsAsync("#notHereElm", TimeSpan.FromMilliseconds(30)));
 
-		expected.Message.ShouldBe(WaitForElementsHelper.TimeoutBeforeFoundMessage);
+		expected.Message.ShouldStartWith(WaitForElementsHelper.TimeoutBeforeFoundMessage);
 		expected.InnerException.ShouldBeNull();
 	}
 
@@ -68,7 +68,7 @@ public class RenderedFragmentWaitForElementsHelperExtensionsAsyncTest : TestCont
 		var expected = await Should.ThrowAsync<WaitForFailedException>(async () =>
 			await cut.WaitForElementsAsync("#notHereElm", 2, TimeSpan.FromMilliseconds(30)));
 
-		expected.Message.ShouldBe(string.Format(CultureInfo.InvariantCulture, WaitForElementsHelper.TimeoutBeforeFoundWithCountMessage, 2));
+		expected.Message.ShouldStartWith(string.Format(CultureInfo.InvariantCulture, WaitForElementsHelper.TimeoutBeforeFoundWithCountMessage, 2));
 		expected.InnerException.ShouldBeNull();
 	}
 

--- a/tests/bunit.web.tests/Extensions/WaitForHelpers/RenderedFragmentWaitForElementsHelperExtensionsTest.cs
+++ b/tests/bunit.web.tests/Extensions/WaitForHelpers/RenderedFragmentWaitForElementsHelperExtensionsTest.cs
@@ -31,7 +31,7 @@ public class RenderedFragmentWaitForElementsHelperExtensionsTest : TestContext
 		var expected = Should.Throw<WaitForFailedException>(() =>
 			cut.WaitForElement("#notHereElm", TimeSpan.FromMilliseconds(10)));
 
-		expected.Message.ShouldBe(WaitForElementHelper.TimeoutBeforeFoundMessage);
+		expected.Message.ShouldStartWith(WaitForElementHelper.TimeoutBeforeFoundMessage);
 	}
 
 	[Fact(DisplayName = "WaitForElements waits until cssSelector returns at least one element")]
@@ -55,7 +55,7 @@ public class RenderedFragmentWaitForElementsHelperExtensionsTest : TestContext
 		var expected = Should.Throw<WaitForFailedException>(() =>
 			cut.WaitForElements("#notHereElm", TimeSpan.FromMilliseconds(30)));
 
-		expected.Message.ShouldBe(WaitForElementsHelper.TimeoutBeforeFoundMessage);
+		expected.Message.ShouldStartWith(WaitForElementsHelper.TimeoutBeforeFoundMessage);
 		expected.InnerException.ShouldBeNull();
 	}
 
@@ -68,7 +68,7 @@ public class RenderedFragmentWaitForElementsHelperExtensionsTest : TestContext
 		var expected = Should.Throw<WaitForFailedException>(() =>
 			cut.WaitForElements("#notHereElm", 2, TimeSpan.FromMilliseconds(30)));
 
-		expected.Message.ShouldBe(string.Format(CultureInfo.InvariantCulture, WaitForElementsHelper.TimeoutBeforeFoundWithCountMessage, 2));
+		expected.Message.ShouldStartWith(string.Format(CultureInfo.InvariantCulture, WaitForElementsHelper.TimeoutBeforeFoundWithCountMessage, 2));
 		expected.InnerException.ShouldBeNull();
 	}
 


### PR DESCRIPTION
This is an interesting debugging addition to the "wait for helper" method. 

When running locally on my old laptop, one of the tests that fail often, `CanAcceptSimultaneousRenderRequests_Sync`, shows a surprising result when it failed. The check count was only 67, in a test that renders 100 components concurrently.

Thoughts?

Here is the test log output from the test run:

```
 Bunit.BlazorE2E.ComponentRenderingTest.CanAcceptSimultaneousRenderRequests_Sync
   Source: ComponentRenderingTest.cs line 552
   Duration: 2,3 sec

  Message: 
Bunit.Extensions.WaitForHelpers.WaitForFailedException : The assertion did not pass within the timeout period. Check count: 67
---- Assert.Equal() Failure
                  ↓ (pos 8)
Expected: 😊😊😊😊😊😊😊😊😊😊😊😊😊😊😊😊😊😊😊😊😊😊😊😊�···
Actual:   😊😊😊😊WAITINGWAITINGWAITINGWAITINGWAITINGWAITIN···
                  ↑ (pos 8)

  Stack Trace: 
RenderedFragmentWaitForHelperExtensions.WaitForAssertion(IRenderedFragmentBase renderedFragment, Action assertion, Nullable`1 timeout) line 77
ComponentRenderingTest.CanAcceptSimultaneousRenderRequests_Sync() line 566

... rest of log excluded for brevity.
```