### PR TITLE
fix: Cancel ExceptionTsc on dispose

### DIFF
--- a/src/bunit.core/Rendering/TestRenderer.cs
+++ b/src/bunit.core/Rendering/TestRenderer.cs
@@ -201,6 +201,7 @@ public class TestRenderer : Renderer, ITestRenderer
 			}
 
 			renderedComponents.Clear();
+			unhandledExceptionTsc.TrySetCanceled();
 		}
 
 		base.Dispose(disposing);


### PR DESCRIPTION
I do think we should cancel the underlying Task for the unhandled exception in our `TestRenderer`.