### PR TITLE
Fix FakeNavigationManager when navigating to Uri without absolute path.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to **bUnit** will be documented in this file. The project ad
 <!-- The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) -->
 
 ## [Unreleased]
+
+### Fixed
+
 -   Added support in `FakeNavigationManager` to handle umlauts.
 
 ## [1.13.5] - 2022-12-16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to **bUnit** will be documented in this file. The project ad
 <!-- The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) -->
 
 ## [Unreleased]
--   Added support in `FakeNavigationManager` to handle cases when navigating to relative path.
+-   Added support in `FakeNavigationManager` to handle umlauts.
 
 ## [1.13.5] - 2022-12-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to **bUnit** will be documented in this file. The project ad
 <!-- The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) -->
 
 ## [Unreleased]
+-   Added support in `FakeNavigationManager` to handle cases when navigating to relative path.
 
 ## [1.13.5] - 2022-12-16
 

--- a/src/bunit.web/TestDoubles/NavigationManager/FakeNavigationManager.cs
+++ b/src/bunit.web/TestDoubles/NavigationManager/FakeNavigationManager.cs
@@ -144,7 +144,7 @@ public sealed class FakeNavigationManager : NavigationManager
 	private URI GetNewAbsoluteUri(string uri)
 		=> URI.IsWellFormedUriString(uri, UriKind.Relative)
 			? ToAbsoluteUri(uri)
-			: new URI(uri, UriKind.Absolute);
+			: new URI(uri, UriKind.RelativeOrAbsolute);
 
 	private bool HasDifferentBaseUri(URI absoluteUri)
 		=> URI.Compare(
@@ -156,6 +156,6 @@ public sealed class FakeNavigationManager : NavigationManager
 
 	private static string GetBaseUri(URI uri)
 	{
-		return uri.Scheme + "://" + uri.Authority + "/";
+		return uri.IsAbsoluteUri ? uri.Scheme + "://" + uri.Authority + "/" : $"https://localhost/{uri.ToString()}";
 	}
 }

--- a/src/bunit.web/TestDoubles/NavigationManager/FakeNavigationManager.cs
+++ b/src/bunit.web/TestDoubles/NavigationManager/FakeNavigationManager.cs
@@ -142,9 +142,8 @@ public sealed class FakeNavigationManager : NavigationManager
 #endif
 
 	private URI GetNewAbsoluteUri(string uri)
-		=> URI.IsWellFormedUriString(uri, UriKind.Relative)
-			? ToAbsoluteUri(uri)
-			: new URI(uri, UriKind.RelativeOrAbsolute);
+		=> new URI(uri, UriKind.RelativeOrAbsolute).IsAbsoluteUri
+			? new URI(uri, UriKind.RelativeOrAbsolute) : ToAbsoluteUri(uri);
 
 	private bool HasDifferentBaseUri(URI absoluteUri)
 		=> URI.Compare(
@@ -156,6 +155,6 @@ public sealed class FakeNavigationManager : NavigationManager
 
 	private static string GetBaseUri(URI uri)
 	{
-		return uri.IsAbsoluteUri ? uri.Scheme + "://" + uri.Authority + "/" : $"https://localhost/{uri.ToString()}";
+		return uri.Scheme + "://" + uri.Authority + "/";
 	}
 }

--- a/tests/bunit.web.tests/TestDoubles/NavigationManager/FakeNavigationManagerTest.cs
+++ b/tests/bunit.web.tests/TestDoubles/NavigationManager/FakeNavigationManagerTest.cs
@@ -339,5 +339,18 @@ public class FakeNavigationManagerTest : TestContext
 		[Inject] private NavigationManager NavigationManager { get; set; } = default!;
 	}
 #endif
+
+	[Fact(DisplayName = "Navigate to path without absolute path")]
+	public void Test016()
+	{
+		var locationChangedInvoked = false;
+		const string externalUri = "/#Storstädning";
+		var sut = CreateFakeNavigationManager();
+		sut.LocationChanged += (s, e) => locationChangedInvoked = true;
+
+		sut.NavigateTo(externalUri);
+
+		locationChangedInvoked.ShouldBeFalse();
+	}
 }
 

--- a/tests/bunit.web.tests/TestDoubles/NavigationManager/FakeNavigationManagerTest.cs
+++ b/tests/bunit.web.tests/TestDoubles/NavigationManager/FakeNavigationManagerTest.cs
@@ -350,7 +350,7 @@ public class FakeNavigationManagerTest : TestContext
 
 		sut.NavigateTo(externalUri);
 
-		locationChangedInvoked.ShouldBeFalse();
+		locationChangedInvoked.ShouldBeTrue();
 	}
 }
 

--- a/tests/bunit.web.tests/TestDoubles/NavigationManager/FakeNavigationManagerTest.cs
+++ b/tests/bunit.web.tests/TestDoubles/NavigationManager/FakeNavigationManagerTest.cs
@@ -33,6 +33,8 @@ public class FakeNavigationManagerTest : TestContext
 	[InlineData("")]
 	[InlineData("/")]
 	[InlineData("/foo")]
+	[InlineData("/#Storstädning")]
+	[InlineData("/#åäö")]
 	public void Test003(string uri)
 	{
 		var sut = CreateFakeNavigationManager();
@@ -339,18 +341,5 @@ public class FakeNavigationManagerTest : TestContext
 		[Inject] private NavigationManager NavigationManager { get; set; } = default!;
 	}
 #endif
-
-	[Fact(DisplayName = "Navigate to path without absolute path")]
-	public void Test016()
-	{
-		var locationChangedInvoked = false;
-		const string externalUri = "/#Storstädning";
-		var sut = CreateFakeNavigationManager();
-		sut.LocationChanged += (s, e) => locationChangedInvoked = true;
-
-		sut.NavigateTo(externalUri);
-
-		locationChangedInvoked.ShouldBeTrue();
-	}
 }
 


### PR DESCRIPTION
Fix FakeNavigationManager when navigating to Uri without absolute path.

## Pull request description
I run some unit tests of a component today that navigates without problem to a path without absolute path.
But in unit test it throws. I did some unit test of bUnit and found out that FakeNavigationManager could not handle that case.
So this is a PR, that seems to fix it. 

### PR meta checklist
- [x] Pull request is targeted at `main` branch for code   
  or targeted at `stable` branch for documentation that is live on bunit.dev.
- [x] Pull request is linked to all related issues, if any.
- [x] I have read the _CONTRIBUTING.md_ document.

### Code PR specific checklist
- [x] My code follows the code style of this project and AspNetCore coding guidelines.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] I have updated the appropriate sub section in the _CHANGELOG.md_.
- [x] I have added, updated or removed tests to according to my changes.
  - [x] All tests passed.
