### PR TITLE
fix: Escape certain characters for attribute values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to **bUnit** will be documented in this file. The project ad
 ### Fixed
 
 -   Added support in `FakeNavigationManager` to handle umlauts.
+-   Fixed a bug where attribute values did not get escaped. Reported by [@brettwinters](https://github.com/brettwinters). Fixed by [@linkdotnet](https://github.com/linkdotnet).
 
 ## [1.13.5] - 2022-12-16
 

--- a/src/bunit.web/Rendering/Internal/Htmlizer.cs
+++ b/src/bunit.web/Rendering/Internal/Htmlizer.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.Text;
 using System.Text.Encodings.Web;
+using System.Text.Unicode;
 using Bunit.Rendering;
 
 namespace Bunit;
@@ -270,7 +271,7 @@ internal static class Htmlizer
 					result.Append(frame.AttributeName);
 					result.Append('=');
 					result.Append('"');
-					result.Append(value);
+					result.Append(Escape(value));
 					result.Append('"');
 					break;
 				default:
@@ -280,6 +281,11 @@ internal static class Htmlizer
 
 		return position + maxElements;
 	}
+
+	private static string Escape(string value) =>
+		value
+			.Replace("&", "&amp;", StringComparison.OrdinalIgnoreCase)
+			.Replace("\"", "&quot;", StringComparison.OrdinalIgnoreCase);
 
 	private sealed class HtmlRenderingContext
 	{

--- a/tests/bunit.testassets/BlazorE2E/ComponentWithEscapableCharacters.razor
+++ b/tests/bunit.testassets/BlazorE2E/ComponentWithEscapableCharacters.razor
@@ -1,5 +1,8 @@
 <p style="@Escaped">@Escaped</p>
 
 @code {
-	private string Escaped => "url('')";
+
+	[Parameter]
+	public string Escaped { get; set; }
+
 }

--- a/tests/bunit.web.tests/BlazorE2E/ComponentRenderingTest.cs
+++ b/tests/bunit.web.tests/BlazorE2E/ComponentRenderingTest.cs
@@ -691,11 +691,13 @@ public class ComponentRenderingTest : TestContext
 	}
 
 	[Fact]
-	public void EscapableCharactersDontGetEncoded()
+	public void SomeEscapableCharactersDontGetEncoded()
 	{
-		var cut = RenderComponent<ComponentWithEscapableCharacters>();
+		const string input = "url('\"&')";
+		var cut = RenderComponent<ComponentWithEscapableCharacters>(
+			p => p.Add(s => s.Escaped, input));
 
-		cut.Markup.ShouldBe("<p style=\"url('')\">url('')</p>");
+		cut.Markup.ShouldBe("<p style=\"url('&quot;&amp;')\">url('\"&')</p>");
 	}
 
 	[Fact]


### PR DESCRIPTION
This PR fixes #947 and fixes #946

