### PR TITLE
feat: Added IMemoryCache by default to the container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to **bUnit** will be documented in this file. The project ad
 
 ### Added
 
-- Added `IMemoryCache` by default to the Service-Cotaniner. By [@linkdotnet](https://github.com/linkdotnet).
+- Added `IMemoryCache` by default to the Services container. By [@linkdotnet](https://github.com/linkdotnet).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to **bUnit** will be documented in this file. The project ad
 
 ## [Unreleased]
 
+### Added
+
+- Added `IMemoryCache` by default to the Service-Cotaniner. By [@linkdotnet](https://github.com/linkdotnet).
+
 ### Fixed
 
 -   Added support in `FakeNavigationManager` to handle umlauts.

--- a/src/bunit.web/Extensions/TestServiceProviderExtensions.cs
+++ b/src/bunit.web/Extensions/TestServiceProviderExtensions.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Components.Authorization;
 using Microsoft.AspNetCore.Components.Routing;
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Localization;
 
 namespace Bunit.Extensions;
@@ -53,6 +54,8 @@ public static class TestServiceProviderExtensions
 		services.AddSingleton<HtmlComparer>();
 		services.AddSingleton<BunitHtmlParser>();
 		services.AddSingleton<IRenderedComponentActivator, RenderedComponentActivator>();
+
+		services.AddSingleton<IMemoryCache, MemoryCache>();
 
 #if NET6_0_OR_GREATER
 		services.AddSingleton<IErrorBoundaryLogger, BunitErrorBoundaryLogger>();

--- a/src/bunit.web/Extensions/TestServiceProviderExtensions.cs
+++ b/src/bunit.web/Extensions/TestServiceProviderExtensions.cs
@@ -55,7 +55,7 @@ public static class TestServiceProviderExtensions
 		services.AddSingleton<BunitHtmlParser>();
 		services.AddSingleton<IRenderedComponentActivator, RenderedComponentActivator>();
 
-		services.AddSingleton<IMemoryCache, MemoryCache>();
+		services.AddMemoryCache();
 
 #if NET6_0_OR_GREATER
 		services.AddSingleton<IErrorBoundaryLogger, BunitErrorBoundaryLogger>();

--- a/src/bunit.web/bunit.web.csproj
+++ b/src/bunit.web/bunit.web.csproj
@@ -24,6 +24,7 @@
 		<PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="$(DotNet3Version)" />
 		<PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="$(DotNet3Version)" />
 		<PackageReference Include="Microsoft.Extensions.Localization.Abstractions" Version="$(DotNet3Version)" />
+		<PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="$(DotNet3Version)" />
 		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="3.2.1" />
 		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="3.2.1" />
 	</ItemGroup>
@@ -32,6 +33,7 @@
 		<PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="$(DotNet5Version)" />
 		<PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="$(DotNet5Version)" />
 		<PackageReference Include="Microsoft.Extensions.Localization.Abstractions" Version="$(DotNet5Version)" />
+		<PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="$(DotNet5Version)" />
 		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="$(DotNet5Version)" />
 		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="$(DotNet5Version)" />
 	</ItemGroup>
@@ -39,6 +41,7 @@
 	<ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
 		<PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="$(DotNet6Version)" />
 		<PackageReference Include="Microsoft.Extensions.Localization.Abstractions" Version="$(DotNet6Version)" />
+		<PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="$(DotNet6Version)" />
 		<PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="$(DotNet6Version)" />
 		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="$(DotNet6Version)" />
 		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="$(DotNet6Version)" />
@@ -47,6 +50,7 @@
 	<ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
 		<PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="$(DotNet7Version)" />
 		<PackageReference Include="Microsoft.Extensions.Localization.Abstractions" Version="$(DotNet7Version)" />
+		<PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="$(DotNet7Version)" />
 		<PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="$(DotNet7Version)" />
 		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="$(DotNet7Version)" />
 		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="$(DotNet7Version)" />


### PR DESCRIPTION
This PR closes #954 

By default, the container has an `IMemoryCache` implementation available. This aligns the behavior to what ASP.NET Core does.