### PR TITLE
chore: Remove AngleSharp.CSS

### DIFF
--- a/src/AngleSharpWrappers/AngleSharpWrappers.csproj
+++ b/src/AngleSharpWrappers/AngleSharpWrappers.csproj
@@ -17,7 +17,6 @@
 
   <ItemGroup>
 		<PackageReference Include="AngleSharp" Version="1.0.1" />
-		<PackageReference Include="AngleSharp.Css" Version="0.16.4" />
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
 	</ItemGroup>
 

--- a/src/bunit.web/bunit.web.csproj
+++ b/src/bunit.web/bunit.web.csproj
@@ -16,7 +16,6 @@
 
 	<ItemGroup>
 		<PackageReference Include="AngleSharp" Version="1.0.1" />
-		<PackageReference Include="AngleSharp.Css" Version="0.16.4" />
 		<PackageReference Include="AngleSharp.Diffing" Version="0.17.0" />
 	</ItemGroup>
 


### PR DESCRIPTION
Remove obsolete `AngleSharp.CSS` dependency.

This closes #958 