### PR TITLE
fix: allow semantic comparer to compare IHtmlUnknownElement types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,11 @@ All notable changes to **bUnit** will be documented in this file. The project ad
 
 ## [Unreleased]
 
+-   Changed semantic comparer to handle elements parsed outside their proper context, e.g. an `<path>` element parsed without being inside a `<svg>` element. The semantic comparer will now be able to treat those as regular elements and thus be able to compare correctly to other elements of the same type and with the same node name. By [@egil](https://github.com/egil).
+
 ## [1.15.5] - 2023-02-04
 
--   Upgrade AngleSharp.Diffing to 0.17.1
+-   Upgrade AngleSharp.Diffing to 0.17.1. 
 
 ## [1.14.4] - 2023-01-11
 

--- a/src/bunit.web/Diffing/BlazorDiffingHelpers.cs
+++ b/src/bunit.web/Diffing/BlazorDiffingHelpers.cs
@@ -1,4 +1,5 @@
 using AngleSharp.Diffing.Core;
+using AngleSharp.Html.Dom;
 
 namespace Bunit.Diffing;
 
@@ -19,5 +20,42 @@ public static class BlazorDiffingHelpers
 			return FilterDecision.Exclude;
 
 		return currentDecision;
+	}
+
+	// Based on the forward searching node matcher in AngleSharp.Diffing,
+	// but this also tries to match nodes that are IHtmlUnknownElement
+	// but have the same NodeType and NodeName. This allow us to
+	// deal with SVG elements that are parsed without the proper context,
+	// i.e. inside an <SVG> element.
+	internal static IEnumerable<Comparison> UnknownElementMatch(
+		IDiffContext context,
+		SourceCollection controlSources,
+		SourceCollection testSources)
+	{
+		var lastMatchedTestNodeIndex = -1;
+		foreach (var control in controlSources.GetUnmatched())
+		{
+			var comparison = TryFindMatchingNodes(control, testSources, lastMatchedTestNodeIndex + 1);
+			if (comparison.HasValue)
+			{
+				yield return comparison.Value;
+				lastMatchedTestNodeIndex = comparison.Value.Test.Index;
+			}
+		}
+	}
+
+	private static Comparison? TryFindMatchingNodes(in ComparisonSource control, SourceCollection testSources, int startIndex)
+	{
+		foreach (var test in testSources.GetUnmatched(startIndex))
+		{
+			if (control.Node is IHtmlUnknownElement
+				|| test.Node is IHtmlUnknownElement
+				&& control.Node.NodeType == test.Node.NodeType
+				&& control.Node.NodeName.Equals(test.Node.NodeName, StringComparison.OrdinalIgnoreCase))
+			{
+				return new Comparison(control, test);
+			}
+		}
+		return null;
 	}
 }

--- a/src/bunit.web/Diffing/HtmlComparer.cs
+++ b/src/bunit.web/Diffing/HtmlComparer.cs
@@ -21,6 +21,7 @@ public sealed class HtmlComparer
 	{
 		var strategy = new DiffingStrategyPipeline();
 		strategy.AddDefaultOptions();
+		strategy.AddMatcher(BlazorDiffingHelpers.UnknownElementMatch, StrategyType.Specialized);
 		strategy.AddFilter(BlazorDiffingHelpers.BlazorAttributeFilter, StrategyType.Specialized);
 		differenceEngine = new HtmlDiffer(strategy);
 	}

--- a/tests/bunit.testassets/SampleComponents/SimpleSvg.razor
+++ b/tests/bunit.testassets/SampleComponents/SimpleSvg.razor
@@ -1,0 +1,1 @@
+<svg><path></path></svg>

--- a/tests/bunit.testassets/XunitExtensions/TheoryDataExtensions.cs
+++ b/tests/bunit.testassets/XunitExtensions/TheoryDataExtensions.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+
+namespace Bunit.TestAssets.XunitExtensions;
+
+public static class TheoryDataExtensions
+{
+	public static TheoryData<T> Clone<T>(this TheoryData<T> existing)
+	{
+		var result = new TheoryData<T>();
+		foreach (var item in existing)
+		{
+			result.Add((T)item[0]);
+		}
+		return result;
+	}
+
+	public static TheoryData<T> AddRange<T>(this TheoryData<T> theoryData, IEnumerable<T> items)
+	{
+		foreach (var item in items)
+		{
+			theoryData.Add(item);
+		}
+		return theoryData;
+	}
+
+	public static TheoryData<T> AddRange<T>(this TheoryData<T> theoryData, params T[] items)
+	{
+		foreach (var item in items)
+		{
+			theoryData.Add(item);
+		}
+		return theoryData;
+	}
+}

--- a/tests/bunit.web.tests/Asserting/MarkupMatchesAssertExtensionsTest.cs
+++ b/tests/bunit.web.tests/Asserting/MarkupMatchesAssertExtensionsTest.cs
@@ -123,4 +123,18 @@ public partial class MarkupMatchesAssertExtensionsTest : TestContext
 
 		cut.Find("div").MarkupMatches(cut.FindAll("div"));
 	}
+
+	[Fact(DisplayName = "Handles HtmlUnknownElement when comparing elements")]
+	public void Test015()
+	{
+		var chart = RenderComponent<SimpleSvg>();
+
+		// the path will be returned as a SvgElement since it is
+		// parsed in the context of a <svg> element.
+		var path = chart.Find("path");
+
+		// path will be parsed as an HtmlUnknownElement because it is not
+		// in a known context (e.g. <svg> or <foreignObject>)
+		path.MarkupMatches("<path />");
+	}
 }

--- a/tests/bunit.web.tests/Rendering/BunitHtmlParserTest.cs
+++ b/tests/bunit.web.tests/Rendering/BunitHtmlParserTest.cs
@@ -1,4 +1,6 @@
+using Bunit.TestAssets.XunitExtensions;
 using AngleSharp.Dom;
+using AngleSharp.Html.Dom;
 
 namespace Bunit.Rendering;
 
@@ -9,26 +11,47 @@ public class BunitHtmlParserTest
 	/// <summary>
 	/// All HTML5 elements according to https://developer.mozilla.org/en-US/docs/Web/HTML/Element.
 	/// </summary>
-	public static readonly IEnumerable<object[]> BodyHtmlElements = new[]
+	public static readonly TheoryData<string> BodyHtmlElements = new TheoryData<string>
 	{
-			"base", "link", "meta", "style", "title",
-			"address", "article", "aside", "footer", "header", "h1", "h2", "h3", "h4", "h5", "h6", "hgroup", "main", "nav", "section",
-			"blockquote", "dd", "div", "dl", "dt", "figcaption", "figure", "hr", "li", "ol", "p", "pre", "ul",
-			"a", "abbr", "b", "bdi", "bdo", "br", "cite", "code", "data", "dfn", "em", "i", "kbd", "mark", "q", "rb", "rp", "rt", "rtc", "ruby", "s", "samp", "small", "span", "strong", "sub", "sup", "time", "u", "var", "wbr",
-			"area", "audio", "img", "map", "track", "video",
-			"embed", "iframe", "object", "param", "picture", "source",
-			"canvas", "noscript", "script",
-			"del", "ins",
-			"caption", "col", "colgroup", "table", "tbody", "td", "tfoot", "th", "thead", "tr",
-			"button", "datalist", "fieldset", "form", "input", "label", "legend", "meter", "optgroup", "option", "output", "progress", "select", "textarea",
-			"details", "dialog", "menu", "summary",
-			"slot", "template",
-			"acronym", "applet", "basefont", "bgsound", "big", "blink", "center", "command", "content", "dir", "element", "font", "keygen", "listing", "marquee", "menuitem", "multicol", "nextid", "nobr", "noembed", "noframes", "plaintext", "shadow", "spacer", "strike", "tt", "xmp",
-			// "frame","frameset","image","isindex" // not supported
-		}.Select(x => new[] { x });
+		"base", "link", "meta", "style", "title",
+		"address", "article", "aside", "footer", "header", "h1", "h2", "h3", "h4", "h5", "h6", "hgroup", "main", "nav", "section",
+		"blockquote", "dd", "div", "dl", "dt", "figcaption", "figure", "hr", "li", "ol", "p", "pre", "ul",
+		"a", "abbr", "b", "bdi", "bdo", "br", "cite", "code", "data", "dfn", "em", "i", "kbd", "mark", "q", "rb", "rp", "rt", "rtc", "ruby", "s", "samp", "small", "span", "strong", "sub", "sup", "time", "u", "var", "wbr",
+		"area", "audio", "img", "map", "track", "video", "svg",
+		"embed", "iframe", "object", "param", "picture", "source",
+		"canvas", "noscript", "script",
+		"del", "ins",
+		"caption", "col", "colgroup", "table", "tbody", "td", "tfoot", "th", "thead", "tr",
+		"button", "datalist", "fieldset", "form", "input", "label", "legend", "meter", "optgroup", "option", "output", "progress", "select", "textarea",
+		"details", "dialog", "menu", "summary",
+		"slot", "template",
+		"acronym", "applet", "basefont", "bgsound", "big", "blink", "center", "command", "content", "dir", "element", "font", "keygen", "listing", "marquee", "menuitem", "multicol", "nextid", "nobr", "noembed", "noframes", "plaintext", "shadow", "spacer", "strike", "tt", "xmp",
+		// "frame","frameset","image","isindex" // not supported
+	};
 
-	public static readonly IEnumerable<object[]> BodyHtmlAndSpecialElements = BodyHtmlElements.Concat(
-		new[] { "html", "head", "body", }.Select(x => new[] { x }));
+	public static readonly IEnumerable<object[]> BodyHtmlAndSpecialElements = BodyHtmlElements
+		.Clone()
+		.AddRange("html", "head", "body");
+
+	public static readonly TheoryData<string> SvgElements = new TheoryData<string>
+	{
+		"animate", "animateMotion", "animateTransform",
+		"circle", "clipPath",
+		"defs", "desc", "discard",
+		"ellipse",
+		"feBlend", "feColorMatrix", "feComponentTransfer", "feComposite", "feConvolveMatrix", "feDiffuseLighting", "feDisplacementMap", "feDistantLight", "feDropShadow", "feFlood", "feFuncA", "feFuncB", "feFuncG", "feFuncR", "feGaussianBlur", "feImage", "feMerge", "feMergeNode", "feMorphology", "feOffset", "fePointLight", "feSpecularLighting", "feSpotLight", "feTile", "feTurbulence", "filter", "foreignObject",
+		"g",
+		"hatch", "hatchpath",
+		"line", "linearGradient",
+		"marker", "mask", "metadata", "mpath",
+		"path", "pattern", "polygon", "polyline",
+		"radialGradient", "rect",
+		"set", "stop", "switch", "symbol",
+		"text", "textPath", "tspan",
+		"use",
+		"view"
+		// "a", "image", "script", "svg", "title", "style" removed since they overlap with HTML elements
+	};
 
 	[Fact(DisplayName = "Parse() called with null")]
 	public void ParseCalledWithNull()
@@ -46,7 +69,7 @@ public class BunitHtmlParserTest
 		actual.ShouldHaveSingleItem().TextContent.ShouldBe(text);
 	}
 
-	[Theory(DisplayName = "Parse() passed <TAG id=TAG>")]
+	[Theory(DisplayName = "Parse() parses <TAG id=TAG>")]
 	[MemberData(nameof(BodyHtmlAndSpecialElements))]
 	public void Test001(string elementName)
 	{
@@ -55,7 +78,7 @@ public class BunitHtmlParserTest
 		VerifyElementParsedWithId(elementName, actual);
 	}
 
-	[Theory(DisplayName = "Parse() passed <TAG> with whitespace before")]
+	[Theory(DisplayName = "Parse() parses <TAG> with whitespace before")]
 	[MemberData(nameof(BodyHtmlElements))]
 	public void Test002(string elementName)
 	{
@@ -64,7 +87,7 @@ public class BunitHtmlParserTest
 		VerifyElementParsedWithId(elementName, actual);
 	}
 
-	[Theory(DisplayName = "Parse() passed <TAG>")]
+	[Theory(DisplayName = "Parse() parses <TAG>")]
 	[MemberData(nameof(BodyHtmlElements))]
 	public void Test003(string elementName)
 	{
@@ -75,7 +98,7 @@ public class BunitHtmlParserTest
 			.NodeName.ShouldBe(elementName, StringCompareShould.IgnoreCase);
 	}
 
-	[Theory(DisplayName = "Parse() passed <TAG/>")]
+	[Theory(DisplayName = "Parse() parses <TAG/>")]
 	[MemberData(nameof(BodyHtmlElements))]
 	public void Test004(string elementName)
 	{
@@ -86,7 +109,7 @@ public class BunitHtmlParserTest
 			.NodeName.ShouldBe(elementName, StringCompareShould.IgnoreCase);
 	}
 
-	[Theory(DisplayName = "Parse() passed <TAG ...")]
+	[Theory(DisplayName = "Parse() parses <TAG ...")]
 	[MemberData(nameof(BodyHtmlElements))]
 	public void Test005(string elementName)
 	{
@@ -94,10 +117,11 @@ public class BunitHtmlParserTest
 		var actual = Parser.Parse(input).ToList();
 
 		actual.ShouldHaveSingleItem()
+			.ShouldBeAssignableTo<IText>()
 			.TextContent.ShouldBe(" ");
 	}
 
-	[Theory(DisplayName = "Parse() passed <TAG .../")]
+	[Theory(DisplayName = "Parse() parses <TAG .../")]
 	[MemberData(nameof(BodyHtmlElements))]
 	public void Test006(string elementName)
 	{
@@ -105,7 +129,21 @@ public class BunitHtmlParserTest
 		var actual = Parser.Parse(input).ToList();
 
 		actual.ShouldHaveSingleItem()
+			.ShouldBeAssignableTo<IText>()
 			.TextContent.ShouldBe(" ");
+	}
+
+	[Theory(DisplayName = "Parse() parses SVG element <TAG>")]
+	[MemberData(nameof(SvgElements))]
+	public void Test020(string elementName)
+	{
+		var actual = Parser.Parse($@"<{elementName}>").ToList();
+
+		// SVG elements that are parsed outside of a SVG parent element will
+		// be returned as an IHtmlUnknownElement, which is precise enough for our need.
+		actual.ShouldHaveSingleItem()
+			.ShouldBeAssignableTo<IHtmlUnknownElement>()
+			.NodeName.ShouldBe(elementName, StringCompareShould.IgnoreCase);
 	}
 
 	private static void VerifyElementParsedWithId(string expectedElementName, List<INode> actual)


### PR DESCRIPTION
## Pull request description

Changed semantic comparer to handle elements parsed outside their proper context, e.g. an `<path>` element parsed without being inside a `<svg>` element. The semantic comparer will now be able to treat those as regular elements and thus be able to compare correctly to other elements of the same type and with the same node name.

Motivation: https://stackoverflow.com/questions/75335821/bunit-simple-markup-verification-for-path-tag

### PR meta checklist
- [x] Pull request is targeted at `main` branch for code   
  or targeted at `stable` branch for documentation that is live on bunit.dev.
- [ ] Pull request is linked to all related issues, if any.
- [x] I have read the _CONTRIBUTING.md_ document.

### Code PR specific checklist
- [x] My code follows the code style of this project and AspNetCore coding guidelines.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] I have updated the appropriate sub section in the _CHANGELOG.md_.
- [x] I have added, updated or removed tests to according to my changes.
  - [x] All tests passed.
