### PR TITLE
experiment: block new render until test allows it to go forward

### DIFF
--- a/src/bunit.core/Extensions/WaitForHelpers/WaitForHelper.cs
+++ b/src/bunit.core/Extensions/WaitForHelpers/WaitForHelper.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using Bunit.Rendering;
 using Microsoft.Extensions.Logging;
 
@@ -51,7 +52,7 @@ public abstract class WaitForHelper<T> : IDisposable
 	{
 		this.renderedFragment = renderedFragment ?? throw new ArgumentNullException(nameof(renderedFragment));
 		this.completeChecker = completeChecker ?? throw new ArgumentNullException(nameof(completeChecker));
-		
+
 		logger = renderedFragment.Services.CreateLogger<WaitForHelper<T>>();
 		renderer = (TestRenderer)renderedFragment
 			.Services
@@ -125,7 +126,7 @@ public abstract class WaitForHelper<T> : IDisposable
 	}
 
 	private Task<T> CreateWaitTask()
-	{	
+	{
 		// Two to failure conditions, that the renderer captures an unhandled
 		// exception from a component or itself, or that the timeout is reached,
 		// are executed on the renderers scheduler, to ensure that OnAfterRender
@@ -194,6 +195,11 @@ public abstract class WaitForHelper<T> : IDisposable
 
 	private static TimeSpan GetRuntimeTimeout(TimeSpan? timeout)
 	{
+		if (Debugger.IsAttached)
+		{
+			return TimeSpan.FromMilliseconds(-1);
+		}
+
 		return timeout ?? TimeSpan.FromSeconds(1);
 	}
 }

--- a/src/bunit.core/Rendering/TestRenderer.cs
+++ b/src/bunit.core/Rendering/TestRenderer.cs
@@ -15,6 +15,8 @@ public class TestRenderer : Renderer, ITestRenderer
 	private TaskCompletionSource<Exception> unhandledExceptionTsc = new(TaskCreationOptions.RunContinuationsAsynchronously);
 	private Exception? capturedUnhandledException;
 
+	public TaskCompletionSource<object>? WaitingRender { get; private set; }
+
 	/// <inheritdoc/>
 	public Task<Exception> UnhandledException => unhandledExceptionTsc.Task;
 
@@ -154,10 +156,11 @@ public class TestRenderer : Renderer, ITestRenderer
 	/// <inheritdoc/>
 	protected override Task UpdateDisplayAsync(in RenderBatch renderBatch)
 	{
+		WaitingRender = new();
 		logger.LogNewRenderBatchReceived();
 
 		RenderCount++;
-		
+
 		var renderEvent = new RenderEvent(renderBatch, new RenderTreeFrameDictionary());
 
 		// removes disposed components
@@ -194,7 +197,7 @@ public class TestRenderer : Renderer, ITestRenderer
 
 		logger.LogChangedComponentsMarkupUpdated();
 
-		return Task.CompletedTask;
+		return WaitingRender.Task;
 	}
 
 	/// <inheritdoc/>

--- a/src/bunit.core/Rendering/TestRenderer.cs
+++ b/src/bunit.core/Rendering/TestRenderer.cs
@@ -197,7 +197,7 @@ public class TestRenderer : Renderer, ITestRenderer
 
 		logger.LogChangedComponentsMarkupUpdated();
 
-		return WaitingRender.Task;
+		return WaitingRender?.Task ?? Task.CompletedTask;
 	}
 
 	/// <inheritdoc/>

--- a/tests/bunit.web.tests/Test.cs
+++ b/tests/bunit.web.tests/Test.cs
@@ -1,0 +1,116 @@
+using System.Diagnostics;
+using Bunit.Rendering;
+
+namespace Bunit;
+
+public class Test : TestContext
+{
+	[Fact]
+	public void MyTestMethod()
+	{
+		var renderer = (TestRenderer)Renderer;
+		var cut = RenderComponent<ConstantRerender>();
+		cut.WaitForAssertion(() =>
+		{
+			Thread.Sleep(500);
+			renderer.WaitingRender.SetResult(null!);
+			cut.Markup.ShouldBe("19");
+		}, TimeSpan.FromSeconds(20));
+	}
+
+	[Fact]
+	public void MyTestMethod_async()
+	{
+		var renderer = (TestRenderer)Renderer;
+		var cut = RenderComponent<ConstantAsyncRerender>();
+		cut.WaitForAssertion(() =>
+		{
+			Thread.Sleep(500);
+			renderer.WaitingRender.SetResult(null!);
+			cut.Markup.ShouldBe("19");
+		}, TimeSpan.FromSeconds(20));
+	}
+
+	[Fact]
+	public void MyTestMethod_2()
+	{
+		var renderer = (TestRenderer)Renderer;
+		var cut = RenderComponent<ConstantRerenderInit>();
+		cut.WaitForAssertion(() =>
+		{
+			Thread.Sleep(500);
+			renderer.WaitingRender.SetResult(null!);
+			cut.Markup.ShouldBe("19");
+		}, TimeSpan.FromSeconds(20));
+	}
+}
+
+public class ConstantRerender : ComponentBase
+{
+	private readonly Stopwatch stopwatch = Stopwatch.StartNew();
+
+	public int RenderCount { get; set; }
+
+	public List<TimeSpan> RenderOffset { get; } = new();
+
+	protected override void OnAfterRender(bool firstRender)
+	{
+		RenderCount++;
+		RenderOffset.Add(stopwatch.Elapsed);
+
+		if (RenderCount < 20)
+		{
+			StateHasChanged();
+		}
+	}
+
+	protected override void BuildRenderTree(RenderTreeBuilder builder)
+		=> builder.AddMarkupContent(0, $"{RenderCount}");
+}
+
+public class ConstantAsyncRerender : ComponentBase
+{
+	private readonly Stopwatch stopwatch = Stopwatch.StartNew();
+
+	public int RenderCount { get; set; }
+
+	public List<TimeSpan> RenderOffset { get; } = new();
+
+	protected override async Task OnAfterRenderAsync(bool firstRender)
+	{
+		RenderCount++;
+		RenderOffset.Add(stopwatch.Elapsed);
+
+		if (RenderCount < 20)
+		{
+			await Task.Delay(1);
+			StateHasChanged();
+		}
+	}
+
+	protected override void BuildRenderTree(RenderTreeBuilder builder)
+		=> builder.AddMarkupContent(0, $"{RenderCount}");
+}
+
+public class ConstantRerenderInit : ComponentBase
+{
+	private readonly Stopwatch stopwatch = Stopwatch.StartNew();
+
+	public int RenderCount { get; set; }
+
+	public List<TimeSpan> RenderOffset { get; } = new();
+
+	protected override async Task OnInitializedAsync()
+	{
+		while (RenderCount < 20)
+		{
+			RenderCount++;
+			RenderOffset.Add(stopwatch.Elapsed);
+			await Task.Delay(1);
+			StateHasChanged();
+		}
+	}
+
+	protected override void BuildRenderTree(RenderTreeBuilder builder)
+		=> builder.AddMarkupContent(0, $"{RenderCount}");
+}


### PR DESCRIPTION
@linkdotnet I did a few experiments to verify our understanding of the Blazor Renderer. Here are my takeaways:

1. Any async re-renders (calls to `StateHasChanged`) from `OnAfterRenderAsync` will not happen before the `Task` returned from `Renderer.UpdateDisplayAsync` is completed. That means re-renders will not happen concurrently but in sequence.
2. Any async re-renders (calls to `StateHasChanged`) from `OnInitializedAsync` will happen concurrently until the first call to `Renderer.UpdateDisplayAsync` returns and the `Task` from it can be awaited.

I made a simple change to the TestRenderer, allowing something external to "pause" renders until they complete the TaskCompletionSource. It's just a hacky experiment but could be an inspiration for future change.

**The PR is just to make it easy to review the changes.**

The first screenshot is from a test where there is an async rerender in OnInitializedAsync. Notice the four first timestamps are very close to each other. They are essentially running immediately. After that, the first UpdateDisplayAsync has finished, and then there is a delay of 500+ ms.

![2023-02-26 15_17_22-Window](https://user-images.githubusercontent.com/105649/221421436-02674c82-4849-4e94-80fd-1d555e07e1e3.png)

Contrast that with this screenshot that shows timestamps spaced out consistently with about 500+ ms between them. This is from the test that re-renders via OnAfterRenderAsync.

![2023-02-26 15_18_12-Window](https://user-images.githubusercontent.com/105649/221421531-464a981a-70bf-448e-a354-b36a889387c2.png)

