### PR TITLE
refactor: use early return and simplify call

### DIFF
--- a/src/bunit.core/Rendering/RootRenderTree.cs
+++ b/src/bunit.core/Rendering/RootRenderTree.cs
@@ -91,16 +91,9 @@ public sealed class RootRenderTree : IReadOnlyCollection<RootRenderTreeRegistrat
 	public int GetCountOf<TComponent>()
 		where TComponent : IComponent
 	{
-		var result = 0;
 		var countType = typeof(TComponent);
 
-		for (int i = 0; i < registrations.Count; i++)
-		{
-			if (countType == registrations[i].ComponentType)
-				result++;
-		}
-
-		return result;
+		return registrations.Count(t => countType == t.ComponentType);
 	}
 
 	private static RenderFragment<RenderFragment> CreateRenderFragmentBuilder<TComponent>(Action<ComponentParameterCollectionBuilder<TComponent>>? parameterBuilder)

--- a/src/bunit.core/Rendering/TestRenderer.cs
+++ b/src/bunit.core/Rendering/TestRenderer.cs
@@ -157,7 +157,7 @@ public class TestRenderer : Renderer, ITestRenderer
 		logger.LogNewRenderBatchReceived();
 
 		RenderCount++;
-		
+
 		var renderEvent = new RenderEvent(renderBatch, new RenderTreeFrameDictionary());
 
 		// removes disposed components
@@ -299,18 +299,14 @@ public class TestRenderer : Renderer, ITestRenderer
 	IRenderedComponentBase<TComponent> GetOrCreateRenderedComponent<TComponent>(RenderTreeFrameDictionary framesCollection, int componentId, TComponent component)
 		where TComponent : IComponent
 	{
-		IRenderedComponentBase<TComponent> result;
-
 		if (renderedComponents.TryGetValue(componentId, out var renderedComponent))
 		{
-			result = (IRenderedComponentBase<TComponent>)renderedComponent;
+			return (IRenderedComponentBase<TComponent>)renderedComponent;
 		}
-		else
-		{
-			LoadRenderTreeFrames(componentId, framesCollection);
-			result = activator.CreateRenderedComponent(componentId, component, framesCollection);
-			renderedComponents.Add(result.ComponentId, result);
-		}
+
+		LoadRenderTreeFrames(componentId, framesCollection);
+		var result = activator.CreateRenderedComponent(componentId, component, framesCollection);
+		renderedComponents.Add(result.ComponentId, result);
 
 		return result;
 	}


### PR DESCRIPTION
Tiny PR with two refactorings:
 * Simplify `GetCountOf` to use LINQ query - yes that would be a small performance regression - but no one on GitHub is using this function anyway (https://grep.app/search?q=.GetCountOf&filter[lang][0]=C%23)
 * Small early return if the lookup is successful 