### PR TITLE
Fix: run dom update in test sync context

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -505,3 +505,4 @@ dotnet_diagnostic.S3459.severity = none # S3459: Unassigned members should be re
 dotnet_diagnostic.S3871.severity = none # S3871: Exception types should be "public"
 dotnet_diagnostic.S1186.severity = none # S1186: Methods should not be empty
 dotnet_diagnostic.S1133.severity = none # S1133: Deprecated code should be removed
+dotnet_diagnostic.S3963.severity = none # S3963: "static" fields should be initialized inline (covered by CA1810)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to **bUnit** will be documented in this file. The project ad
 
 ## [Unreleased]
 
+
+### Changed 
+
+- Changed test renderer such that updates to rendered components markup happen in the same synchronization context as the test framework is using (if any), if any, to avoid memory race conditions. By [@egil](https://github.com/egil).
+- Changed default "WaitFor" timeout to 10 seconds. By [@egil](https://github.com/egil).
+
 ## [1.18.4] - 2023-02-26
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@ All notable changes to **bUnit** will be documented in this file. The project ad
 ### Changed 
 
 - Changed test renderer such that updates to rendered components markup happen in the same synchronization context as the test framework is using (if any), if any, to avoid memory race conditions. By [@egil](https://github.com/egil).
-- Changed default "WaitFor" timeout to 10 seconds. By [@egil](https://github.com/egil).
 
 ## [1.18.4] - 2023-02-26
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -19,9 +19,9 @@
 	<PropertyGroup Label="Compile settings">
 		<Nullable>enable</Nullable>
 		<LangVersion>11.0</LangVersion>
-		<AccelerateBuildsInVisualStudio>true</AccelerateBuildsInVisualStudio>
+		<AccelerateBuildsInVisualStudio>false</AccelerateBuildsInVisualStudio>
 		<ImplicitUsings>enable</ImplicitUsings>
-		<NoWarn>CA1014,NU5104</NoWarn>
+		<NoWarn>CA1014,NU5104,NETSDK1138</NoWarn>
 		<CheckEolTargetFramework>false</CheckEolTargetFramework>
 
 		<!-- Used by code coverage -->
@@ -50,7 +50,7 @@
 	<!-- Shared code analyzers used for all projects in the solution -->
 	<ItemGroup Label="Code Analyzers">
 		<PackageReference Include="AsyncFixer" Version="1.6.0" PrivateAssets="All" />
-		<PackageReference Include="SonarAnalyzer.CSharp" Version="8.53.0.62665" PrivateAssets="All" />
+		<PackageReference Include="SonarAnalyzer.CSharp" Version="8.54.0.63966" PrivateAssets="All" />
 	</ItemGroup>
 
 	<ItemGroup Label="Implicit usings"

--- a/src/bunit.core/Extensions/WaitForHelpers/WaitForFailedException.cs
+++ b/src/bunit.core/Extensions/WaitForHelpers/WaitForFailedException.cs
@@ -1,5 +1,3 @@
-using System.ComponentModel;
-
 namespace Bunit.Extensions.WaitForHelpers;
 
 /// <summary>

--- a/src/bunit.core/Rendering/RootComponent.cs
+++ b/src/bunit.core/Rendering/RootComponent.cs
@@ -12,7 +12,8 @@ internal sealed class RootComponent : IComponent
 
 	public void Attach(RenderHandle renderHandle) => this.renderHandle = renderHandle;
 
-	public Task SetParametersAsync(ParameterView parameters) => throw new InvalidOperationException($"{nameof(RootComponent)} shouldn't receive any parameters");
+	public Task SetParametersAsync(ParameterView parameters)
+		=> throw new InvalidOperationException($"{nameof(RootComponent)} shouldn't receive any parameters");
 
 	public void Render() => renderHandle.Render(renderFragment);
 

--- a/src/bunit.core/TestServiceProvider.cs
+++ b/src/bunit.core/TestServiceProvider.cs
@@ -1,5 +1,4 @@
 using System.Collections;
-using Microsoft.Extensions.DependencyInjection;
 
 namespace Bunit;
 

--- a/src/bunit.web/Extensions/TestServiceProviderExtensions.cs
+++ b/src/bunit.web/Extensions/TestServiceProviderExtensions.cs
@@ -5,7 +5,6 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Components.Authorization;
 using Microsoft.AspNetCore.Components.Routing;
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
-using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Localization;
 
 namespace Bunit.Extensions;

--- a/tests/.editorconfig
+++ b/tests/.editorconfig
@@ -44,3 +44,4 @@ dotnet_diagnostic.CA1819.severity = suggestion		# CA1819: Properties should not 
 dotnet_diagnostic.CA1849.severity = suggestion		# CA1849: Call async methods when in an async method
 dotnet_diagnostic.xUnit1026.severity = none			# xUnit1026: Theory methods should use all of their parameters
 dotnet_diagnostic.S1144.severity = suggestion		# S1144: Unused private types or members should be removed
+dotnet_diagnostic.S2094.severity = suggestion		# S2094: Classes should not be empty

--- a/tests/AngleSharpWrappers.Tests/ElementWrapperTest.cs
+++ b/tests/AngleSharpWrappers.Tests/ElementWrapperTest.cs
@@ -1,9 +1,3 @@
-using System.Collections.Generic;
-using System.Data.Common;
-using System.Linq;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
 using AngleSharp.Dom;
 using Shouldly;
 using Xunit;

--- a/tests/AngleSharpWrappers.Tests/HtmlParser.cs
+++ b/tests/AngleSharpWrappers.Tests/HtmlParser.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using AngleSharp;
+﻿using AngleSharp;
 using AngleSharp.Dom;
 using AngleSharp.Html.Parser;
 

--- a/tests/AngleSharpWrappers.Tests/TestFactory.cs
+++ b/tests/AngleSharpWrappers.Tests/TestFactory.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using AngleSharp.Dom;
+﻿using AngleSharp.Dom;
 
 namespace AngleSharpWrappers
 {

--- a/tests/bunit.testassets/XunitExtensions/RepeatAttribute.cs
+++ b/tests/bunit.testassets/XunitExtensions/RepeatAttribute.cs
@@ -1,0 +1,29 @@
+using System.Reflection;
+using Xunit.Sdk;
+
+namespace Xunit;
+
+public sealed class RepeatAttribute : DataAttribute
+{
+	public int Count { get; }
+
+	public RepeatAttribute(int count)
+	{
+		if (count < 1)
+		{
+			throw new ArgumentOutOfRangeException(
+				paramName: nameof(count),
+				message: "Repeat count must be greater than 0.");
+		}
+
+		Count = count;
+	}
+
+	public override IEnumerable<object[]> GetData(MethodInfo testMethod)
+	{
+		for (int count = 1; count <= Count; count++)
+		{
+			yield return new object[] { count };
+		}
+	}
+}

--- a/tests/bunit.testassets/XunitExtensions/TheoryDataExtensions.cs
+++ b/tests/bunit.testassets/XunitExtensions/TheoryDataExtensions.cs
@@ -1,9 +1,4 @@
-using System;
-using System.Collections.Generic;
-using System.Text;
-using Xunit;
-
-namespace Bunit.TestAssets.XunitExtensions;
+namespace Xunit;
 
 public static class TheoryDataExtensions
 {

--- a/tests/bunit.web.testcomponents.tests/RazorTesting/RazorTestDiscovererTest.cs
+++ b/tests/bunit.web.testcomponents.tests/RazorTesting/RazorTestDiscovererTest.cs
@@ -1,8 +1,6 @@
 using Bunit.SampleComponents;
 using Xunit.Abstractions;
-using Xunit;
 using Xunit.Sdk;
-using Xunit.Runners;
 
 namespace Bunit.RazorTesting;
 

--- a/tests/bunit.web.tests/BlazorE2E/ComponentRenderingTest.cs
+++ b/tests/bunit.web.tests/BlazorE2E/ComponentRenderingTest.cs
@@ -674,7 +674,7 @@ public class ComponentRenderingTest : TestContext
 
 		cut.Find("button").Click();
 
-		cut.WaitForStateAsync(() => !cut.FindAll("div").Any());
+		cut.WaitForState(() => !cut.FindAll("div").Any());
 		cut.FindAll("div").Count.ShouldBe(0);
 	}
 

--- a/tests/bunit.web.tests/EventDispatchExtensions/GeneralEventDispatchExtensionsTest.cs
+++ b/tests/bunit.web.tests/EventDispatchExtensions/GeneralEventDispatchExtensionsTest.cs
@@ -1,12 +1,18 @@
 using AngleSharp;
 using AngleSharp.Dom;
 using Bunit.Rendering;
+using Xunit.Abstractions;
 
 namespace Bunit;
 
 public class GeneralEventDispatchExtensionsTest : EventDispatchExtensionsTest<EventArgs>
 {
 	protected override string ElementName => "p";
+
+	public GeneralEventDispatchExtensionsTest(ITestOutputHelper outputHelper)
+	{
+		Services.AddXunitLogger(outputHelper);
+	}
 
 	[Theory(DisplayName = "General events are raised correctly through helpers")]
 	[MemberData(nameof(GetEventHelperMethods), typeof(GeneralEventDispatchExtensions))]
@@ -314,16 +320,13 @@ public class GeneralEventDispatchExtensionsTest : EventDispatchExtensionsTest<Ev
 		cut.Instance.Clicked.ShouldBeTrue();
 	}
 
-	public static IEnumerable<object[]> GetTenNumbers() => Enumerable.Range(0, 10)
-		.Select(i => new object[] { i });
-
 	// Runs the test multiple times to trigger the race condition
 	// reliably.
 	[SuppressMessage("Style", "IDE0060:Remove unused parameter", Justification = "Needed to trigger multiple reruns of test.")]
 	[Theory(DisplayName = "TriggerEventAsync avoids race condition with DOM tree updates")]
-	[MemberData(nameof(GetTenNumbers))]
+	[Repeat(10)]
 	[Trait("Category", "async")]
-	public async Task Test400(int i)
+	public async Task Test400(int repeatCount)
 	{
 		var cut = RenderComponent<CounterComponentDynamic>();
 
@@ -338,9 +341,9 @@ public class GeneralEventDispatchExtensionsTest : EventDispatchExtensionsTest<Ev
 	// reliably.
 	[SuppressMessage("Style", "IDE0060:Remove unused parameter", Justification = "Needed to trigger multiple reruns of test.")]
 	[Theory(DisplayName = "TriggerEventAsync avoids race condition with DOM tree updates")]
-	[MemberData(nameof(GetTenNumbers))]
-	[Trait("Category", "sync")]
-	public async Task Test400_Sync(int i)
+    [Repeat(10)]
+    [Trait("Category", "sync")]
+	public async Task Test400_Sync(int repeatCount)
 	{
 		var cut = RenderComponent<CounterComponentDynamic>();
 

--- a/tests/bunit.web.tests/Extensions/WaitForHelpers/RenderedFragmentWaitForElementsHelperExtensions.Async.Test.cs
+++ b/tests/bunit.web.tests/Extensions/WaitForHelpers/RenderedFragmentWaitForElementsHelperExtensions.Async.Test.cs
@@ -5,7 +5,9 @@ namespace Bunit.Extensions.WaitForHelpers;
 
 public class RenderedFragmentWaitForElementsHelperExtensionsAsyncTest : TestContext
 {
-	public RenderedFragmentWaitForElementsHelperExtensionsAsyncTest(ITestOutputHelper testOutput)
+    private readonly static TimeSpan WaitForTestTimeout = TimeSpan.FromMilliseconds(5);
+
+    public RenderedFragmentWaitForElementsHelperExtensionsAsyncTest(ITestOutputHelper testOutput)
 	{
 		Services.AddXunitLogger(testOutput);
 	}
@@ -29,7 +31,7 @@ public class RenderedFragmentWaitForElementsHelperExtensionsAsyncTest : TestCont
 		var cut = RenderComponent<DelayRenderFragment>();
 
 		var expected = await Should.ThrowAsync<WaitForFailedException>(async () =>
-			await cut.WaitForElementAsync("#notHereElm", TimeSpan.FromMilliseconds(10)));
+			await cut.WaitForElementAsync("#notHereElm", WaitForTestTimeout));
 
 		expected.Message.ShouldStartWith(WaitForElementHelper.TimeoutBeforeFoundMessage);
 	}
@@ -53,7 +55,7 @@ public class RenderedFragmentWaitForElementsHelperExtensionsAsyncTest : TestCont
 		var cut = RenderComponent<DelayRenderFragment>();
 
 		var expected = await Should.ThrowAsync<WaitForFailedException>(async () =>
-			await cut.WaitForElementsAsync("#notHereElm", TimeSpan.FromMilliseconds(30)));
+			await cut.WaitForElementsAsync("#notHereElm", WaitForTestTimeout));
 
 		expected.Message.ShouldStartWith(WaitForElementsHelper.TimeoutBeforeFoundMessage);
 		expected.InnerException.ShouldBeNull();
@@ -66,7 +68,7 @@ public class RenderedFragmentWaitForElementsHelperExtensionsAsyncTest : TestCont
 		var cut = RenderComponent<DelayRenderFragment>();
 
 		var expected = await Should.ThrowAsync<WaitForFailedException>(async () =>
-			await cut.WaitForElementsAsync("#notHereElm", 2, TimeSpan.FromMilliseconds(30)));
+			await cut.WaitForElementsAsync("#notHereElm", 2, WaitForTestTimeout));
 
 		expected.Message.ShouldStartWith(string.Format(CultureInfo.InvariantCulture, WaitForElementsHelper.TimeoutBeforeFoundWithCountMessage, 2));
 		expected.InnerException.ShouldBeNull();

--- a/tests/bunit.web.tests/Extensions/WaitForHelpers/RenderedFragmentWaitForElementsHelperExtensions.Async.Test.cs
+++ b/tests/bunit.web.tests/Extensions/WaitForHelpers/RenderedFragmentWaitForElementsHelperExtensions.Async.Test.cs
@@ -5,7 +5,7 @@ namespace Bunit.Extensions.WaitForHelpers;
 
 public class RenderedFragmentWaitForElementsHelperExtensionsAsyncTest : TestContext
 {
-    private readonly static TimeSpan WaitForTestTimeout = TimeSpan.FromMilliseconds(5);
+    private readonly static TimeSpan WaitForTestTimeout = TimeSpan.FromMilliseconds(100);
 
     public RenderedFragmentWaitForElementsHelperExtensionsAsyncTest(ITestOutputHelper testOutput)
 	{

--- a/tests/bunit.web.tests/Extensions/WaitForHelpers/RenderedFragmentWaitForElementsHelperExtensionsTest.cs
+++ b/tests/bunit.web.tests/Extensions/WaitForHelpers/RenderedFragmentWaitForElementsHelperExtensionsTest.cs
@@ -5,6 +5,8 @@ namespace Bunit.Extensions.WaitForHelpers;
 
 public class RenderedFragmentWaitForElementsHelperExtensionsTest : TestContext
 {
+	private readonly static TimeSpan WaitForTestTimeout = TimeSpan.FromMilliseconds(5);
+
 	public RenderedFragmentWaitForElementsHelperExtensionsTest(ITestOutputHelper testOutput)
 	{
 		Services.AddXunitLogger(testOutput);
@@ -29,7 +31,7 @@ public class RenderedFragmentWaitForElementsHelperExtensionsTest : TestContext
 		var cut = RenderComponent<DelayRenderFragment>();
 
 		var expected = Should.Throw<WaitForFailedException>(() =>
-			cut.WaitForElement("#notHereElm", TimeSpan.FromMilliseconds(10)));
+			cut.WaitForElement("#notHereElm", WaitForTestTimeout));
 
 		expected.Message.ShouldStartWith(WaitForElementHelper.TimeoutBeforeFoundMessage);
 	}
@@ -53,7 +55,7 @@ public class RenderedFragmentWaitForElementsHelperExtensionsTest : TestContext
 		var cut = RenderComponent<DelayRenderFragment>();
 
 		var expected = Should.Throw<WaitForFailedException>(() =>
-			cut.WaitForElements("#notHereElm", TimeSpan.FromMilliseconds(30)));
+			cut.WaitForElements("#notHereElm", WaitForTestTimeout));
 
 		expected.Message.ShouldStartWith(WaitForElementsHelper.TimeoutBeforeFoundMessage);
 		expected.InnerException.ShouldBeNull();
@@ -66,7 +68,7 @@ public class RenderedFragmentWaitForElementsHelperExtensionsTest : TestContext
 		var cut = RenderComponent<DelayRenderFragment>();
 
 		var expected = Should.Throw<WaitForFailedException>(() =>
-			cut.WaitForElements("#notHereElm", 2, TimeSpan.FromMilliseconds(30)));
+			cut.WaitForElements("#notHereElm", 2, WaitForTestTimeout));
 
 		expected.Message.ShouldStartWith(string.Format(CultureInfo.InvariantCulture, WaitForElementsHelper.TimeoutBeforeFoundWithCountMessage, 2));
 		expected.InnerException.ShouldBeNull();

--- a/tests/bunit.web.tests/Rendering/BunitHtmlParserTest.cs
+++ b/tests/bunit.web.tests/Rendering/BunitHtmlParserTest.cs
@@ -1,4 +1,3 @@
-using Bunit.TestAssets.XunitExtensions;
 using AngleSharp.Dom;
 using AngleSharp.Html.Dom;
 

--- a/tests/bunit.web.tests/TestDoubles/Authorization/AuthorizationTest.cs
+++ b/tests/bunit.web.tests/TestDoubles/Authorization/AuthorizationTest.cs
@@ -1,9 +1,15 @@
 using System.Security.Claims;
+using Xunit.Abstractions;
 
 namespace Bunit.TestDoubles.Authorization;
 
 public class AuthorizationTest : TestContext
 {
+	public AuthorizationTest(ITestOutputHelper outputHelper)
+	{
+		Services.AddXunitLogger(outputHelper);
+	}
+
 	[Fact(DisplayName = "AuthorizeView with unauthenticated user")]
 	public void Test001()
 	{


### PR DESCRIPTION
Changed test renderer such that updates to rendered components markup happen in the same synchronization context as the test framework is using (if any).

This includes two changes:

1. a lock around calls to `base.ProcessPendingRender()` and
2. using the callers sync context to update rendered components/rendered fragments DOM

The theory is that multiple async renders (calls to StateHasChanged)
that happen rapidly can cause the internal render tree to get
updated almost concurrently. The updates to the render tree
happens after calling base.ProcessPendingRender() and is finished
when UpdateDisplayAsync is called.

Since UpdateDisplayAsync is used to notify RenderedComponent/RenderedFragment
to update their markup based on render tree data retrieved via
Renderer.GetCurrentRenderTreeFrames, this should ensure that
the render tree is not updated while a UpdateDisplayAsync is
still executing. `base.ProcessPendingRender()` calls `UpdateDisplayAsync`
after it has finished updating the internal render tree of each component.

The caller's sync context, typically one established by
xUnit or another testing framework is used to update any
rendered fragments/dom trees and trigger WaitForX handlers.
This ensures that changes to DOM observed inside a WaitForX handler
will also be visible outside a WaitForX handler, since
they will be running in the same sync context. The theory is that 
this should mitigate the issues where Blazors dispatcher/thread is used 
to verify an assertion inside a WaitForX handler, and another thread is 
used again to access the DOM/repeat the assertion, where the change
may not be visible yet (another theory about why that may happen is different 
CPU cache updates not happening immediately).

### PR meta checklist
- [x] Pull request is targeted at `main` branch for code   
  or targeted at `stable` branch for documentation that is live on bunit.dev.
- [x] Pull request is linked to all related issues, if any.
- [x] I have read the _CONTRIBUTING.md_ document.

### Code PR specific checklist
- [x] My code follows the code style of this project and AspNetCore coding guidelines.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] I have updated the appropriate sub section in the _CHANGELOG.md_.
- [x] I have added, updated or removed tests to according to my changes.
  - [x] All tests passed.
