### PR TITLE
V2 enumerable internal

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -5,3 +5,20 @@ This document describes the changes that need to be made to migrate from bUnit 1
 The `GetChangesSinceFirstRender` and `GetChangesSinceLastRender` methods have been removed from `IRenderedComponent<TComponent>`. There is no one-to-one replacement for these methods, but the general idea is to select the HTML in question via `Find` and assert against that.
 
 Alternatively, the `IRenderFragment` still offers the `OnMarkupUpdated` event, which can be used to assert against the markup after a render.
+
+## Removal of `IsNullOrEmpty` extension method on `IEnumerable<T>` and `CreateLogger` on `IserviceProvider`
+The `IsNullOrEmpty` extension method on `IEnumerable<T>` has been removed, as well as the `CreateLogger` extension method on `IServiceProvider`. These extension methods are pretty common and conflict with other libraries. These methods can be recreated like this:
+
+```csharp
+public static class Extensions
+{
+    public static bool IsNullOrEmpty<T>(this IEnumerable<T> enumerable)
+        => enumerable == null || !enumerable.Any();
+    
+    public static ILogger<T> CreateLogger<T>(this IServiceProvider serviceProvider)
+    {
+        var loggerFactory = serviceProvider.GetRequiredService<ILoggerFactory>() ?? NullLoggerFactory.Instance;
+        return loggerFactory.CreateLogger<T>();
+    }
+}
+```

--- a/src/bunit.core/Extensions/LoggerHelperExtensions.cs
+++ b/src/bunit.core/Extensions/LoggerHelperExtensions.cs
@@ -6,7 +6,7 @@ namespace Bunit.Extensions;
 /// <summary>
 /// Helper extension methods for getting a logger.
 /// </summary>
-public static class LoggerHelperExtensions
+internal static class LoggerHelperExtensions
 {
 	/// <summary>
 	/// Creates a logger from the <see cref="ILoggerFactory"/> registered in the <see cref="IServiceProvider"/>.

--- a/src/bunit.web/Extensions/EnumerableExtensions.cs
+++ b/src/bunit.web/Extensions/EnumerableExtensions.cs
@@ -3,10 +3,10 @@ namespace Bunit.Extensions;
 /// <summary>
 /// Helper methods for working with <see cref="IEnumerable{T}"/>.
 /// </summary>
-public static class EnumerableExtensions
+internal static class EnumerableExtensions
 {
 	/// <summary>
-	/// Returns true if the numerable is null or empty.
+	/// Returns true if the enumerable is null or empty.
 	/// </summary>
 	public static bool IsNullOrEmpty<T>([NotNullWhen(false)] this IEnumerable<T>? enumerable)
 	{


### PR DESCRIPTION
I moved the `EnumerableExtensions` to `bunit.web` and made it `internal`.

There are two reasons: The main point being that this is a very common extension people are using - this might confuse users as well as conflict with other 3rd party libraries. I don't think bUnit should expose such functions.

The second reason: We are only using it in one place - I was thinking even having it only has a static local function instead of an extension.