### PR TITLE
add: ObsoleteAttribute for soon to be removed API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to **bUnit** will be documented in this file. The project ad
 
 ## [Unreleased]
 
+### Added
+- `ObsoleteAttribute` for API that will be removed with `v2`.
+
 ## [1.19.14] - 2023-04-26
 
 ### Fixed

--- a/src/bunit.core/Extensions/EnumerableExtensions.cs
+++ b/src/bunit.core/Extensions/EnumerableExtensions.cs
@@ -8,6 +8,7 @@ public static class EnumerableExtensions
 	/// <summary>
 	/// Returns true if the numerable is null or empty.
 	/// </summary>
+	[Obsolete("Will be removed in v2.")]
 	public static bool IsNullOrEmpty<T>([NotNullWhen(false)] this IEnumerable<T>? enumerable)
 	{
 		return enumerable is null || !enumerable.Any();

--- a/src/bunit.web/Asserting/DiffAssertExtensions.cs
+++ b/src/bunit.web/Asserting/DiffAssertExtensions.cs
@@ -14,6 +14,7 @@ public static class DiffAssertExtensions
 	/// </summary>
 	/// <param name="diffs">The collection to be inspected.</param>
 	/// <returns>The expected single <see cref="IDiff"/> in the collection.</returns>
+	[Obsolete("Will be removed in v2.")]
 	public static IDiff ShouldHaveSingleChange(this IEnumerable<IDiff> diffs)
 	{
 		if (diffs is null)
@@ -39,6 +40,7 @@ public static class DiffAssertExtensions
 	/// <param name="diffs">The collection to be inspected.</param>
 	/// <param name="diffInspectors">The <see cref="IDiff"/> inspectors, which inspect each <see cref="IDiff"/> in turn.
 	/// The total number of <see cref="IDiff"/> inspectors must exactly match the number of <see cref="IDiff"/>s in the collection.</param>
+	[Obsolete("Will be removed in v2.")]
 	public static void ShouldHaveChanges(this IEnumerable<IDiff> diffs, params Action<IDiff>[] diffInspectors)
 	{
 		if (diffs is null)

--- a/src/bunit.web/Asserting/ShouldBeAdditionAssertExtensions.cs
+++ b/src/bunit.web/Asserting/ShouldBeAdditionAssertExtensions.cs
@@ -17,6 +17,7 @@ public static class ShouldBeAdditionAssertExtensions
 	/// <param name="actualChange">The change to verify.</param>
 	/// <param name="expectedChange">The expected additions to verify against.</param>
 	/// <param name="userMessage">A custom user message to display in case the verification fails.</param>
+	[Obsolete("Will be removed in v2.")]
 	public static void ShouldBeAddition(this IDiff actualChange, string expectedChange, string? userMessage = null)
 	{
 		if (actualChange is null)
@@ -48,6 +49,7 @@ public static class ShouldBeAdditionAssertExtensions
 	/// <param name="actualChange">The change to verify.</param>
 	/// <param name="expectedChange">The expected additions to verify against.</param>
 	/// <param name="userMessage">A custom user message to display in case the verification fails.</param>
+	[Obsolete("Will be removed in v2.")]
 	public static void ShouldBeAddition(this IDiff actualChange, IRenderedFragment expectedChange, string? userMessage = null)
 	{
 		if (expectedChange is null)
@@ -63,6 +65,7 @@ public static class ShouldBeAdditionAssertExtensions
 	/// <param name="actualChange">The change to verify.</param>
 	/// <param name="expectedChange">The expected additions to verify against.</param>
 	/// <param name="userMessage">A custom user message to display in case the verification fails.</param>
+	[Obsolete("Will be removed in v2.")]
 	public static void ShouldBeAddition(this IDiff actualChange, INodeList expectedChange, string? userMessage = null)
 	{
 		if (actualChange is null)

--- a/src/bunit.web/Asserting/ShouldBeRemovalAssertExtensions.cs
+++ b/src/bunit.web/Asserting/ShouldBeRemovalAssertExtensions.cs
@@ -17,6 +17,7 @@ public static class ShouldBeRemovalAssertExtensions
 	/// <param name="actualChange">The change to verify.</param>
 	/// <param name="expectedChange">The expected removal to verify against.</param>
 	/// <param name="userMessage">A custom user message to display in case the verification fails.</param>
+	[Obsolete("Will be removed in v2.")]
 	public static void ShouldBeRemoval(this IDiff actualChange, string expectedChange, string? userMessage = null)
 	{
 		if (actualChange is null)
@@ -48,6 +49,7 @@ public static class ShouldBeRemovalAssertExtensions
 	/// <param name="actualChange">The change to verify.</param>
 	/// <param name="expectedChange">The expected removal to verify against.</param>
 	/// <param name="userMessage">A custom user message to display in case the verification fails.</param>
+	[Obsolete("Will be removed in v2.")]
 	public static void ShouldBeRemoval(this IDiff actualChange, IRenderedFragment expectedChange, string? userMessage = null)
 	{
 		if (expectedChange is null)
@@ -63,6 +65,7 @@ public static class ShouldBeRemovalAssertExtensions
 	/// <param name="actualChange">The change to verify.</param>
 	/// <param name="expectedChange">The expected removal to verify against.</param>
 	/// <param name="userMessage">A custom user message to display in case the verification fails.</param>
+	[Obsolete("Will be removed in v2.")]
 	public static void ShouldBeRemoval(this IDiff actualChange, INodeList expectedChange, string? userMessage = null)
 	{
 		if (actualChange is null)

--- a/src/bunit.web/Asserting/ShouldBeTextChangeAssertExtensions.cs
+++ b/src/bunit.web/Asserting/ShouldBeTextChangeAssertExtensions.cs
@@ -16,6 +16,7 @@ public static class ShouldBeTextChangeAssertExtensions
 	/// <param name="diffs">The list of diffs to verify against.</param>
 	/// <param name="expectedChange">The expected text change.</param>
 	/// <param name="userMessage">A custom error message to show if the verification fails.</param>
+	[Obsolete("Will be removed in v2.")]
 	public static void ShouldHaveSingleTextChange(this IEnumerable<IDiff> diffs, string expectedChange, string? userMessage = null)
 	{
 		DiffAssertExtensions.ShouldHaveSingleChange(diffs).ShouldBeTextChange(expectedChange, userMessage);
@@ -27,6 +28,7 @@ public static class ShouldBeTextChangeAssertExtensions
 	/// <param name="actualChange">The diff to verify.</param>
 	/// <param name="expectedChange">The expected text change.</param>
 	/// <param name="userMessage">A custom error message to show if the verification fails.</param>
+	[Obsolete("Will be removed in v2.")]
 	public static void ShouldBeTextChange(this IDiff actualChange, string expectedChange, string? userMessage = null)
 	{
 		if (actualChange is null)
@@ -55,6 +57,7 @@ public static class ShouldBeTextChangeAssertExtensions
 	/// <param name="actualChange">The diff to verify.</param>
 	/// <param name="expectedChange">The rendered fragment containing the expected text change.</param>
 	/// <param name="userMessage">A custom error message to show if the verification fails.</param>
+	[Obsolete("Will be removed in v2.")]
 	public static void ShouldBeTextChange(this IDiff actualChange, IRenderedFragment expectedChange, string? userMessage = null)
 	{
 		if (expectedChange is null)
@@ -68,6 +71,7 @@ public static class ShouldBeTextChangeAssertExtensions
 	/// <param name="actualChange">The diff to verify.</param>
 	/// <param name="expectedChange">The node list containing the expected text change.</param>
 	/// <param name="userMessage">A custom error message to show if the verification fails.</param>
+	[Obsolete("Will be removed in v2.")]
 	public static void ShouldBeTextChange(this IDiff actualChange, INodeList expectedChange, string? userMessage = null)
 	{
 		if (actualChange is null)
@@ -94,6 +98,7 @@ public static class ShouldBeTextChangeAssertExtensions
 	/// <param name="expectedAttrName">The expected name of the changed attribute.</param>
 	/// <param name="expectedAttrValue">The expected value of the changed attribute.</param>
 	/// <param name="userMessage">A custom user message to show when the verification fails.</param>
+	[Obsolete("Will be removed in v2.")]
 	public static void ShouldBeAttributeChange(this IDiff actualChange, string expectedAttrName, string expectedAttrValue, string? userMessage = null)
 	{
 		if (actualChange is null)

--- a/src/bunit.web/IRenderedFragment.cs
+++ b/src/bunit.web/IRenderedFragment.cs
@@ -30,6 +30,7 @@ public interface IRenderedFragment : IRenderedFragmentBase
 	/// or component under test.
 	/// </summary>
 	/// <returns>A list of differences found.</returns>
+	[Obsolete("Will be removed in v2.")]
 	IReadOnlyList<IDiff> GetChangesSinceFirstRender();
 
 	/// <summary>
@@ -38,6 +39,7 @@ public interface IRenderedFragment : IRenderedFragmentBase
 	/// with the current rendering of the fragment or component under test.
 	/// </summary>
 	/// <returns>A list of differences found.</returns>
+	[Obsolete("Will be removed in v2.")]
 	IReadOnlyList<IDiff> GetChangesSinceSnapshot();
 
 	/// <summary>
@@ -45,5 +47,6 @@ public interface IRenderedFragment : IRenderedFragmentBase
 	/// Use the method <see cref="GetChangesSinceSnapshot"/> later to get the difference between
 	/// the snapshot and the rendered markup at that time.
 	/// </summary>
+	[Obsolete("Will be removed in v2.")]
 	void SaveSnapshot();
 }

--- a/src/bunit.web/IRenderedFragment.cs
+++ b/src/bunit.web/IRenderedFragment.cs
@@ -31,7 +31,9 @@ public interface IRenderedFragment : IRenderedFragmentBase
 	/// </summary>
 	/// <returns>A list of differences found.</returns>
 	[Obsolete("Will be removed in v2.")]
+#pragma warning disable CA1024 // Public API - cannot change structure
 	IReadOnlyList<IDiff> GetChangesSinceFirstRender();
+#pragma warning restore CA1024
 
 	/// <summary>
 	/// Performs a comparison of the markup produced by the rendering of the
@@ -40,7 +42,9 @@ public interface IRenderedFragment : IRenderedFragmentBase
 	/// </summary>
 	/// <returns>A list of differences found.</returns>
 	[Obsolete("Will be removed in v2.")]
+#pragma warning disable CA1024 // Public API - cannot change structure
 	IReadOnlyList<IDiff> GetChangesSinceSnapshot();
+#pragma warning restore CA1024
 
 	/// <summary>
 	/// Saves the markup from the current rendering of the fragment or component under test.

--- a/src/bunit.web/TestDoubles/Authorization/FakeAuthorizationService.cs
+++ b/src/bunit.web/TestDoubles/Authorization/FakeAuthorizationService.cs
@@ -108,7 +108,9 @@ public class FakeAuthorizationService : IAuthorizationService
 
 	private AuthorizationResult VerifyRequiredPolicies(IReadOnlyCollection<IAuthorizationRequirement> requirements)
 	{
+#pragma warning disable CS0618
 		if (supportedPolicies.IsNullOrEmpty() || requirements.IsNullOrEmpty())
+#pragma warning restore CS0618
 		{
 			return AuthorizationResult.Failed();
 		}

--- a/tests/.editorconfig
+++ b/tests/.editorconfig
@@ -45,3 +45,4 @@ dotnet_diagnostic.CA1849.severity = suggestion		# CA1849: Call async methods whe
 dotnet_diagnostic.xUnit1026.severity = none			# xUnit1026: Theory methods should use all of their parameters
 dotnet_diagnostic.S1144.severity = suggestion		# S1144: Unused private types or members should be removed
 dotnet_diagnostic.S2094.severity = suggestion		# S2094: Classes should not be empty
+dotnet_diagnostic.CS0618.severity = none			# CS0618: 'ObsoleteAttribute' is obsolete: '...'


### PR DESCRIPTION
Fixes #962 

Basically I added some `ObsoleteAttribute` to the diff API that isn't around in `v2` anymore.