### PR TITLE
refactor: Rename fallback service provider method

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -461,6 +461,7 @@ dotnet_diagnostic.S112.severity = none # S112: General exceptions should never b
 dotnet_diagnostic.S1075.severity = suggestion # S1075: URIs should not be hardcoded
 dotnet_diagnostic.S1186.severity = suggestion # S1186: Methods should not be empty
 dotnet_diagnostic.S2292.severity = suggestion # S2292: Trivial properties should be auto-implemented
+dotnet_diagnostic.S3925.severity = none # BUGGY with .NET 8 new Analyzers
 dotnet_diagnostic.S4158.severity = none # BUGGY with C#9 code - doesnt understand local methods
 
 # Razor specific rules

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -39,3 +39,6 @@ The `WebTestRender` class has been merged into the `TestRender` class. If you us
 
 ## `AddFallbackServiceProvider` renamed to `SetFallbackServiceProvider`
 The `AddFallbackServiceProvider` on the `TestServiceProvider` has been renamed to `SetFallbackServiceProvider`. If you used `AddFallbackServiceProvider`, you should replace it with `SetFallbackServiceProvider`.
+
+## Exceptions remove obsolete `SerializableAttribute` and `ISerializable` interface
+With .NET 8 the `SerializableAttribute` and `ISerializable` interface have been marked as obsolete. Therefore, exceptions in bUnit no longer implement `ISerializable` and are no longer marked with the `SerializableAttribute`. More information can be found here: https://github.com/dotnet/docs/issues/34893

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -36,3 +36,6 @@ The `WebTestRender` class has been merged into the `TestRender` class. If you us
 
 ## `WaitFor` methods are asynchronous
 `WaitForState`, `WaitForAssertion`, `WaitForElement` and `WaitForElements` are now asynchronous methods. Therefore they should be awaited and all of them have the `Async` suffix in the method name.
+
+## `AddFallbackServiceProvider` renamed to `SetFallbackServiceProvider`
+The `AddFallbackServiceProvider` on the `TestServiceProvider` has been renamed to `SetFallbackServiceProvider`. If you used `AddFallbackServiceProvider`, you should replace it with `SetFallbackServiceProvider`.

--- a/src/bunit/Asserting/ActualExpectedAssertException.cs
+++ b/src/bunit/Asserting/ActualExpectedAssertException.cs
@@ -3,7 +3,6 @@ namespace Bunit.Asserting;
 /// <summary>
 /// Represents a generic assert exception used when an actual result does not match an expected result.
 /// </summary>
-[Serializable]
 public class ActualExpectedAssertException : Exception
 {
 	/// <summary>
@@ -18,12 +17,6 @@ public class ActualExpectedAssertException : Exception
 		: base(CreateMessage(actual, expected, actualText, expectedText, message))
 	{
 	}
-
-	/// <summary>
-	/// Initializes a new instance of the <see cref="ActualExpectedAssertException"/> class.
-	/// </summary>
-	protected ActualExpectedAssertException(SerializationInfo info, StreamingContext context)
-		: base(info, context) { }
 
 	private static string CreateMessage(string actual, string expected, string actualText, string expectedText, string message)
 	{

--- a/src/bunit/Asserting/HtmlEqualException.cs
+++ b/src/bunit/Asserting/HtmlEqualException.cs
@@ -7,7 +7,6 @@ namespace Bunit;
 /// <summary>
 /// Represents an differences between pieces of markup.
 /// </summary>
-[Serializable]
 public sealed class HtmlEqualException : ActualExpectedAssertException
 {
 	/// <summary>
@@ -52,9 +51,6 @@ public sealed class HtmlEqualException : ActualExpectedAssertException
 		static string NodeName(ComparisonSource source) => source.Node.NodeType.ToString().ToLowerInvariant();
 #pragma warning restore CA1308
 	}
-
-	private HtmlEqualException(SerializationInfo serializationInfo, StreamingContext streamingContext)
-		: base(serializationInfo, streamingContext) { }
 
 	private static string PrintHtml(IMarkupFormattable nodes) => nodes.ToDiffMarkup() + Environment.NewLine;
 }

--- a/src/bunit/Asserting/JSInvokeCountExpectedException.cs
+++ b/src/bunit/Asserting/JSInvokeCountExpectedException.cs
@@ -3,7 +3,6 @@ namespace Bunit;
 /// <summary>
 /// Represents a number of unexpected invocation to a <see cref="BunitJSInterop"/>.
 /// </summary>
-[Serializable]
 public sealed class JSInvokeCountExpectedException : Exception
 {
 	/// <summary>
@@ -30,26 +29,6 @@ public sealed class JSInvokeCountExpectedException : Exception
 		ExpectedInvocationCount = expectedCount;
 		ActualInvocationCount = actualCount;
 		Identifier = identifier;
-	}
-
-	private JSInvokeCountExpectedException(SerializationInfo serializationInfo, StreamingContext streamingContext)
-		: base(serializationInfo, streamingContext)
-	{
-		ArgumentNullException.ThrowIfNull(serializationInfo);
-		ExpectedInvocationCount = serializationInfo.GetInt32(nameof(ExpectedInvocationCount));
-		ActualInvocationCount = serializationInfo.GetInt32(nameof(ActualInvocationCount));
-		Identifier = serializationInfo.GetString(nameof(Identifier)) ?? string.Empty;
-	}
-
-	/// <inheritdoc/>
-	public override void GetObjectData(SerializationInfo info, StreamingContext context)
-	{
-		ArgumentNullException.ThrowIfNull(info);
-
-		info.AddValue(nameof(ExpectedInvocationCount), ExpectedInvocationCount);
-		info.AddValue(nameof(ActualInvocationCount), ActualInvocationCount);
-		info.AddValue(nameof(Identifier), Identifier);
-		base.GetObjectData(info, context);
 	}
 
 	private static string CreateMessage(string identifier, int expectedCount, int actualCount, string assertMethod, string? userMessage = null)

--- a/src/bunit/EventDispatchExtensions/MissingEventHandlerException.cs
+++ b/src/bunit/EventDispatchExtensions/MissingEventHandlerException.cs
@@ -5,7 +5,6 @@ namespace Bunit;
 /// <summary>
 /// Represents an exception that is thrown when triggering an event handler failed because it wasn't available on the targeted <see cref="IElement"/>.
 /// </summary>
-[Serializable]
 public sealed class MissingEventHandlerException : Exception
 {
 	/// <summary>
@@ -33,7 +32,4 @@ public sealed class MissingEventHandlerException : Exception
 
 		return $"{result}{suggestAlternatives}";
 	}
-
-	private MissingEventHandlerException(SerializationInfo serializationInfo, StreamingContext streamingContext)
-		: base(serializationInfo, streamingContext) { }
 }

--- a/src/bunit/Extensions/ElementNotFoundException.cs
+++ b/src/bunit/Extensions/ElementNotFoundException.cs
@@ -4,7 +4,6 @@ namespace Bunit;
 /// Represents a failure to find an element in the searched target
 /// using a CSS selector.
 /// </summary>
-[Serializable]
 public class ElementNotFoundException : Exception
 {
 	/// <summary>
@@ -28,22 +27,5 @@ public class ElementNotFoundException : Exception
 		: base(message)
 	{
 		CssSelector = cssSelector;
-	}
-
-	/// <summary>
-	/// Initializes a new instance of the <see cref="ElementNotFoundException"/> class.
-	/// </summary>
-	protected ElementNotFoundException(SerializationInfo serializationInfo, StreamingContext streamingContext)
-		: base(serializationInfo, streamingContext)
-	{
-		CssSelector = serializationInfo?.GetString(nameof(CssSelector)) ?? string.Empty;
-	}
-
-	/// <inheritdoc/>
-	public override void GetObjectData(SerializationInfo info, StreamingContext context)
-	{
-		ArgumentNullException.ThrowIfNull(info);
-		info.AddValue(nameof(CssSelector), CssSelector);
-		base.GetObjectData(info, context);
 	}
 }

--- a/src/bunit/Extensions/ElementRemovedFromDomException.cs
+++ b/src/bunit/Extensions/ElementRemovedFromDomException.cs
@@ -4,7 +4,6 @@ namespace Bunit;
 /// Represents an exception that is thrown when trying to access an element
 /// that was previous found in the DOM.
 /// </summary>
-[Serializable]
 public sealed class ElementRemovedFromDomException : ElementNotFoundException
 {
 	/// <summary>
@@ -14,7 +13,4 @@ public sealed class ElementRemovedFromDomException : ElementNotFoundException
 		: base($"The DOM element you tried to access, which you previously found with the CSS selector \"{cssSelector}\", is no longer available in the DOM tree. It has probably been removed after a render.", cssSelector)
 	{
 	}
-
-	private ElementRemovedFromDomException(SerializationInfo serializationInfo, StreamingContext streamingContext)
-		: base(serializationInfo, streamingContext) { }
 }

--- a/src/bunit/Extensions/TestServiceProviderExtensions.cs
+++ b/src/bunit/Extensions/TestServiceProviderExtensions.cs
@@ -42,6 +42,9 @@ public static class TestServiceProviderExtensions
 		services.AddSingleton<FakeWebAssemblyHostEnvironment>();
 		services.AddSingleton<IWebAssemblyHostEnvironment>(s => s.GetRequiredService<FakeWebAssemblyHostEnvironment>());
 
+		// bUnits fake ScrollToLocationHash
+		services.AddSingleton<IScrollToLocationHash, FakeScrollToLocationHash>();
+
 		// bUnit specific services
 		services.AddSingleton(testContext);
 		services.AddSingleton<TestRenderer>();

--- a/src/bunit/Extensions/WaitForHelpers/WaitForFailedException.cs
+++ b/src/bunit/Extensions/WaitForHelpers/WaitForFailedException.cs
@@ -3,7 +3,6 @@ namespace Bunit.Extensions.WaitForHelpers;
 /// <summary>
 /// Represents an exception thrown when the <see cref="WaitForHelper{T}"/> does not complete successfully.
 /// </summary>
-[Serializable]
 public sealed class WaitForFailedException : Exception
 {
 	/// <summary>
@@ -18,7 +17,4 @@ public sealed class WaitForFailedException : Exception
 		: base(errorMessage + $" Check count: {checkCount}. Component render count: {componentRenderCount}. Total render count: {totalRenderCount}.", innerException)
 	{
 	}
-
-	private WaitForFailedException(SerializationInfo info, StreamingContext context)
-		: base(info, context) { }
 }

--- a/src/bunit/JSInterop/JSRuntimeUnhandledInvocationException.cs
+++ b/src/bunit/JSInterop/JSRuntimeUnhandledInvocationException.cs
@@ -7,7 +7,6 @@ namespace Bunit;
 /// received by the <see cref="BunitJSInterop"/> running in <see cref="JSRuntimeMode.Strict"/> mode,
 /// which didn't contain a matching invocation handler.
 /// </summary>
-[Serializable]
 public sealed class JSRuntimeUnhandledInvocationException : Exception
 {
 	/// <summary>
@@ -24,11 +23,6 @@ public sealed class JSRuntimeUnhandledInvocationException : Exception
 		: base(CreateErrorMessage(invocation))
 	{
 		Invocation = invocation;
-	}
-
-	private JSRuntimeUnhandledInvocationException(SerializationInfo serializationInfo, StreamingContext streamingContext)
-		: base(serializationInfo, streamingContext)
-	{
 	}
 
 	private static string CreateErrorMessage(JSRuntimeInvocation invocation)

--- a/src/bunit/ParameterException.cs
+++ b/src/bunit/ParameterException.cs
@@ -3,7 +3,6 @@ namespace Bunit.RazorTesting;
 /// <summary>
 /// Represents an missing or invalid Blazor parameter on a Blazor component.
 /// </summary>
-[Serializable]
 public sealed class ParameterException : ArgumentException
 {
 	/// <summary>
@@ -13,9 +12,5 @@ public sealed class ParameterException : ArgumentException
 	/// <param name="parameterName">Name of the Blazor parameter.</param>
 	public ParameterException(string messsage, string parameterName)
 		: base(messsage, parameterName)
-	{ }
-
-	private ParameterException(SerializationInfo serializationInfo, StreamingContext streamingContext)
-		: base(serializationInfo, streamingContext)
 	{ }
 }

--- a/src/bunit/Rendering/ComponentDisposedException.cs
+++ b/src/bunit/Rendering/ComponentDisposedException.cs
@@ -4,7 +4,6 @@ namespace Bunit.Rendering;
 /// Represents an exception that is thrown when a <see cref="Bunit.IRenderedFragment"/>'s
 /// properties is accessed after the underlying component has been disposed by the renderer.
 /// </summary>
-[Serializable]
 public sealed class ComponentDisposedException : Exception
 {
 	/// <summary>
@@ -15,7 +14,4 @@ public sealed class ComponentDisposedException : Exception
 		: base($"The component has been removed from the render tree by the renderer and is no longer available for inspection. ComponentId = {componentId}.")
 	{
 	}
-
-	private ComponentDisposedException(SerializationInfo serializationInfo, StreamingContext streamingContext)
-		: base(serializationInfo, streamingContext) { }
 }

--- a/src/bunit/Rendering/ComponentNotFoundException.cs
+++ b/src/bunit/Rendering/ComponentNotFoundException.cs
@@ -3,7 +3,6 @@ namespace Bunit.Rendering;
 /// <summary>
 /// Represents an exception that is thrown when a search for a component did not succeed.
 /// </summary>
-[Serializable]
 public sealed class ComponentNotFoundException : Exception
 {
 	/// <summary>
@@ -14,7 +13,4 @@ public sealed class ComponentNotFoundException : Exception
 		: base($"A component of type {componentType?.Name} was not found in the render tree.")
 	{
 	}
-
-	private ComponentNotFoundException(SerializationInfo serializationInfo, StreamingContext streamingContext)
-		: base(serializationInfo, streamingContext) { }
 }

--- a/src/bunit/Rendering/TestRenderer.cs
+++ b/src/bunit/Rendering/TestRenderer.cs
@@ -65,15 +65,15 @@ public class TestRenderer : Renderer, ITestRenderer
 	}
 
 	/// <inheritdoc/>
-	public new Task DispatchEventAsync(
+	public override Task DispatchEventAsync(
 		ulong eventHandlerId,
-		EventFieldInfo fieldInfo,
+		EventFieldInfo? fieldInfo,
 		EventArgs eventArgs) => DispatchEventAsync(eventHandlerId, fieldInfo, eventArgs, ignoreUnknownEventHandlers: false);
 
 	/// <inheritdoc/>
-	public Task DispatchEventAsync(
+	public new Task DispatchEventAsync(
 		ulong eventHandlerId,
-		EventFieldInfo fieldInfo,
+		EventFieldInfo? fieldInfo,
 		EventArgs eventArgs,
 		bool ignoreUnknownEventHandlers)
 	{

--- a/src/bunit/Rendering/TestRenderer.cs
+++ b/src/bunit/Rendering/TestRenderer.cs
@@ -68,51 +68,7 @@ public class TestRenderer : Renderer, ITestRenderer
 	public override Task DispatchEventAsync(
 		ulong eventHandlerId,
 		EventFieldInfo? fieldInfo,
-		EventArgs eventArgs) => DispatchEventAsync(eventHandlerId, fieldInfo, eventArgs, ignoreUnknownEventHandlers: false);
-
-	/// <inheritdoc/>
-	public new Task DispatchEventAsync(
-		ulong eventHandlerId,
-		EventFieldInfo? fieldInfo,
-		EventArgs eventArgs,
-		bool ignoreUnknownEventHandlers)
-	{
-		ArgumentNullException.ThrowIfNull(fieldInfo);
-
-		// Calling base.DispatchEventAsync updates the render tree
-		// if the event contains associated data.
-		lock (renderTreeUpdateLock)
-		{
-			var result = Dispatcher.InvokeAsync(() =>
-			{
-				ResetUnhandledException();
-
-				try
-				{
-					return base.DispatchEventAsync(eventHandlerId, fieldInfo, eventArgs);
-				}
-				catch (ArgumentException ex) when (string.Equals(ex.Message, $"There is no event handler associated with this event. EventId: '{eventHandlerId}'. (Parameter 'eventHandlerId')", StringComparison.Ordinal))
-				{
-					if (ignoreUnknownEventHandlers)
-					{
-						return Task.CompletedTask;
-					}
-
-					var betterExceptionMsg = new UnknownEventHandlerIdException(eventHandlerId, fieldInfo, ex);
-					return Task.FromException(betterExceptionMsg);
-				}
-			});
-
-			if (result.IsFaulted && result.Exception is not null)
-			{
-				HandleException(result.Exception);
-			}
-
-			AssertNoUnhandledExceptions();
-
-			return result;
-		}
-	}
+		EventArgs eventArgs) => DispatchEventInternalAsync(eventHandlerId, fieldInfo, eventArgs, ignoreUnknownEventHandlers: false);
 
 	/// <inheritdoc/>
 	public IRenderedComponent<TComponent> FindComponent<TComponent>(IRenderedFragment parentComponent)
@@ -193,6 +149,49 @@ public class TestRenderer : Renderer, ITestRenderer
 		}
 
 		return Task.CompletedTask;
+	}
+
+	private Task DispatchEventInternalAsync(
+		ulong eventHandlerId,
+		EventFieldInfo? fieldInfo,
+		EventArgs eventArgs,
+		bool ignoreUnknownEventHandlers)
+	{
+		ArgumentNullException.ThrowIfNull(fieldInfo);
+
+		// Calling base.DispatchEventAsync updates the render tree
+		// if the event contains associated data.
+		lock (renderTreeUpdateLock)
+		{
+			var result = Dispatcher.InvokeAsync(() =>
+			{
+				ResetUnhandledException();
+
+				try
+				{
+					return base.DispatchEventAsync(eventHandlerId, fieldInfo, eventArgs);
+				}
+				catch (ArgumentException ex) when (string.Equals(ex.Message, $"There is no event handler associated with this event. EventId: '{eventHandlerId}'. (Parameter 'eventHandlerId')", StringComparison.Ordinal))
+				{
+					if (ignoreUnknownEventHandlers)
+					{
+						return Task.CompletedTask;
+					}
+
+					var betterExceptionMsg = new UnknownEventHandlerIdException(eventHandlerId, fieldInfo, ex);
+					return Task.FromException(betterExceptionMsg);
+				}
+			});
+
+			if (result.IsFaulted && result.Exception is not null)
+			{
+				HandleException(result.Exception);
+			}
+
+			AssertNoUnhandledExceptions();
+
+			return result;
+		}
 	}
 
 	private void UpdateDisplay(in RenderBatch renderBatch)

--- a/src/bunit/Rendering/UnknownEventHandlerIdException.cs
+++ b/src/bunit/Rendering/UnknownEventHandlerIdException.cs
@@ -4,7 +4,6 @@ namespace Bunit.Rendering;
 /// Represents an exception that is thrown when the Blazor <see cref="Renderer"/>
 /// does not have any event handler with the specified a given ID.
 /// </summary>
-[Serializable]
 public sealed class UnknownEventHandlerIdException : Exception
 {
 	/// <summary>
@@ -14,9 +13,6 @@ public sealed class UnknownEventHandlerIdException : Exception
 		: base(CreateMessage(eventHandlerId, fieldInfo), innerException)
 	{
 	}
-
-	private UnknownEventHandlerIdException(SerializationInfo serializationInfo, StreamingContext streamingContext)
-		: base(serializationInfo, streamingContext) { }
 
 	private static string CreateMessage(ulong eventHandlerId, EventFieldInfo fieldInfo)
 		=> $"There is no event handler with ID '{eventHandlerId}' associated with the '{fieldInfo.FieldValue}' event " +

--- a/src/bunit/TestDoubles/Authorization/MissingFakeAuthorizationException.cs
+++ b/src/bunit/TestDoubles/Authorization/MissingFakeAuthorizationException.cs
@@ -4,7 +4,6 @@ namespace Bunit.TestDoubles;
 /// Exception used to indicate that the fake authorization services are required by a test
 /// but provided in TestContext.Services.
 /// </summary>
-[Serializable]
 public sealed class MissingFakeAuthorizationException : Exception
 {
 	/// <summary>
@@ -22,11 +21,5 @@ public sealed class MissingFakeAuthorizationException : Exception
 	{
 		ServiceName = serviceName;
 		HelpLink = "https://bunit.egilhansen.com/docs/test-doubles/faking-auth";
-	}
-
-	private MissingFakeAuthorizationException(SerializationInfo serializationInfo, StreamingContext streamingContext)
-		: base(serializationInfo, streamingContext)
-	{
-		ServiceName = serializationInfo?.GetString(nameof(ServiceName)) ?? string.Empty;
 	}
 }

--- a/src/bunit/TestDoubles/Components/ParameterNotFoundException.cs
+++ b/src/bunit/TestDoubles/Components/ParameterNotFoundException.cs
@@ -1,11 +1,10 @@
 namespace Bunit.TestDoubles;
 
 /// <summary>
-/// Represents an exception which is thrown when the 
+/// Represents an exception which is thrown when the
 /// <see cref="CapturedParameterView{TComponent}.Get{TValue}(System.Linq.Expressions.Expression{Func{TComponent, TValue}})"/>
 /// is used to get a parameter that was not passed to the doubled component.
 /// </summary>
-[Serializable]
 public sealed class ParameterNotFoundException : Exception
 {
 	/// <summary>
@@ -16,8 +15,4 @@ public sealed class ParameterNotFoundException : Exception
 	public ParameterNotFoundException(string parameterName, string componentName)
 		: base($"The parameter '{parameterName}' was not passed to the component '{componentName}' when it was rendered.")
 	{ }
-
-	private ParameterNotFoundException(SerializationInfo info, StreamingContext context) : base(info, context)
-	{
-	}
 }

--- a/src/bunit/TestDoubles/HttpClient/MissingMockHttpClientException.cs
+++ b/src/bunit/TestDoubles/HttpClient/MissingMockHttpClientException.cs
@@ -4,7 +4,6 @@ namespace Bunit.TestDoubles;
 /// Exception use to indicate that a mock HttpClient is required by a test
 /// but was not provided.
 /// </summary>
-[Serializable]
 public sealed class MissingMockHttpClientException : Exception
 {
 	[NonSerialized]
@@ -27,7 +26,4 @@ public sealed class MissingMockHttpClientException : Exception
 		this.request = request;
 		HelpLink = "https://bunit.egilhansen.com/docs/test-doubles/mocking-httpclient";
 	}
-
-	private MissingMockHttpClientException(SerializationInfo serializationInfo, StreamingContext streamingContext)
-		: base(serializationInfo, streamingContext) { }
 }

--- a/src/bunit/TestDoubles/Localization/MissingMockStringLocalizationException.cs
+++ b/src/bunit/TestDoubles/Localization/MissingMockStringLocalizationException.cs
@@ -4,7 +4,6 @@ namespace Bunit.TestDoubles;
 /// Exception use to indicate that a IStringLocalizer is required by a test
 /// but was not provided.
 /// </summary>
-[Serializable]
 public sealed class MissingMockStringLocalizationException : Exception
 {
 	/// <summary>
@@ -22,20 +21,5 @@ public sealed class MissingMockStringLocalizationException : Exception
 		: base($"This test requires a IStringLocalizer to be supplied, because the component under test invokes the IStringLocalizer during the test. The method that was called was '{methodName}', the parameters are container within the '{nameof(Arguments)}' property of this exception.")
 	{
 		Arguments = arguments;
-	}
-
-	private MissingMockStringLocalizationException(SerializationInfo serializationInfo, StreamingContext streamingContext)
-		: base(serializationInfo, streamingContext)
-	{
-		ArgumentNullException.ThrowIfNull(serializationInfo);
-		Arguments = serializationInfo.GetValue(nameof(Arguments), Array.Empty<object?>().GetType()) as object?[] ?? Array.Empty<object?>();
-	}
-
-	/// <inheritdoc/>
-	public override void GetObjectData(SerializationInfo info, StreamingContext context)
-	{
-		ArgumentNullException.ThrowIfNull(info);
-		info.AddValue(nameof(Arguments), Arguments, Array.Empty<object?>().GetType());
-		base.GetObjectData(info, context);
 	}
 }

--- a/src/bunit/TestDoubles/ScrollToLocationHash/FakeScrollToLocationHash.cs
+++ b/src/bunit/TestDoubles/ScrollToLocationHash/FakeScrollToLocationHash.cs
@@ -1,0 +1,8 @@
+using Microsoft.AspNetCore.Components.Routing;
+
+namespace Bunit.TestDoubles;
+
+internal sealed class FakeScrollToLocationHash : IScrollToLocationHash
+{
+	public Task RefreshScrollPositionForHash(string locationAbsolute) => Task.CompletedTask;
+}

--- a/src/bunit/TestServiceProvider.cs
+++ b/src/bunit/TestServiceProvider.cs
@@ -65,10 +65,10 @@ public sealed class TestServiceProvider : IServiceProvider, IServiceCollection, 
 	}
 
 	/// <summary>
-	/// Add a fall back service provider that provides services when the default returns null.
+	/// Sets a fall back service provider that provides services when the default returns null.
 	/// </summary>
 	/// <param name="serviceProvider">The fallback service provider.</param>
-	public void AddFallbackServiceProvider(IServiceProvider serviceProvider)
+	public void SetFallbackServiceProvider(IServiceProvider serviceProvider)
 		=> fallbackServiceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
 
 	/// <summary>

--- a/tests/bunit.tests/JSInterop/InvocationHandlers/FocusOnNavigateHandlerTest.cs
+++ b/tests/bunit.tests/JSInterop/InvocationHandlers/FocusOnNavigateHandlerTest.cs
@@ -6,7 +6,6 @@ public class FocusOnNavigateHandlerTest : TestContext
 	public void Test001()
 	{
 		// <FocusOnNavigate RouteData="@routeData" Selector="h1" />
-		Services.AddScoped(_ => Mock.Of<IScrollToLocationHash>());
 		var cut = RenderComponent<App>(ps => ps
 			.Add<FocusOnNavigate, RouteData>(p => p.FoundTemplate, routeData => cps => cps
 				.Add(x => x.RouteData, routeData)
@@ -23,7 +22,6 @@ public class FocusOnNavigateHandlerTest : TestContext
 	[Fact(DisplayName = "Will return completed task")]
 	public void Test002()
 	{
-		Services.AddScoped(_ => Mock.Of<IScrollToLocationHash>());
 		var cut = RenderComponent<App>(ps => ps
 			.Add<FocusOnNavigateInternal, RouteData>(p => p.FoundTemplate, routeData => cps => cps
 				.Add(x => x.RouteData, routeData)

--- a/tests/bunit.tests/JSInterop/InvocationHandlers/FocusOnNavigateHandlerTest.cs
+++ b/tests/bunit.tests/JSInterop/InvocationHandlers/FocusOnNavigateHandlerTest.cs
@@ -6,6 +6,7 @@ public class FocusOnNavigateHandlerTest : TestContext
 	public void Test001()
 	{
 		// <FocusOnNavigate RouteData="@routeData" Selector="h1" />
+		Services.AddScoped(_ => Mock.Of<IScrollToLocationHash>());
 		var cut = RenderComponent<App>(ps => ps
 			.Add<FocusOnNavigate, RouteData>(p => p.FoundTemplate, routeData => cps => cps
 				.Add(x => x.RouteData, routeData)
@@ -22,6 +23,7 @@ public class FocusOnNavigateHandlerTest : TestContext
 	[Fact(DisplayName = "Will return completed task")]
 	public void Test002()
 	{
+		Services.AddScoped(_ => Mock.Of<IScrollToLocationHash>());
 		var cut = RenderComponent<App>(ps => ps
 			.Add<FocusOnNavigateInternal, RouteData>(p => p.FoundTemplate, routeData => cps => cps
 				.Add(x => x.RouteData, routeData)

--- a/tests/bunit.tests/TestServiceProviderTest.cs
+++ b/tests/bunit.tests/TestServiceProviderTest.cs
@@ -126,7 +126,7 @@ public class TestServiceProviderTest
 	public void Test022()
 	{
 		using var sut = new TestServiceProvider();
-		sut.AddFallbackServiceProvider(new FallbackServiceProvider());
+		sut.SetFallbackServiceProvider(new FallbackServiceProvider());
 
 		var result = sut.GetService(typeof(object));
 
@@ -138,7 +138,7 @@ public class TestServiceProviderTest
 	public void Test023()
 	{
 		using var sut = new TestServiceProvider();
-		Assert.Throws<ArgumentNullException>(() => sut.AddFallbackServiceProvider(null!));
+		Assert.Throws<ArgumentNullException>(() => sut.SetFallbackServiceProvider(null!));
 	}
 
 	[Fact(DisplayName = "Service provider returns value before fallback service provider")]
@@ -148,7 +148,7 @@ public class TestServiceProviderTest
 
 		using var sut = new TestServiceProvider();
 		sut.AddSingleton<string>(exceptionStringResult);
-		sut.AddFallbackServiceProvider(new FallbackServiceProvider());
+		sut.SetFallbackServiceProvider(new FallbackServiceProvider());
 
 		var stringResult = sut.GetService(typeof(string));
 		Assert.Equal(exceptionStringResult, stringResult);
@@ -161,8 +161,8 @@ public class TestServiceProviderTest
 	public void Test025()
 	{
 		using var sut = new TestServiceProvider();
-		sut.AddFallbackServiceProvider(new FallbackServiceProvider());
-		sut.AddFallbackServiceProvider(new AnotherFallbackServiceProvider());
+		sut.SetFallbackServiceProvider(new FallbackServiceProvider());
+		sut.SetFallbackServiceProvider(new AnotherFallbackServiceProvider());
 
 		var result = sut.GetService(typeof(object));
 
@@ -177,7 +177,7 @@ public class TestServiceProviderTest
 		var fallbackServiceProvider = new ServiceCollection()
 			.AddSingleton(new DummyService())
 			.BuildServiceProvider();
-		ctx.Services.AddFallbackServiceProvider(fallbackServiceProvider);
+		ctx.Services.SetFallbackServiceProvider(fallbackServiceProvider);
 
 		// Act and assert
 		Should.NotThrow(() => ctx.RenderComponent<DummyComponentWhichRequiresDummyService>());


### PR DESCRIPTION
Renamed the function from `Add` to `Set` as the user is not able to have a list of fallback providers, but only one.
The API naming makes it clearer.