### PR TITLE
feat: Added Debugger hints for FakeNavigationManager types

### DIFF
--- a/src/bunit/TestDoubles/NavigationManager/FakeNavigationManager.cs
+++ b/src/bunit/TestDoubles/NavigationManager/FakeNavigationManager.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using Bunit.Rendering;
 using Microsoft.AspNetCore.Components.Routing;
 
@@ -9,6 +10,7 @@ using URI = Uri;
 /// Represents a fake <see cref="NavigationManager"/> that captures calls to
 /// <see cref="NavigationManager.NavigateTo(string, bool)"/> for testing purposes.
 /// </summary>
+[DebuggerDisplay("Current Uri: {Uri}, History Count: {History.Count}")]
 public sealed class FakeNavigationManager : NavigationManager
 {
 	private readonly ITestRenderer renderer;

--- a/src/bunit/TestDoubles/NavigationManager/NavigationHistory.cs
+++ b/src/bunit/TestDoubles/NavigationManager/NavigationHistory.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Text.Json;
 using Microsoft.AspNetCore.Components.Routing;
 
@@ -6,6 +7,7 @@ namespace Bunit.TestDoubles;
 /// <summary>
 /// Represents a navigation to a <seealso cref="Uri"/> with a set of specific navigation <seealso cref="Options"/>.
 /// </summary>
+[DebuggerDisplay("Uri={Uri}, NavigationState={State}, HasException={HasException}")]
 public sealed class NavigationHistory : IEquatable<NavigationHistory>
 {
 	/// <summary>
@@ -31,16 +33,7 @@ public sealed class NavigationHistory : IEquatable<NavigationHistory>
 	/// </remarks>
 	public Exception? Exception { get; }
 
-	/// <summary>
-	/// Initializes a new instance of the <see cref="NavigationHistory"/> class.
-	/// </summary>
-	/// <param name="uri"></param>
-	/// <param name="options"></param>
-	public NavigationHistory(string uri, NavigationOptions options)
-	{
-		Uri = uri;
-		Options = options;
-	}
+	private bool HasException => Exception is not null;
 
 	/// <summary>
 	/// Initializes a new instance of the <see cref="NavigationHistory"/> class.


### PR DESCRIPTION
This PR is related to #1077 and starts to add some crucial information for the `FakeNavigationManager` and its types.

Result:
<img width="728" alt="image" src="https://github.com/bUnit-dev/bUnit/assets/26365461/9945b328-e237-48f3-b352-885b970c5951">
