### PR TITLE
refactor: remove extensions in favor of partial class

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -45,3 +45,6 @@ With .NET 8 the `SerializableAttribute` and `ISerializable` interface have been 
 
 ## Renamed `Fake` to `Bunit` in many test doubles
 The `Fake` prefix has been replaced with `Bunit` in many test doubles. For example, `FakeNavigationManager` is now `BunitNavigationManager`. If you reference any of these types explicitly, you need to update your code.
+
+### Renamed `AddTestAuthorization` to `AddAuthorization`
+The `AddTestAuthorization` method on `TestContext` has been renamed to `AddAuthorization`. If you used `AddTestAuthorization`, you should replace it with `AddAuthorization`.

--- a/docs/samples/tests/xunit/FallBackServiceProviderUsage.cs
+++ b/docs/samples/tests/xunit/FallBackServiceProviderUsage.cs
@@ -8,7 +8,7 @@ public class FallBackServiceProviderUsageExample : TestContext
   [Fact]
   public void FallBackServiceProviderReturns()
   {
-    Services.AddFallbackServiceProvider(new FallbackServiceProvider());
+    Services.SetFallbackServiceProvider(new FallbackServiceProvider());
 
     var dummyService = Services.GetService<DummyService>();
 

--- a/docs/samples/tests/xunit/InjectAuthServiceTest.cs
+++ b/docs/samples/tests/xunit/InjectAuthServiceTest.cs
@@ -10,7 +10,7 @@ public class InjectAuthServiceTest : TestContext
   public void Test001()
   {
     // arrange
-    var authContext = AddTestAuthorization();
+    var authContext = AddAuthorization();
     authContext.SetAuthorized("TestUserName", AuthorizationState.Authorized);
 
     // act
@@ -24,7 +24,7 @@ public class InjectAuthServiceTest : TestContext
   public void Test002()
   {
     // arrange
-    var authContext = AddTestAuthorization();
+    var authContext = AddAuthorization();
 
     // act
     var cut = RenderComponent<InjectAuthService>();

--- a/docs/samples/tests/xunit/InjectAuthServiceTest.cs
+++ b/docs/samples/tests/xunit/InjectAuthServiceTest.cs
@@ -10,7 +10,7 @@ public class InjectAuthServiceTest : TestContext
   public void Test001()
   {
     // arrange
-    var authContext = this.AddTestAuthorization();
+    var authContext = AddTestAuthorization();
     authContext.SetAuthorized("TestUserName", AuthorizationState.Authorized);
 
     // act
@@ -24,7 +24,7 @@ public class InjectAuthServiceTest : TestContext
   public void Test002()
   {
     // arrange
-    var authContext = this.AddTestAuthorization();
+    var authContext = AddTestAuthorization();
 
     // act
     var cut = RenderComponent<InjectAuthService>();

--- a/docs/samples/tests/xunit/UserInfoTest.cs
+++ b/docs/samples/tests/xunit/UserInfoTest.cs
@@ -9,7 +9,7 @@ public class UserInfoTest : TestContext
   public void Test001()
   {
     // Arrange
-    this.AddTestAuthorization();
+    AddTestAuthorization();
 
     // Act
     var cut = RenderComponent<UserInfo>();
@@ -23,7 +23,7 @@ public class UserInfoTest : TestContext
   public void Test004()
   {
     // Arrange
-    var authContext = this.AddTestAuthorization();
+    var authContext = AddTestAuthorization();
     authContext.SetAuthorizing();
 
     // Act
@@ -38,7 +38,7 @@ public class UserInfoTest : TestContext
   public void Test002()
   {
     // Arrange
-    var authContext = this.AddTestAuthorization();
+    var authContext = AddTestAuthorization();
     authContext.SetAuthorized("TEST USER", AuthorizationState.Unauthorized);
 
     // Act
@@ -53,7 +53,7 @@ public class UserInfoTest : TestContext
   public void Test003()
   {
     // Arrange
-    var authContext = this.AddTestAuthorization();
+    var authContext = AddTestAuthorization();
     authContext.SetAuthorized("TEST USER");
 
     // Act

--- a/docs/samples/tests/xunit/UserInfoTest.cs
+++ b/docs/samples/tests/xunit/UserInfoTest.cs
@@ -9,7 +9,7 @@ public class UserInfoTest : TestContext
   public void Test001()
   {
     // Arrange
-    AddTestAuthorization();
+    AddAuthorization();
 
     // Act
     var cut = RenderComponent<UserInfo>();
@@ -23,7 +23,7 @@ public class UserInfoTest : TestContext
   public void Test004()
   {
     // Arrange
-    var authContext = AddTestAuthorization();
+    var authContext = AddAuthorization();
     authContext.SetAuthorizing();
 
     // Act
@@ -38,7 +38,7 @@ public class UserInfoTest : TestContext
   public void Test002()
   {
     // Arrange
-    var authContext = AddTestAuthorization();
+    var authContext = AddAuthorization();
     authContext.SetAuthorized("TEST USER", AuthorizationState.Unauthorized);
 
     // Act
@@ -53,7 +53,7 @@ public class UserInfoTest : TestContext
   public void Test003()
   {
     // Arrange
-    var authContext = AddTestAuthorization();
+    var authContext = AddAuthorization();
     authContext.SetAuthorized("TEST USER");
 
     // Act

--- a/docs/samples/tests/xunit/UserRightsTest.cs
+++ b/docs/samples/tests/xunit/UserRightsTest.cs
@@ -11,7 +11,7 @@ public class UserRightsTest : TestContext
   public void Test001()
   {
     // Arrange
-    var authContext = AddTestAuthorization();
+    var authContext = AddAuthorization();
     authContext.SetAuthorized("TEST USER");
 
     // Act
@@ -26,7 +26,7 @@ public class UserRightsTest : TestContext
   public void Test002()
   {
     // Arrange
-    var authContext = AddTestAuthorization();
+    var authContext = AddAuthorization();
     authContext.SetAuthorized("TEST USER");
     authContext.SetRoles("superuser");
 
@@ -44,7 +44,7 @@ public class UserRightsTest : TestContext
   public void Test003()
   {
     // Arrange
-    var authContext = AddTestAuthorization();
+    var authContext = AddAuthorization();
     authContext.SetAuthorized("TEST USER");
     authContext.SetRoles("admin", "superuser");
 
@@ -63,7 +63,7 @@ public class UserRightsTest : TestContext
   public void Test004()
   {
     // Arrange
-    var authContext = AddTestAuthorization();
+    var authContext = AddAuthorization();
     authContext.SetAuthorized("TEST USER");
     authContext.SetPolicies("content-editor");
 
@@ -81,7 +81,7 @@ public class UserRightsTest : TestContext
   public void Test0041()
   {
     // Arrange
-    var authContext = AddTestAuthorization();
+    var authContext = AddAuthorization();
     authContext.SetAuthorized("TEST USER");
     authContext.SetPolicies("content-editor", "approver");
 
@@ -99,7 +99,7 @@ public class UserRightsTest : TestContext
   public void Test006()
   {
     // Arrange
-    var authContext = AddTestAuthorization();
+    var authContext = AddAuthorization();
     authContext.SetAuthorized("TEST USER");
     authContext.SetClaims(
       new Claim(ClaimTypes.Email, "test@example.com"),
@@ -121,7 +121,7 @@ public class UserRightsTest : TestContext
   public void Test005()
   {
     // Arrange
-    var authContext = AddTestAuthorization();
+    var authContext = AddAuthorization();
     authContext.SetAuthorized("TEST USER");
     authContext.SetRoles("admin", "superuser");
     authContext.SetPolicies("content-editor");
@@ -144,7 +144,7 @@ public class UserRightsTest : TestContext
   public void Test007()
   {
     // Arrange
-    var authContext = AddTestAuthorization();
+    var authContext = AddAuthorization();
     authContext.SetAuthorized("TEST USER");
     authContext.SetAuthenticationType("custom-auth-type");
 

--- a/docs/samples/tests/xunit/UserRightsTest.cs
+++ b/docs/samples/tests/xunit/UserRightsTest.cs
@@ -11,7 +11,7 @@ public class UserRightsTest : TestContext
   public void Test001()
   {
     // Arrange
-    var authContext = this.AddTestAuthorization();
+    var authContext = AddTestAuthorization();
     authContext.SetAuthorized("TEST USER");
 
     // Act
@@ -26,7 +26,7 @@ public class UserRightsTest : TestContext
   public void Test002()
   {
     // Arrange
-    var authContext = this.AddTestAuthorization();
+    var authContext = AddTestAuthorization();
     authContext.SetAuthorized("TEST USER");
     authContext.SetRoles("superuser");
 
@@ -44,7 +44,7 @@ public class UserRightsTest : TestContext
   public void Test003()
   {
     // Arrange
-    var authContext = this.AddTestAuthorization();
+    var authContext = AddTestAuthorization();
     authContext.SetAuthorized("TEST USER");
     authContext.SetRoles("admin", "superuser");
 
@@ -63,7 +63,7 @@ public class UserRightsTest : TestContext
   public void Test004()
   {
     // Arrange
-    var authContext = this.AddTestAuthorization();
+    var authContext = AddTestAuthorization();
     authContext.SetAuthorized("TEST USER");
     authContext.SetPolicies("content-editor");
 
@@ -81,7 +81,7 @@ public class UserRightsTest : TestContext
   public void Test0041()
   {
     // Arrange
-    var authContext = this.AddTestAuthorization();
+    var authContext = AddTestAuthorization();
     authContext.SetAuthorized("TEST USER");
     authContext.SetPolicies("content-editor", "approver");
 
@@ -99,7 +99,7 @@ public class UserRightsTest : TestContext
   public void Test006()
   {
     // Arrange
-    var authContext = this.AddTestAuthorization();
+    var authContext = AddTestAuthorization();
     authContext.SetAuthorized("TEST USER");
     authContext.SetClaims(
       new Claim(ClaimTypes.Email, "test@example.com"),
@@ -121,7 +121,7 @@ public class UserRightsTest : TestContext
   public void Test005()
   {
     // Arrange
-    var authContext = this.AddTestAuthorization();
+    var authContext = AddTestAuthorization();
     authContext.SetAuthorized("TEST USER");
     authContext.SetRoles("admin", "superuser");
     authContext.SetPolicies("content-editor");
@@ -144,7 +144,7 @@ public class UserRightsTest : TestContext
   public void Test007()
   {
     // Arrange
-    var authContext = this.AddTestAuthorization();
+    var authContext = AddTestAuthorization();
     authContext.SetAuthorized("TEST USER");
     authContext.SetAuthenticationType("custom-auth-type");
 

--- a/docs/site/docs/test-doubles/auth.md
+++ b/docs/site/docs/test-doubles/auth.md
@@ -15,10 +15,10 @@ The test implementation of Blazor's authentication and authorization can be put 
 - **Authenticated** and **authorized** 
 - **Authenticated** and **authorized** with one or more **roles**, **claims**, and/or **policies**
 
-bUnit's authentication and authorization implementation is easily available by calling [`AddTestAuthorization()`](xref:Bunit.TestDoubles.BunitAuthorizationExtensions.AddTestAuthorization(Bunit.TestContextBase)) on a test context. This adds the necessary services to the `Services` collection and the `CascadingAuthenticationState` component to the [root render tree](xref:root-render-tree). The method returns an instance of the <xref:Bunit.TestDoubles.TestAuthorizationContext> type that allows you to control the authentication and authorization state for a test.
+bUnit's authentication and authorization implementation is easily available by calling [`AddTestAuthorization()`](xref:Bunit.TestContextBase.AddTestAuthorization()) on a test context. This adds the necessary services to the `Services` collection and the `CascadingAuthenticationState` component to the [root render tree](xref:root-render-tree). The method returns an instance of the <xref:Bunit.TestDoubles.TestAuthorizationContext> type that allows you to control the authentication and authorization state for a test.
 
 > [!NOTE]
-> If your test class inherits directly from bUnit's <xref:Bunit.TestContext>, as described in <xref:writing-tests#remove-boilerplate-code-from-tests>, then you need to call the [`AddTestAuthorization()`](xref:Bunit.TestDoubles.BunitAuthorizationExtensions.AddTestAuthorization(Bunit.TestContextBase)) method on `this`, since `AddTestAuthorization()` is an extension method, otherwise it wont be available. E.g.: `this.AddTestAuthorization()`.
+> If your test class inherits directly from bUnit's <xref:Bunit.TestContext>, as described in <xref:writing-tests#remove-boilerplate-code-from-tests>, then you need to call the [`AddTestAuthorization()`](xref:Bunit.TestContextBase.AddTestAuthorization()) method.
 
 The following sections show how to set each of these states in a test.
 

--- a/docs/site/docs/test-doubles/auth.md
+++ b/docs/site/docs/test-doubles/auth.md
@@ -15,10 +15,7 @@ The test implementation of Blazor's authentication and authorization can be put 
 - **Authenticated** and **authorized** 
 - **Authenticated** and **authorized** with one or more **roles**, **claims**, and/or **policies**
 
-bUnit's authentication and authorization implementation is easily available by calling [`AddTestAuthorization()`](xref:Bunit.TestContextBase.AddTestAuthorization()) on a test context. This adds the necessary services to the `Services` collection and the `CascadingAuthenticationState` component to the [root render tree](xref:root-render-tree). The method returns an instance of the <xref:Bunit.TestDoubles.TestAuthorizationContext> type that allows you to control the authentication and authorization state for a test.
-
-> [!NOTE]
-> If your test class inherits directly from bUnit's <xref:Bunit.TestContext>, as described in <xref:writing-tests#remove-boilerplate-code-from-tests>, then you need to call the [`AddTestAuthorization()`](xref:Bunit.TestContextBase.AddTestAuthorization()) method.
+bUnit's authentication and authorization implementation is easily available by calling [`AddAuthorization()`](xref:Bunit.TestContextBase.AddAuthorization()) on a test context. This adds the necessary services to the `Services` collection and the `CascadingAuthenticationState` component to the [root render tree](xref:root-render-tree). The method returns an instance of the <xref:Bunit.TestDoubles.TestAuthorizationContext> type that allows you to control the authentication and authorization state for a test.
 
 The following sections show how to set each of these states in a test.
 
@@ -36,9 +33,9 @@ To set the state to unauthenticated and unauthorized, do the following:
 
 [!code-csharp[UserInfoTest.cs](../../../samples/tests/xunit/UserInfoTest.cs?start=11&end=19&highlight=2)]
 
-The highlighted line shows how `AddTestAuthorization()` is used to add the test-specific implementation of Blazor's authentication and authorization types to the `Services` collection, which makes the authentication state available to other services as well as components used throughout the test that require it.
+The highlighted line shows how `AddAuthorization()` is used to add the test-specific implementation of Blazor's authentication and authorization types to the `Services` collection, which makes the authentication state available to other services as well as components used throughout the test that require it.
 
-After calling `AddTestAuthorization()`, the default authentication state is unauthenticated and unauthorized.
+After calling `AddAuthorization()`, the default authentication state is unauthenticated and unauthorized.
 
 ### Authenticating and authorizing state
 
@@ -46,7 +43,7 @@ To set the state to authenticating and authorizing, do the following:
 
 [!code-csharp[UserInfoTest.cs](../../../samples/tests/xunit/UserInfoTest.cs?start=25&end=34&highlight=3)]
 
-After calling `AddTestAuthorization()`, the returned <xref:Bunit.TestDoubles.TestAuthorizationContext> is used to set the authenticating and authorizing state through the <xref:Bunit.TestDoubles.TestAuthorizationContext.SetAuthorizing> method.
+After calling `AddAuthorization()`, the returned <xref:Bunit.TestDoubles.TestAuthorizationContext> is used to set the authenticating and authorizing state through the <xref:Bunit.TestDoubles.TestAuthorizationContext.SetAuthorizing> method.
 
 ### Authenticated and unauthorized state
 
@@ -54,7 +51,7 @@ To set the state to authenticated and unauthorized, do the following:
 
 [!code-csharp[UserInfoTest.cs](../../../samples/tests/xunit/UserInfoTest.cs?start=40&end=49&highlight=3)]
 
-After calling `AddTestAuthorization()`, the returned <xref:Bunit.TestDoubles.TestAuthorizationContext> is used to set the authenticated and unauthorized state through the <xref:Bunit.TestDoubles.TestAuthorizationContext.SetAuthorized(System.String,Bunit.TestDoubles.AuthorizationState)> method.
+After calling `AddAuthorization()`, the returned <xref:Bunit.TestDoubles.TestAuthorizationContext> is used to set the authenticated and unauthorized state through the <xref:Bunit.TestDoubles.TestAuthorizationContext.SetAuthorized(System.String,Bunit.TestDoubles.AuthorizationState)> method.
 
 ### Authenticated and authorized state
 
@@ -62,7 +59,7 @@ To set the state to authenticated and authorized, do the following:
 
 [!code-csharp[UserInfoTest.cs](../../../samples/tests/xunit/UserInfoTest.cs?start=55&end=64&highlight=3)]
 
-After calling `AddTestAuthorization()`, the returned <xref:Bunit.TestDoubles.TestAuthorizationContext> is used to set the authenticated and authorized state through the <xref:Bunit.TestDoubles.TestAuthorizationContext.SetAuthorized(System.String,Bunit.TestDoubles.AuthorizationState)> method. 
+After calling `AddAuthorization()`, the returned <xref:Bunit.TestDoubles.TestAuthorizationContext> is used to set the authenticated and authorized state through the <xref:Bunit.TestDoubles.TestAuthorizationContext.SetAuthorized(System.String,Bunit.TestDoubles.AuthorizationState)> method. 
 
 Note that the second parameter, `AuthorizationState`, is optional, and defaults to `AuthorizationState.Authorized` if not specified.
 

--- a/docs/site/docs/test-doubles/persistentcomponentstate.md
+++ b/docs/site/docs/test-doubles/persistentcomponentstate.md
@@ -9,7 +9,7 @@ bUnit comes with its own version of the `PersistentComponentState` type in Blazo
 
 ## Using bUnit's `PersistentComponentState`
 
-To use bUnit's `PersistentComponentState`, call the `AddBunitPersistentComponentState` extension method on `TestContext`:
+To use bUnit's `PersistentComponentState`, call the `AddBunitPersistentComponentState` method on `TestContext`:
 
 ```csharp
 var state = AddBunitPersistentComponentState();

--- a/src/bunit/TestContextBase.cs
+++ b/src/bunit/TestContextBase.cs
@@ -5,7 +5,7 @@ namespace Bunit;
 /// <summary>
 /// A test context is a factory that makes it possible to create components under tests.
 /// </summary>
-public abstract class TestContextBase : IDisposable
+public abstract partial class TestContextBase : IDisposable
 {
 	private bool disposed;
 	private ITestRenderer? testRenderer;

--- a/src/bunit/TestDoubles/Authorization/BunitAuthorizationContext.cs
+++ b/src/bunit/TestDoubles/Authorization/BunitAuthorizationContext.cs
@@ -8,7 +8,7 @@ namespace Bunit.TestDoubles;
 /// Root authorization service that manages different authentication/authorization state
 /// in the system.
 /// </summary>
-public class TestAuthorizationContext
+public class BunitAuthorizationContext
 {
 	private readonly BunitAuthorizationService authService = new();
 	private readonly BunitAuthorizationPolicyProvider policyProvider = new();
@@ -66,7 +66,7 @@ public class TestAuthorizationContext
 	/// </summary>
 	/// <param name="userName">User name for the principal identity.</param>
 	/// <param name="state">Authorization state.</param>
-	public TestAuthorizationContext SetAuthorized(string userName, AuthorizationState state = AuthorizationState.Authorized)
+	public BunitAuthorizationContext SetAuthorized(string userName, AuthorizationState state = AuthorizationState.Authorized)
 	{
 		IsAuthenticated = true;
 		UserName = userName;
@@ -83,7 +83,7 @@ public class TestAuthorizationContext
 	/// <summary>
 	/// Puts the authorization services into the authorizing state.
 	/// </summary>
-	public TestAuthorizationContext SetAuthorizing()
+	public BunitAuthorizationContext SetAuthorizing()
 	{
 		IsAuthenticated = false;
 		Roles = Array.Empty<string>();
@@ -99,7 +99,7 @@ public class TestAuthorizationContext
 	/// <summary>
 	/// Puts the authorization services into an unauthenticated and unauthorized state.
 	/// </summary>
-	public TestAuthorizationContext SetNotAuthorized()
+	public BunitAuthorizationContext SetNotAuthorized()
 	{
 		IsAuthenticated = false;
 		Roles = Array.Empty<string>();
@@ -116,7 +116,7 @@ public class TestAuthorizationContext
 	/// Sets the user roles in this context..
 	/// </summary>
 	/// <param name="roles">Roles for the claims principal.</param>
-	public TestAuthorizationContext SetRoles(params string[] roles)
+	public BunitAuthorizationContext SetRoles(params string[] roles)
 	{
 		Roles = roles;
 		authService.SetRoles(Roles);
@@ -129,7 +129,7 @@ public class TestAuthorizationContext
 	/// Sets the authorization policies supported for the current user.
 	/// </summary>
 	/// <param name="policies">Supported authorization policies.</param>
-	public TestAuthorizationContext SetPolicies(params string[] policies)
+	public BunitAuthorizationContext SetPolicies(params string[] policies)
 	{
 		Policies = policies;
 		policyProvider.SetPolicyScheme(PolicySchemeName);
@@ -142,7 +142,7 @@ public class TestAuthorizationContext
 	/// Sets the claims on the current user/principal.
 	/// </summary>
 	/// <param name="claims">Claims to set.</param>
-	public TestAuthorizationContext SetClaims(params Claim[] claims)
+	public BunitAuthorizationContext SetClaims(params Claim[] claims)
 	{
 		Claims = claims;
 		authProvider.TriggerAuthenticationStateChanged(UserName, Roles, Claims);
@@ -154,7 +154,7 @@ public class TestAuthorizationContext
 	/// Sets the Identity.AuthenticationType for the current user/principa;.
 	/// </summary>
 	/// <param name="authenticationType">The authentication type to set.</param>
-	public TestAuthorizationContext SetAuthenticationType(string authenticationType)
+	public BunitAuthorizationContext SetAuthenticationType(string authenticationType)
 	{
 		this.authProvider.TriggerAuthenticationStateChanged(this.UserName, this.Roles, this.Claims, authenticationType);
 		return this;

--- a/src/bunit/TestDoubles/Authorization/BunitAuthorizationExtensions.cs
+++ b/src/bunit/TestDoubles/Authorization/BunitAuthorizationExtensions.cs
@@ -11,14 +11,14 @@ public abstract partial class TestContextBase
 	/// an authenticated user, as well as adding the <see cref="CascadingAuthenticationState"/> component to the
 	/// test contexts render tree.
 	/// </summary>
-	public TestAuthorizationContext AddAuthorization()
+	public BunitAuthorizationContext AddAuthorization()
 	{
 		RenderTree.TryAdd<CascadingAuthenticationState>();
 		Services.AddSingleton<BunitSignOutSessionStateManager>();
 #pragma warning disable CS0618
 		Services.AddSingleton<SignOutSessionStateManager>(s => s.GetRequiredService<BunitSignOutSessionStateManager>());
 #pragma warning restore CS0618
-		var authCtx = new TestAuthorizationContext();
+		var authCtx = new BunitAuthorizationContext();
 		authCtx.SetNotAuthorized();
 		authCtx.RegisterAuthorizationServices(Services);
 		return authCtx;

--- a/src/bunit/TestDoubles/Authorization/BunitAuthorizationExtensions.cs
+++ b/src/bunit/TestDoubles/Authorization/BunitAuthorizationExtensions.cs
@@ -1,31 +1,26 @@
+using Bunit.TestDoubles;
 using Microsoft.AspNetCore.Components.Authorization;
 using Microsoft.AspNetCore.Components.WebAssembly.Authentication;
 
-namespace Bunit.TestDoubles;
+namespace Bunit;
 
-/// <summary>
-/// Helper methods for registering the Authentication/Authorization services with
-/// a <see cref="TestServiceProvider"/>.
-/// </summary>
-public static class BunitAuthorizationExtensions
+public abstract partial class TestContextBase
 {
 	/// <summary>
 	/// Adds the appropriate Blazor authentication and authorization services to the <see cref="TestServiceProvider"/> to enable
 	/// an authenticated user, as well as adding the <see cref="CascadingAuthenticationState"/> component to the
 	/// test contexts render tree.
 	/// </summary>
-	public static TestAuthorizationContext AddTestAuthorization(this TestContextBase context)
+	public TestAuthorizationContext AddTestAuthorization()
 	{
-		ArgumentNullException.ThrowIfNull(context);
-
-		context.RenderTree.TryAdd<CascadingAuthenticationState>();
-		context.Services.AddSingleton<BunitSignOutSessionStateManager>();
+		RenderTree.TryAdd<CascadingAuthenticationState>();
+		Services.AddSingleton<BunitSignOutSessionStateManager>();
 #pragma warning disable CS0618
-		context.Services.AddSingleton<SignOutSessionStateManager>(s => s.GetRequiredService<BunitSignOutSessionStateManager>());
+		Services.AddSingleton<SignOutSessionStateManager>(s => s.GetRequiredService<BunitSignOutSessionStateManager>());
 #pragma warning restore CS0618
 		var authCtx = new TestAuthorizationContext();
 		authCtx.SetNotAuthorized();
-		authCtx.RegisterAuthorizationServices(context.Services);
+		authCtx.RegisterAuthorizationServices(Services);
 		return authCtx;
 	}
 }

--- a/src/bunit/TestDoubles/Authorization/BunitAuthorizationExtensions.cs
+++ b/src/bunit/TestDoubles/Authorization/BunitAuthorizationExtensions.cs
@@ -11,7 +11,7 @@ public abstract partial class TestContextBase
 	/// an authenticated user, as well as adding the <see cref="CascadingAuthenticationState"/> component to the
 	/// test contexts render tree.
 	/// </summary>
-	public TestAuthorizationContext AddTestAuthorization()
+	public TestAuthorizationContext AddAuthorization()
 	{
 		RenderTree.TryAdd<CascadingAuthenticationState>();
 		Services.AddSingleton<BunitSignOutSessionStateManager>();

--- a/src/bunit/TestDoubles/PersistentComponentState/TestContextBaseExtensions.cs
+++ b/src/bunit/TestDoubles/PersistentComponentState/TestContextBaseExtensions.cs
@@ -1,23 +1,18 @@
+using Bunit.TestDoubles;
 using Microsoft.AspNetCore.Components.Infrastructure;
 
-namespace Bunit.TestDoubles;
+namespace Bunit;
 
-/// <summary>
-/// Extensions related to <see cref="BunitPersistentComponentState"/>.
-/// </summary>
-public static class TestContextBaseExtensions
+public abstract partial class TestContextBase
 {
 	/// <summary>
-	/// Adds and returns a <see cref="BunitPersistentComponentState"/> to the services of the <paramref name="testContext"/>.
+	/// Adds and returns a <see cref="BunitPersistentComponentState"/> to the services of this <see cref="TestContextBase"/>.
 	/// </summary>
-	/// <param name="testContext">The test context to add the <see cref="BunitPersistentComponentState"/> to.</param>
 	/// <returns>The added <see cref="BunitPersistentComponentState"/>.</returns>
-	public static BunitPersistentComponentState AddBunitPersistentComponentState(this TestContextBase testContext)
+	public BunitPersistentComponentState AddBunitPersistentComponentState()
 	{
-		ArgumentNullException.ThrowIfNull(testContext);
-
-		testContext.Services.AddSingleton<ComponentStatePersistenceManager>();
-		testContext.Services.AddSingleton<PersistentComponentState>(s => s.GetRequiredService<ComponentStatePersistenceManager>().State);
-		return new BunitPersistentComponentState(testContext.Services);
+		Services.AddSingleton<ComponentStatePersistenceManager>();
+		Services.AddSingleton<PersistentComponentState>(s => s.GetRequiredService<ComponentStatePersistenceManager>().State);
+		return new BunitPersistentComponentState(Services);
 	}
 }

--- a/tests/bunit.tests/TestDoubles/Authorization/AuthorizationTest.cs
+++ b/tests/bunit.tests/TestDoubles/Authorization/AuthorizationTest.cs
@@ -14,7 +14,7 @@ public class AuthorizationTest : TestContext
 	public void Test001()
 	{
 		// Arrange
-		this.AddTestAuthorization();
+		AddTestAuthorization();
 
 		// Act
 		var cut = RenderComponent<SimpleAuthView>();
@@ -27,7 +27,7 @@ public class AuthorizationTest : TestContext
 	public void Test002()
 	{
 		// arrange
-		var authContext = this.AddTestAuthorization();
+		var authContext = AddTestAuthorization();
 		authContext.SetAuthorized("TestUser", AuthorizationState.Authorized);
 
 		// act
@@ -41,7 +41,7 @@ public class AuthorizationTest : TestContext
 	public void Test003()
 	{
 		// arrange
-		var authContext = this.AddTestAuthorization();
+		var authContext = AddTestAuthorization();
 		authContext.SetAuthorized("TestUser", AuthorizationState.Unauthorized);
 
 		// act
@@ -55,7 +55,7 @@ public class AuthorizationTest : TestContext
 	public async Task Test004()
 	{
 		// arrange
-		var authContext = this.AddTestAuthorization();
+		var authContext = AddTestAuthorization();
 
 		// start off unauthenticated.
 		var cut = RenderComponent<SimpleAuthView>();
@@ -74,7 +74,7 @@ public class AuthorizationTest : TestContext
 	public void Test005()
 	{
 		// arrange
-		var authContext = this.AddTestAuthorization();
+		var authContext = AddTestAuthorization();
 		authContext.SetAuthorized("TestUser005", AuthorizationState.Authorized);
 
 		// start off unauthenticated.
@@ -105,7 +105,7 @@ public class AuthorizationTest : TestContext
 	public void Test007()
 	{
 		// arrange
-		var authContext = this.AddTestAuthorization();
+		var authContext = AddTestAuthorization();
 		authContext.SetAuthorized("TestUser").SetPolicies("ContentViewer");
 
 		// act
@@ -119,7 +119,7 @@ public class AuthorizationTest : TestContext
 	public void Test008()
 	{
 		// arrange
-		var authContext = this.AddTestAuthorization();
+		var authContext = AddTestAuthorization();
 		authContext.SetAuthorized("TestUser");
 
 		// act
@@ -133,7 +133,7 @@ public class AuthorizationTest : TestContext
 	public void Test0081()
 	{
 		// arrange
-		var authContext = this.AddTestAuthorization();
+		var authContext = AddTestAuthorization();
 		authContext.SetAuthorized("TestUser").SetPolicies("OtherPolicy");
 
 		// act
@@ -147,7 +147,7 @@ public class AuthorizationTest : TestContext
 	public void Test009()
 	{
 		// arrange
-		var authContext = this.AddTestAuthorization();
+		var authContext = AddTestAuthorization();
 		authContext.SetAuthorized("TestUser").SetRoles("Admin");
 
 		// act
@@ -161,7 +161,7 @@ public class AuthorizationTest : TestContext
 	public void Test010()
 	{
 		// arrange
-		var authContext = this.AddTestAuthorization();
+		var authContext = AddTestAuthorization();
 		authContext.SetAuthorized("TestUser");
 
 		// act
@@ -175,7 +175,7 @@ public class AuthorizationTest : TestContext
 	public void Test011()
 	{
 		// arrange
-		var authContext = this.AddTestAuthorization();
+		var authContext = AddTestAuthorization();
 		authContext.SetAuthorized("TestUser").SetRoles("NotAdmin");
 
 		// act
@@ -189,7 +189,7 @@ public class AuthorizationTest : TestContext
 	public void Test012()
 	{
 		// arrange
-		var authContext = this.AddTestAuthorization();
+		var authContext = AddTestAuthorization();
 		authContext.SetAuthorizing();
 
 		// act
@@ -204,7 +204,7 @@ public class AuthorizationTest : TestContext
 	{
 		// arrange
 		var userId = new Guid("{5d5fa9c1-abf9-4ed6-8fb0-3365382b629c}");
-		var authContext = this.AddTestAuthorization();
+		var authContext = AddTestAuthorization();
 		var emailClaim = new Claim(ClaimTypes.Email, "user@test.com");
 		var uuidClaim = new Claim(ClaimTypes.Sid, userId.ToString());
 		authContext.SetAuthorized("TestUser").SetClaims(uuidClaim, emailClaim);
@@ -223,7 +223,7 @@ public class AuthorizationTest : TestContext
 	public void Test014()
 	{
 		// arrange
-		var authContext = this.AddTestAuthorization();
+		var authContext = AddTestAuthorization();
 		authContext.SetAuthorized("TestUser");
 
 		// act
@@ -238,7 +238,7 @@ public class AuthorizationTest : TestContext
 	public void Test020()
 	{
 		var role = "myTestRole";
-		var authCtx = this.AddTestAuthorization();
+		var authCtx = AddTestAuthorization();
 		authCtx.SetAuthorized("FooBar");
 		authCtx.SetRoles(role);
 
@@ -251,7 +251,7 @@ public class AuthorizationTest : TestContext
 	public void Test021()
 	{
 		// arrange
-		var authContext = this.AddTestAuthorization();
+		var authContext = AddTestAuthorization();
 		authContext.SetAuthorized("TestUser");
 		authContext.SetAuthenticationType("custom-auth-type");
 
@@ -266,7 +266,7 @@ public class AuthorizationTest : TestContext
 	public void Test022()
 	{
 		// arrange
-		var authContext = this.AddTestAuthorization();
+		var authContext = AddTestAuthorization();
 		authContext.SetAuthorized("TestUser");
 
 		// act

--- a/tests/bunit.tests/TestDoubles/Authorization/AuthorizationTest.cs
+++ b/tests/bunit.tests/TestDoubles/Authorization/AuthorizationTest.cs
@@ -14,7 +14,7 @@ public class AuthorizationTest : TestContext
 	public void Test001()
 	{
 		// Arrange
-		AddTestAuthorization();
+		AddAuthorization();
 
 		// Act
 		var cut = RenderComponent<SimpleAuthView>();
@@ -27,7 +27,7 @@ public class AuthorizationTest : TestContext
 	public void Test002()
 	{
 		// arrange
-		var authContext = AddTestAuthorization();
+		var authContext = AddAuthorization();
 		authContext.SetAuthorized("TestUser", AuthorizationState.Authorized);
 
 		// act
@@ -41,7 +41,7 @@ public class AuthorizationTest : TestContext
 	public void Test003()
 	{
 		// arrange
-		var authContext = AddTestAuthorization();
+		var authContext = AddAuthorization();
 		authContext.SetAuthorized("TestUser", AuthorizationState.Unauthorized);
 
 		// act
@@ -55,7 +55,7 @@ public class AuthorizationTest : TestContext
 	public async Task Test004()
 	{
 		// arrange
-		var authContext = AddTestAuthorization();
+		var authContext = AddAuthorization();
 
 		// start off unauthenticated.
 		var cut = RenderComponent<SimpleAuthView>();
@@ -74,7 +74,7 @@ public class AuthorizationTest : TestContext
 	public void Test005()
 	{
 		// arrange
-		var authContext = AddTestAuthorization();
+		var authContext = AddAuthorization();
 		authContext.SetAuthorized("TestUser005", AuthorizationState.Authorized);
 
 		// start off unauthenticated.
@@ -105,7 +105,7 @@ public class AuthorizationTest : TestContext
 	public void Test007()
 	{
 		// arrange
-		var authContext = AddTestAuthorization();
+		var authContext = AddAuthorization();
 		authContext.SetAuthorized("TestUser").SetPolicies("ContentViewer");
 
 		// act
@@ -119,7 +119,7 @@ public class AuthorizationTest : TestContext
 	public void Test008()
 	{
 		// arrange
-		var authContext = AddTestAuthorization();
+		var authContext = AddAuthorization();
 		authContext.SetAuthorized("TestUser");
 
 		// act
@@ -133,7 +133,7 @@ public class AuthorizationTest : TestContext
 	public void Test0081()
 	{
 		// arrange
-		var authContext = AddTestAuthorization();
+		var authContext = AddAuthorization();
 		authContext.SetAuthorized("TestUser").SetPolicies("OtherPolicy");
 
 		// act
@@ -147,7 +147,7 @@ public class AuthorizationTest : TestContext
 	public void Test009()
 	{
 		// arrange
-		var authContext = AddTestAuthorization();
+		var authContext = AddAuthorization();
 		authContext.SetAuthorized("TestUser").SetRoles("Admin");
 
 		// act
@@ -161,7 +161,7 @@ public class AuthorizationTest : TestContext
 	public void Test010()
 	{
 		// arrange
-		var authContext = AddTestAuthorization();
+		var authContext = AddAuthorization();
 		authContext.SetAuthorized("TestUser");
 
 		// act
@@ -175,7 +175,7 @@ public class AuthorizationTest : TestContext
 	public void Test011()
 	{
 		// arrange
-		var authContext = AddTestAuthorization();
+		var authContext = AddAuthorization();
 		authContext.SetAuthorized("TestUser").SetRoles("NotAdmin");
 
 		// act
@@ -189,7 +189,7 @@ public class AuthorizationTest : TestContext
 	public void Test012()
 	{
 		// arrange
-		var authContext = AddTestAuthorization();
+		var authContext = AddAuthorization();
 		authContext.SetAuthorizing();
 
 		// act
@@ -204,7 +204,7 @@ public class AuthorizationTest : TestContext
 	{
 		// arrange
 		var userId = new Guid("{5d5fa9c1-abf9-4ed6-8fb0-3365382b629c}");
-		var authContext = AddTestAuthorization();
+		var authContext = AddAuthorization();
 		var emailClaim = new Claim(ClaimTypes.Email, "user@test.com");
 		var uuidClaim = new Claim(ClaimTypes.Sid, userId.ToString());
 		authContext.SetAuthorized("TestUser").SetClaims(uuidClaim, emailClaim);
@@ -223,7 +223,7 @@ public class AuthorizationTest : TestContext
 	public void Test014()
 	{
 		// arrange
-		var authContext = AddTestAuthorization();
+		var authContext = AddAuthorization();
 		authContext.SetAuthorized("TestUser");
 
 		// act
@@ -238,7 +238,7 @@ public class AuthorizationTest : TestContext
 	public void Test020()
 	{
 		var role = "myTestRole";
-		var authCtx = AddTestAuthorization();
+		var authCtx = AddAuthorization();
 		authCtx.SetAuthorized("FooBar");
 		authCtx.SetRoles(role);
 
@@ -251,7 +251,7 @@ public class AuthorizationTest : TestContext
 	public void Test021()
 	{
 		// arrange
-		var authContext = AddTestAuthorization();
+		var authContext = AddAuthorization();
 		authContext.SetAuthorized("TestUser");
 		authContext.SetAuthenticationType("custom-auth-type");
 
@@ -266,7 +266,7 @@ public class AuthorizationTest : TestContext
 	public void Test022()
 	{
 		// arrange
-		var authContext = AddTestAuthorization();
+		var authContext = AddAuthorization();
 		authContext.SetAuthorized("TestUser");
 
 		// act

--- a/tests/bunit.tests/TestDoubles/Authorization/TestAuthorizationContextTest.cs
+++ b/tests/bunit.tests/TestDoubles/Authorization/TestAuthorizationContextTest.cs
@@ -6,7 +6,7 @@ public class TestAuthorizationContextTest : TestContext
 	public void Test003()
 	{
 		// act
-		var authContext = AddTestAuthorization();
+		var authContext = AddAuthorization();
 
 		// assert
 		Assert.False(authContext.IsAuthenticated);
@@ -19,7 +19,7 @@ public class TestAuthorizationContextTest : TestContext
 	public void Test0031()
 	{
 		// act
-		var authContext = AddTestAuthorization();
+		var authContext = AddAuthorization();
 		authContext.SetAuthorizing();
 
 		// assert
@@ -33,7 +33,7 @@ public class TestAuthorizationContextTest : TestContext
 	public void Test002()
 	{
 		// act
-		var authContext = AddTestAuthorization();
+		var authContext = AddAuthorization();
 		authContext.SetAuthorized("DarthPedro", AuthorizationState.Unauthorized);
 
 		// assert
@@ -47,7 +47,7 @@ public class TestAuthorizationContextTest : TestContext
 	public void Test0010()
 	{
 		// act
-		var authContext = AddTestAuthorization();
+		var authContext = AddAuthorization();
 		authContext.SetAuthorized("DarthPedro");
 
 		// assert
@@ -61,7 +61,7 @@ public class TestAuthorizationContextTest : TestContext
 	public void Test001()
 	{
 		// act
-		var authContext = AddTestAuthorization();
+		var authContext = AddAuthorization();
 		authContext.SetAuthorized("DarthPedro");
 		authContext.SetRoles("some-role");
 
@@ -76,7 +76,7 @@ public class TestAuthorizationContextTest : TestContext
 	public void Test0011()
 	{
 		// act
-		var authContext = AddTestAuthorization();
+		var authContext = AddAuthorization();
 		authContext.SetAuthorized("DarthPedro");
 		authContext.SetPolicies("TestPolicy", "Other");
 

--- a/tests/bunit.tests/TestDoubles/Authorization/TestAuthorizationContextTest.cs
+++ b/tests/bunit.tests/TestDoubles/Authorization/TestAuthorizationContextTest.cs
@@ -6,7 +6,7 @@ public class TestAuthorizationContextTest : TestContext
 	public void Test003()
 	{
 		// act
-		var authContext = this.AddTestAuthorization();
+		var authContext = AddTestAuthorization();
 
 		// assert
 		Assert.False(authContext.IsAuthenticated);
@@ -19,7 +19,7 @@ public class TestAuthorizationContextTest : TestContext
 	public void Test0031()
 	{
 		// act
-		var authContext = this.AddTestAuthorization();
+		var authContext = AddTestAuthorization();
 		authContext.SetAuthorizing();
 
 		// assert
@@ -33,7 +33,7 @@ public class TestAuthorizationContextTest : TestContext
 	public void Test002()
 	{
 		// act
-		var authContext = this.AddTestAuthorization();
+		var authContext = AddTestAuthorization();
 		authContext.SetAuthorized("DarthPedro", AuthorizationState.Unauthorized);
 
 		// assert
@@ -47,7 +47,7 @@ public class TestAuthorizationContextTest : TestContext
 	public void Test0010()
 	{
 		// act
-		var authContext = this.AddTestAuthorization();
+		var authContext = AddTestAuthorization();
 		authContext.SetAuthorized("DarthPedro");
 
 		// assert
@@ -61,7 +61,7 @@ public class TestAuthorizationContextTest : TestContext
 	public void Test001()
 	{
 		// act
-		var authContext = this.AddTestAuthorization();
+		var authContext = AddTestAuthorization();
 		authContext.SetAuthorized("DarthPedro");
 		authContext.SetRoles("some-role");
 
@@ -76,7 +76,7 @@ public class TestAuthorizationContextTest : TestContext
 	public void Test0011()
 	{
 		// act
-		var authContext = this.AddTestAuthorization();
+		var authContext = AddTestAuthorization();
 		authContext.SetAuthorized("DarthPedro");
 		authContext.SetPolicies("TestPolicy", "Other");
 

--- a/tests/bunit.tests/TestDoubles/BunitSignOutSessionStateManagerTest.cs
+++ b/tests/bunit.tests/TestDoubles/BunitSignOutSessionStateManagerTest.cs
@@ -5,7 +5,7 @@ public class BunitSignOutSessionStateManagerTest : TestContext
 	[Theory, AutoData]
 	public void ShouldSignOut(string randomUserName)
 	{
-		AddTestAuthorization().SetAuthorized(randomUserName);
+		AddAuthorization().SetAuthorized(randomUserName);
 		var cut = RenderComponent<SignOutSessionManagerLoginDisplay>();
 
 		cut.Find("button").Click();

--- a/tests/bunit.tests/TestDoubles/BunitSignOutSessionStateManagerTest.cs
+++ b/tests/bunit.tests/TestDoubles/BunitSignOutSessionStateManagerTest.cs
@@ -5,7 +5,7 @@ public class BunitSignOutSessionStateManagerTest : TestContext
 	[Theory, AutoData]
 	public void ShouldSignOut(string randomUserName)
 	{
-		this.AddTestAuthorization().SetAuthorized(randomUserName);
+		AddTestAuthorization().SetAuthorized(randomUserName);
 		var cut = RenderComponent<SignOutSessionManagerLoginDisplay>();
 
 		cut.Find("button").Click();

--- a/tests/bunit.tests/TestDoubles/PersistentComponentState/BunitPersistentComponentStateTest.cs
+++ b/tests/bunit.tests/TestDoubles/PersistentComponentState/BunitPersistentComponentStateTest.cs
@@ -12,7 +12,7 @@ public class BunitPersistentComponentStateTest : TestContext
 	[Fact(DisplayName = "AddFakePersistentComponentState is registers PersistentComponentState in services")]
 	public void Test001()
 	{
-		_ = this.AddBunitPersistentComponentState();
+		_ = AddBunitPersistentComponentState();
 
 		var actual = Services.GetService<PersistentComponentState>();
 
@@ -22,7 +22,7 @@ public class BunitPersistentComponentStateTest : TestContext
 	[Fact(DisplayName = "AddFakePersistentComponentState enables PersistentComponentState injection into components")]
 	public void Test002()
 	{
-		this.AddBunitPersistentComponentState();
+		AddBunitPersistentComponentState();
 
 		var cut = RenderComponent<PersistentComponentStateSample>();
 
@@ -33,7 +33,7 @@ public class BunitPersistentComponentStateTest : TestContext
 	[AutoData]
 	public void Test011(string key, string data)
 	{
-		var fakeState = this.AddBunitPersistentComponentState();
+		var fakeState = AddBunitPersistentComponentState();
 
 		fakeState.Persist(key, data);
 
@@ -45,7 +45,7 @@ public class BunitPersistentComponentStateTest : TestContext
 	[Fact(DisplayName = "TryTake returns true if key contains data saved in store")]
 	public void Test012()
 	{
-		var fakeState = this.AddBunitPersistentComponentState();
+		var fakeState = AddBunitPersistentComponentState();
 		var cut = RenderComponent<PersistentComponentStateSample>();
 
 		fakeState.TriggerOnPersisting();
@@ -58,7 +58,7 @@ public class BunitPersistentComponentStateTest : TestContext
 	[AutoData]
 	public void Test013(string key)
 	{
-		var fakeState = this.AddBunitPersistentComponentState();
+		var fakeState = AddBunitPersistentComponentState();
 
 		fakeState.TryTake<string>(key, out var actual).ShouldBeFalse();
 	}
@@ -67,7 +67,7 @@ public class BunitPersistentComponentStateTest : TestContext
 	public void Test014()
 	{
 		var onPersistingCalledTimes = 0;
-		var fakeState = this.AddBunitPersistentComponentState();
+		var fakeState = AddBunitPersistentComponentState();
 		var store = Services.GetService<PersistentComponentState>();
 		store.RegisterOnPersisting(() =>
 		{


### PR DESCRIPTION
This PR closes #1081 

This PR removed the necessity to call `this.` for:
* AddBunitPersistentComponentState
* AddTestAuthorization

