### PR TITLE
More debugger hints

### DIFF
--- a/src/bunit/ComponentParameter.cs
+++ b/src/bunit/ComponentParameter.cs
@@ -4,7 +4,7 @@ namespace Bunit;
 /// Represents a single parameter supplied to an <see cref="Microsoft.AspNetCore.Components.IComponent"/>
 /// component under test.
 /// </summary>
-public readonly struct ComponentParameter : IEquatable<ComponentParameter>
+public readonly record struct ComponentParameter
 {
 	/// <summary>
 	/// Gets the name of the parameter. Can be null if the parameter is for an unnamed cascading value.
@@ -47,7 +47,7 @@ public readonly struct ComponentParameter : IEquatable<ComponentParameter>
 	/// <param name="value">Value or null to pass the component.</param>
 	/// <returns>The created <see cref="ComponentParameter"/>.</returns>
 	public static ComponentParameter CreateParameter(string name, object? value)
-		=> new ComponentParameter(name, value, isCascadingValue: false);
+		=> new(name, value, isCascadingValue: false);
 
 	/// <summary>
 	/// Create a Cascading Value parameter for a component under test.
@@ -56,7 +56,7 @@ public readonly struct ComponentParameter : IEquatable<ComponentParameter>
 	/// <param name="value">The cascading value.</param>
 	/// <returns>The created <see cref="ComponentParameter"/>.</returns>
 	public static ComponentParameter CreateCascadingValue(string? name, object value)
-		=> new ComponentParameter(name, value, isCascadingValue: true);
+		=> new(name, value, isCascadingValue: true);
 
 	/// <summary>
 	/// Create a parameter for a component under test.
@@ -72,27 +72,5 @@ public readonly struct ComponentParameter : IEquatable<ComponentParameter>
 	/// <param name="input">A name/value/isCascadingValue triple for the parameter.</param>
 	/// <returns>The created <see cref="ComponentParameter"/>.</returns>
 	public static implicit operator ComponentParameter((string? Name, object? Value, bool IsCascadingValue) input)
-		=> new ComponentParameter(input.Name, input.Value, input.IsCascadingValue);
-
-	/// <inheritdoc/>
-	public bool Equals(ComponentParameter other)
-		=> string.Equals(Name, other.Name, StringComparison.Ordinal)
-		&& ((Value is null && other.Value is null) || (Value?.Equals(other.Value) ?? false))
-		&& IsCascadingValue.Equals(other.IsCascadingValue);
-
-	/// <inheritdoc/>
-	public override bool Equals(object? obj) => obj is ComponentParameter other && Equals(other);
-
-	/// <inheritdoc/>
-	public override int GetHashCode() => HashCode.Combine(Name, Value, IsCascadingValue);
-
-	/// <summary>
-	/// Verify whether the <paramref name="left"/> and <paramref name="right"/> <see cref="ComponentParameter"/> are equal.
-	/// </summary>
-	public static bool operator ==(ComponentParameter left, ComponentParameter right) => left.Equals(right);
-
-	/// <summary>
-	/// Verify whether the <paramref name="left"/> and <paramref name="right"/> <see cref="ComponentParameter"/> are not equal.
-	/// </summary>
-	public static bool operator !=(ComponentParameter left, ComponentParameter right) => !(left == right);
+		=> new(input.Name, input.Value, input.IsCascadingValue);
 }

--- a/src/bunit/Extensions/InputFile/BunitBrowserFile.cs
+++ b/src/bunit/Extensions/InputFile/BunitBrowserFile.cs
@@ -2,7 +2,7 @@ using Microsoft.AspNetCore.Components.Forms;
 
 namespace Bunit;
 
-internal class BUnitBrowserFile : IBrowserFile
+internal sealed class BunitBrowserFile : IBrowserFile
 {
 	public string Name { get; }
 	public DateTimeOffset LastModified { get; }
@@ -10,7 +10,7 @@ internal class BUnitBrowserFile : IBrowserFile
 	public string ContentType { get; }
 	public byte[] Content { get; }
 
-	public BUnitBrowserFile(
+	public BunitBrowserFile(
 		string name,
 		DateTimeOffset lastModified,
 		long size,

--- a/src/bunit/Extensions/InputFile/InputFileExtensions.cs
+++ b/src/bunit/Extensions/InputFile/InputFileExtensions.cs
@@ -22,7 +22,7 @@ public static class InputFileExtensions
 		if (files.Length == 0)
 			throw new ArgumentException("No files were provided to be uploaded.", nameof(files));
 
-		var browserFiles = files.Select(file => new BUnitBrowserFile(
+		var browserFiles = files.Select(file => new BunitBrowserFile(
 			file.Filename ?? string.Empty,
 			file.LastModified ?? default,
 			file.Size,

--- a/src/bunit/Extensions/Internal/RefreshableElementCollection.cs
+++ b/src/bunit/Extensions/Internal/RefreshableElementCollection.cs
@@ -1,8 +1,10 @@
 using System.Collections;
+using System.Diagnostics;
 using AngleSharp.Dom;
 
 namespace Bunit;
 
+[DebuggerDisplay("Selector={cssSelector},AutoRefresh={enableAutoRefresh}")]
 internal sealed class RefreshableElementCollection : IRefreshableElementCollection<IElement>
 {
 	private readonly IRenderedFragment renderedFragment;

--- a/src/bunit/Extensions/Internal/RefreshableElementCollection.cs
+++ b/src/bunit/Extensions/Internal/RefreshableElementCollection.cs
@@ -4,7 +4,7 @@ using AngleSharp.Dom;
 
 namespace Bunit;
 
-[DebuggerDisplay("Selector={cssSelector},AutoRefresh={enableAutoRefresh}")]
+[DebuggerDisplay("Selector={cssSelector}, AutoRefresh={enableAutoRefresh}")]
 internal sealed class RefreshableElementCollection : IRefreshableElementCollection<IElement>
 {
 	private readonly IRenderedFragment renderedFragment;

--- a/src/bunit/ParameterException.cs
+++ b/src/bunit/ParameterException.cs
@@ -8,9 +8,9 @@ public sealed class ParameterException : ArgumentException
 	/// <summary>
 	/// Initializes a new instance of the <see cref="ParameterException"/> class.
 	/// </summary>
-	/// <param name="messsage">Validation message.</param>
+	/// <param name="message">Validation message.</param>
 	/// <param name="parameterName">Name of the Blazor parameter.</param>
-	public ParameterException(string messsage, string parameterName)
-		: base(messsage, parameterName)
+	public ParameterException(string message, string parameterName)
+		: base(message, parameterName)
 	{ }
 }

--- a/tests/bunit.tests/Rendering/ComponentParameterTest.cs
+++ b/tests/bunit.tests/Rendering/ComponentParameterTest.cs
@@ -2,24 +2,6 @@ namespace Bunit.Rendering;
 
 public class ComponentParameterTest
 {
-	public static IEnumerable<object[]> GetEqualsTestData()
-	{
-		var name = "foo";
-		var value = "bar";
-		var p1 = ComponentParameter.CreateParameter(name, value);
-		var p2 = ComponentParameter.CreateParameter(name, value);
-		var p3 = ComponentParameter.CreateCascadingValue(name, value);
-		var p4 = ComponentParameter.CreateParameter(string.Empty, value);
-		var p5 = ComponentParameter.CreateParameter(name, string.Empty);
-
-		yield return new object[] { p1, p1, true };
-		yield return new object[] { p1, p2, true };
-		yield return new object[] { p3, p3, true };
-		yield return new object[] { p1, p3, false };
-		yield return new object[] { p1, p4, false };
-		yield return new object[] { p1, p5, false };
-	}
-
 	[Fact(DisplayName = "Creating a cascading value with null throws")]
 	public void Test001()
 	{
@@ -32,32 +14,5 @@ public class ComponentParameterTest
 	{
 		Should.Throw<ArgumentNullException>(() => ComponentParameter.CreateParameter(null!, null));
 		Should.Throw<ArgumentNullException>(() => (ComponentParameter)(null, null, false));
-	}
-
-	[Theory(DisplayName = "Equals compares correctly")]
-	[MemberData(nameof(GetEqualsTestData))]
-	public void Test003(ComponentParameter left, ComponentParameter right, bool expectedResult)
-	{
-		left.Equals(right).ShouldBe(expectedResult);
-		right.Equals(left).ShouldBe(expectedResult);
-		(left == right).ShouldBe(expectedResult);
-		(left != right).ShouldNotBe(expectedResult);
-		left.Equals((object)right).ShouldBe(expectedResult);
-		right.Equals((object)left).ShouldBe(expectedResult);
-	}
-
-	[Fact(DisplayName = "Equals operator works as expected with non compatible types")]
-	public void Test004()
-	{
-		ComponentParameter.CreateParameter(string.Empty, string.Empty)
-			.Equals(new object())
-			.ShouldBeFalse();
-	}
-
-	[Theory(DisplayName = "GetHashCode returns same result for equal ComponentParameter")]
-	[MemberData(nameof(GetEqualsTestData))]
-	public void Test005(ComponentParameter left, ComponentParameter right, bool expectedResult)
-	{
-		left.GetHashCode().Equals(right.GetHashCode()).ShouldBe(expectedResult);
 	}
 }


### PR DESCRIPTION
This PR does the following:
 * Add another enhanced debugger tip for `RefreshableElementCollection`
 * Renamed `BUnitBrowserFile` to `BunitBrowserFile`
 * Made `ComponentParameter` a `record struct` to simplify some code.

![image](https://github.com/bUnit-dev/bUnit/assets/26365461/c598d022-8a33-41a9-8fed-61997576cf83)

This PR enhances #1077