### PR TITLE
Markup event dispose

### DIFF
--- a/src/bunit/Rendering/RenderedFragment.cs
+++ b/src/bunit/Rendering/RenderedFragment.cs
@@ -167,5 +167,6 @@ internal class RenderedFragment : IRenderedFragment
 		IsDisposed = true;
 		markup = string.Empty;
 		OnAfterRender = null;
+		OnMarkupUpdated = null;
 	}
 }


### PR DESCRIPTION
We should unsubscribe from all events in the `Dispose` method.

Furthermore, for `v2`: We should (in the docs as well as in our code base) use the `using` more often. 

From:
```csharp
var cut = RenderComponent<MyComponent>();
```

To:
```csharp
using var cut = RenderComponent<MyComponent>();
```

The reason is that I found multiple instances where we are still attached via `OnMarkupUpdated` event, hindering the GC from doing its work. Of course, for calls to `FindComponent` that isn't necessary as there is no active subscriber to those events.