### PR TITLE
refactor: Add IAsyncDisposable (closes #1061)

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -51,3 +51,7 @@ The `AddTestAuthorization` method on `TestContext` has been renamed to `AddAutho
 
 ## Merged `TestContext` and `TestContextBase`
 The `TestContext` and `TestContextBase` classes have been merged into a single `TestContext` class. All references to `TestContextBase` should replace them with `TestContext` to migrate.
+
+## `TestContext` implements `IDisposable` and `IAsyncDisposable`
+The `TestContext` now implements `IDisposable` and `IAsyncDisposable`. In version 1.x, `TestContext` only implemented `IDisposable` and cleaned up asynchronous objects in the synchronous `Dispose` method. This is no longer the case, and asynchronous objects are now cleaned up in the `DisposeAsync` method.
+If you register services into the container that implement `IAsyncDisposable` make sure that the test framework calls the right method.

--- a/src/bunit/TestContext.cs
+++ b/src/bunit/TestContext.cs
@@ -6,7 +6,7 @@ namespace Bunit;
 /// <summary>
 /// A test context is a factory that makes it possible to create components under tests.
 /// </summary>
-public partial class TestContext : IDisposable
+public partial class TestContext : IDisposable, IAsyncDisposable
 {
 	private bool disposed;
 	private BunitRenderer? testRenderer;
@@ -115,17 +115,37 @@ public partial class TestContext : IDisposable
 		GC.SuppressFinalize(this);
 	}
 
+	/// <inheritdoc/>
+	public async ValueTask DisposeAsync()
+	{
+		await DisposeAsyncCore();
+
+		Dispose(disposing: false);
+		GC.SuppressFinalize(this);
+	}
+
+	/// <summary>
+	/// Disposes of the test context resources that are asynchronous, in particular it disposes the <see cref="Services"/>
+	/// service provider.s
+	/// </summary>
+	protected virtual async ValueTask DisposeAsyncCore()
+	{
+		if (disposed)
+			return;
+
+		disposed = true;
+
+		await Services.DisposeAsync();
+	}
+
 	/// <summary>
 	/// Disposes of the test context resources, in particular it disposes the <see cref="Services"/>
-	/// service provider. Any async services registered with the service provider will disposed first,
-	/// but their disposal will not be awaited..
 	/// </summary>
 	/// <remarks>
 	/// The disposing parameter should be false when called from a finalizer, and true when called from the
 	/// <see cref="Dispose()"/> method. In other words, it is true when deterministically called and false when non-deterministically called.
 	/// </remarks>
-	/// <param name="disposing">Set to true if called from <see cref="Dispose()"/>, false if called from a finalizer.f.</param>
-	[SuppressMessage("Reliability", "CA2012:Use ValueTasks correctly", Justification = "Explicitly ignoring DisposeAsync to avoid breaking changes to API surface.")]
+	/// <param name="disposing">Set to true if called from <see cref="Dispose()"/>, false if called from a finalizer.</param>
 	protected virtual void Dispose(bool disposing)
 	{
 		if (disposed || !disposing)
@@ -133,16 +153,6 @@ public partial class TestContext : IDisposable
 
 		disposed = true;
 
-		// Ignore the async task as GetAwaiter().GetResult() can cause deadlock
-		// and implementing IAsyncDisposable in TestContext will be a breaking change.
-		//
-		// NOTE: This has to be called before Services.Dispose().
-		// If there are IAsyncDisposable services registered, calling Dispose first
-		// causes the service provider to throw an exception.
-		_ = Services.DisposeAsync();
-
-		// The service provider should dispose of any
-		// disposable object it has created, when it is disposed.
 		Services.Dispose();
 	}
 

--- a/tests/bunit.tests/TestContextTest.cs
+++ b/tests/bunit.tests/TestContextTest.cs
@@ -125,10 +125,10 @@ public class TestContextTest : TestContext
 	}
 
 	[Fact(DisplayName = "Can correctly resolve and dispose of scoped disposable service")]
-	public void Net5Test001()
+	public async Task Net5Test001()
 	{
 		AsyncDisposableService asyncDisposable;
-		using (var sut = new TestContext())
+		await using (var sut = new TestContext())
 		{
 			sut.Services.AddScoped<AsyncDisposableService>();
 			asyncDisposable = sut.Services.GetService<AsyncDisposableService>();
@@ -137,10 +137,10 @@ public class TestContextTest : TestContext
 	}
 
 	[Fact(DisplayName = "Can correctly resolve and dispose of transient disposable service")]
-	public void Net5Test002()
+	public async Task Net5Test002()
 	{
 		AsyncDisposableService asyncDisposable;
-		using (var sut = new TestContext())
+		await using (var sut = new TestContext())
 		{
 			sut.Services.AddTransient<AsyncDisposableService>();
 			asyncDisposable = sut.Services.GetService<AsyncDisposableService>();
@@ -149,10 +149,10 @@ public class TestContextTest : TestContext
 	}
 
 	[Fact(DisplayName = "Can correctly resolve and dispose of singleton disposable service")]
-	public void Net5Test003()
+	public async Task Net5Test003()
 	{
 		AsyncDisposableService asyncDisposable;
-		using (var sut = new TestContext())
+		await using (var sut = new TestContext())
 		{
 			sut.Services.AddSingleton<AsyncDisposableService>();
 			asyncDisposable = sut.Services.GetService<AsyncDisposableService>();


### PR DESCRIPTION
This PR refactors the `TestContext` so it uses `IDisposable` and `IAsyncDisposable`. Therefore the user is responsible to call the right method depending on whether or not he injected services into the container that are sync or async.