### PR TITLE
refactor: Remove Console logging

### DIFF
--- a/tests/bunit.testassets/BlazorE2E/KeyPressEventComponent.razor
+++ b/tests/bunit.testassets/BlazorE2E/KeyPressEventComponent.razor
@@ -1,5 +1,3 @@
-@using System.Text.Json
-
 Type here: <input @onkeypress=OnKeyPressed />
 <ul>
     @foreach (var key in keysPressed)
@@ -13,7 +11,6 @@ Type here: <input @onkeypress=OnKeyPressed />
 
     void OnKeyPressed(KeyboardEventArgs eventArgs)
     {
-        Console.WriteLine(JsonSerializer.Serialize(eventArgs));
         keysPressed.Add(eventArgs.Key);
     }
 }


### PR DESCRIPTION
You asked yourself, where this:
```json
{"Key":"a","Code":null,"Location":0,"Repeat":false,"CtrlKey":false,"ShiftKey":false,"AltKey":false,"MetaKey":false,"Type":null}
{"Key":"b","Code":null,"Location":0,"Repeat":false,"CtrlKey":false,"ShiftKey":false,"AltKey":false,"MetaKey":false,"Type":null}
```

Is coming from? There we go ;) as we use the console directly - it will just pop up once a test fails (due to Debug log level(