### PR TITLE
fix: use correct nullability annotation in type

### DIFF
--- a/src/bunit/JSInterop/JSRuntimeInvocationDictionary.cs
+++ b/src/bunit/JSInterop/JSRuntimeInvocationDictionary.cs
@@ -52,11 +52,12 @@ public sealed class JSRuntimeInvocationDictionary : IReadOnlyCollection<JSRuntim
 	{
 		Count++;
 
-		if (!invocations.ContainsKey(invocation.Identifier))
+		if (!invocations.TryGetValue(invocation.Identifier, out var value))
 		{
-			invocations.Add(invocation.Identifier, new List<JSRuntimeInvocation>());
+			value = new List<JSRuntimeInvocation>();
+			invocations.Add(invocation.Identifier, value);
 		}
 
-		invocations[invocation.Identifier].Add(invocation);
+		value.Add(invocation);
 	}
 }

--- a/src/bunit/TestDoubles/Components/CapturedParameterView{TComponent}.cs
+++ b/src/bunit/TestDoubles/Components/CapturedParameterView{TComponent}.cs
@@ -9,19 +9,19 @@ namespace Bunit.TestDoubles;
 /// Represents a view of parameters captured by a <see cref="ComponentDoubleBase{TComponent}"/>.
 /// </summary>
 /// <typeparam name="TComponent"></typeparam>
-public class CapturedParameterView<TComponent> : IReadOnlyDictionary<string, object>
+public class CapturedParameterView<TComponent> : IReadOnlyDictionary<string, object?>
 	where TComponent : IComponent
 {
 	/// <summary>
 	/// Gets a empty <see cref="CapturedParameterView{TComponent}"/>.
 	/// </summary>
-	public static CapturedParameterView<TComponent> Empty { get; } = new(ImmutableDictionary<string, object>.Empty);
+	public static CapturedParameterView<TComponent> Empty { get; } = new(ImmutableDictionary<string, object?>.Empty);
 
 	private static readonly Type ComponentType = typeof(TComponent);
 
-	private readonly IReadOnlyDictionary<string, object> parameters;
+	private readonly IReadOnlyDictionary<string, object?> parameters;
 
-	private CapturedParameterView(IReadOnlyDictionary<string, object> parameters)
+	private CapturedParameterView(IReadOnlyDictionary<string, object?> parameters)
 		=> this.parameters = parameters;
 
 	/// <summary>
@@ -29,7 +29,7 @@ public class CapturedParameterView<TComponent> : IReadOnlyDictionary<string, obj
 	/// </summary>
 	/// <param name="key">Name of the parameter to get.</param>
 	/// <returns>The value of the parameter</returns>
-	public object this[string key]
+	public object? this[string key]
 		=> parameters[key];
 
 	/// <inheritdoc/>
@@ -37,7 +37,7 @@ public class CapturedParameterView<TComponent> : IReadOnlyDictionary<string, obj
 		=> parameters.Keys;
 
 	/// <inheritdoc/>
-	public IEnumerable<object> Values
+	public IEnumerable<object?> Values
 		=> parameters.Values;
 
 	/// <inheritdoc/>
@@ -63,7 +63,7 @@ public class CapturedParameterView<TComponent> : IReadOnlyDictionary<string, obj
 	/// <exception cref="ParameterNotFoundException">Thrown when the selected parameter was not passed to the captured <typeparamref name="TComponent"/>.</exception>
 	/// <exception cref="InvalidCastException">Throw when the type of the value passed to the selected parameter is not the same as the selected parameters type, i.e. <typeparamref name="TValue"/>.</exception>
 	/// <returns>The <typeparamref name="TValue"/>.</returns>
-	public TValue Get<TValue>(Expression<Func<TComponent, TValue>> parameterSelector)
+	public TValue? Get<TValue>(Expression<Func<TComponent, TValue?>> parameterSelector)
 	{
 		ArgumentNullException.ThrowIfNull(parameterSelector);
 
@@ -83,11 +83,11 @@ public class CapturedParameterView<TComponent> : IReadOnlyDictionary<string, obj
 		if (!parameters.TryGetValue(propertyInfo.Name, out var objectResult))
 			throw new ParameterNotFoundException(propertyInfo.Name, ComponentType.ToString());
 
-		return (TValue)objectResult;
+		return (TValue?)objectResult;
 	}
 
 	/// <inheritdoc/>
-	public IEnumerator<KeyValuePair<string, object>> GetEnumerator()
+	public IEnumerator<KeyValuePair<string, object?>> GetEnumerator()
 		=> parameters.GetEnumerator();
 
 	/// <inheritdoc/>

--- a/tests/.editorconfig
+++ b/tests/.editorconfig
@@ -42,6 +42,7 @@ dotnet_diagnostic.CA2007.severity = none            # https://github.com/atc-net
 
 dotnet_diagnostic.CA1819.severity = suggestion		# CA1819: Properties should not return arrays
 dotnet_diagnostic.CA1849.severity = suggestion		# CA1849: Call async methods when in an async method
+dotnet_diagnostic.CA1861.severity = suggestion		# CA1861: Prefer 'static readonly' fields over constant array arguments
 dotnet_diagnostic.xUnit1026.severity = none			# xUnit1026: Theory methods should use all of their parameters
 dotnet_diagnostic.S1144.severity = suggestion		# S1144: Unused private types or members should be removed
 dotnet_diagnostic.S2094.severity = suggestion		# S2094: Classes should not be empty


### PR DESCRIPTION
I got a local error (in Release):
```no-class
/Users/stgi/repos/bUnit/src/bunit/TestDoubles/Components/CapturedParameterView{TComponent}.cs(104,10): error CS8620: Argument of type 'IReadOnlyDictionary<string, object?>' cannot be used for parameter 'parameters' of type 'IReadOnlyDictionary<string, object>' in 'CapturedParameterView<TComponent>.CapturedParameterView(IReadOnlyDictionary<string, object> parameters)' due to differences in the nullability of reference types. [/Users/stgi/repos/bUnit/src/bunit/bunit.csproj]
    0 Warning(s)
    1 Error(s)
```

Therefore here the fix. Not sure why our CI/CD pipeline was quite.