### PR TITLE
fix: prevent endless recursion loading render tree frames

### DIFF
--- a/src/bunit.core/Rendering/TestRenderer.cs
+++ b/src/bunit.core/Rendering/TestRenderer.cs
@@ -279,6 +279,11 @@ public class TestRenderer : Renderer, ITestRenderer
 		{
 			var id = renderBatch.DisposedComponentIDs.Array[i];
 
+			// Add disposed components to the frames collection
+			// to avoid them being added into the dictionary later during a
+			// LoadRenderTreeFrames/GetOrLoadRenderTreeFrame call.
+			renderEvent.Frames.Add(id, default);
+
 			logger.LogComponentDisposed(id);
 
 			if (renderedComponents.TryGetValue(id, out var rc))
@@ -443,7 +448,8 @@ public class TestRenderer : Renderer, ITestRenderer
 		for (var i = 0; i < frames.Count; i++)
 		{
 			ref var frame = ref frames.Array[i];
-			if (frame.FrameType == RenderTreeFrameType.Component)
+			
+			if (frame.FrameType == RenderTreeFrameType.Component && !framesCollection.Contains(frame.ComponentId))
 			{
 				LoadRenderTreeFrames(frame.ComponentId, framesCollection);
 			}


### PR DESCRIPTION
Look at the logs that @groogiam has shared with me, I see a bunch of renders happening after the TestRenderer has been disposed, i.e. LogRenderCycleActiveAfterDispose is being triggered.

However, that does not explain the stack overflow. Thus, the following code should prevent loading render tree frames from being loaded in an endless loop, perhaps because were are attempting load render tree frames for disposed components.

fixes #1064

### PR meta checklist
- [x] Pull request is targeted at `main` branch for code   
  or targeted at `stable` branch for documentation that is live on bunit.dev.
- [x] Pull request is linked to all related issues, if any.
- [ ] I have read the _CONTRIBUTING.md_ document.

### Code PR specific checklist
- [x] My code follows the code style of this project and AspNetCore coding guidelines.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] I have updated the appropriate sub section in the _CHANGELOG.md_.
- [x] I have added, updated or removed tests to according to my changes.
  - [x] All tests passed.
