### PR TITLE
New bUnit v2 render pipeline

### DIFF
--- a/src/bunit/Rendering/Internal/BunitComponentState.cs
+++ b/src/bunit/Rendering/Internal/BunitComponentState.cs
@@ -1,0 +1,140 @@
+using System.Text;
+
+namespace Bunit.Rendering.Internal;
+
+internal abstract class BunitComponentState : ComponentState
+{
+	private IRenderedFragment? renderedComponent;
+	private List<BunitChildComponentState>? children;
+
+	protected internal int MarkupStart { get; set; }
+
+	protected internal int MarkupLength { get; set; }
+
+	public IReadOnlyList<BunitChildComponentState> Children
+		=> children is null
+		? Array.Empty<BunitChildComponentState>()
+		: children.AsReadOnly();
+
+	public abstract ReadOnlySpan<char> Markup { get; }
+
+	protected BunitComponentState(BunitRendererV2 renderer, int componentId, IComponent component, BunitComponentState? parentComponentState)
+		: base(renderer, componentId, component, parentComponentState)
+	{
+	}
+
+	public override ValueTask DisposeAsync()
+	{
+		renderedComponent?.Dispose();
+		renderedComponent = null;
+		return base.DisposeAsync();
+	}
+
+	internal abstract void UpdateMarkup(int version);
+
+	internal RenderedComponentV2<TComponent> GetRenderedComponent<TComponent>()
+		where TComponent : IComponent
+	{
+		renderedComponent ??= new RenderedComponentV2<TComponent>(this);
+		return (RenderedComponentV2<TComponent>)renderedComponent;
+	}
+
+	internal void AddChild(BunitChildComponentState child)
+	{
+		if (children is null)
+		{
+			children = new();
+		}
+
+		children.Add(child);
+	}
+
+	internal void RemoveChild(BunitChildComponentState child) => children?.Remove(child);
+}
+
+internal class BunitRootComponentState : BunitComponentState
+{
+	private readonly BunitRendererV2 renderer;
+	private readonly StringBuilder markupBuilder = new();
+	private int version;
+	private string markup;
+
+	internal string? ClosestSelectValueAsString { get; set; }
+
+	public override ReadOnlySpan<char> Markup => markup.AsSpan();
+
+	public BunitRootComponentState(BunitRendererV2 renderer, int componentId, BunitRootComponent component)
+		: base(renderer, componentId, component, null)
+	{
+		this.renderer = renderer;
+		markup = string.Empty;
+	}
+
+	internal override void UpdateMarkup(int version)
+	{
+		if (this.version >= version)
+		{
+			return;
+		}
+
+		this.version = version;
+
+		markupBuilder.Clear();
+		HtmlizerV2.GenerateMarkup(this);
+		markup = markupBuilder.ToString();
+		MarkupLength = markup.Length;
+	}
+
+	internal void Append(char value)
+		=> markupBuilder.Append(value);
+
+	internal void Append(string value)
+		=> markupBuilder.Append(value);
+
+	internal void Append(ReadOnlySpan<char> value)
+		=> markupBuilder.Append(value);
+
+	internal ArrayRange<RenderTreeFrame> GetRenderTreeFrames(int componentId)
+		=> renderer.GetCurrentRenderTreeFrames(componentId);
+
+	internal void MarkComponentStart(int componentId)
+		=> renderer
+		.GetComponentState(componentId)
+		.MarkupStart = markupBuilder.Length;
+
+	internal void MarkComponentStop(int componentId)
+	{
+		var childComponentState = renderer.GetComponentState(componentId);
+		childComponentState.MarkupLength = markupBuilder.Length - childComponentState.MarkupStart;
+	}
+}
+
+internal class BunitChildComponentState : BunitComponentState
+{
+	private readonly BunitRootComponentState rootComponent;
+	private readonly BunitComponentState parentComponentState;
+
+	public override ReadOnlySpan<char> Markup
+		=> rootComponent.Markup.Slice(MarkupStart, MarkupLength);
+
+	public BunitChildComponentState(BunitRendererV2 renderer, int componentId, IComponent component, BunitComponentState parentComponentState)
+		: base(renderer, componentId, component, parentComponentState)
+	{
+		this.rootComponent = parentComponentState is BunitChildComponentState childComponentState
+			? childComponentState.rootComponent
+			: (BunitRootComponentState)parentComponentState;
+		this.parentComponentState = parentComponentState;
+		parentComponentState.AddChild(this);
+	}
+
+	public override ValueTask DisposeAsync()
+	{
+		parentComponentState.RemoveChild(this);
+		return base.DisposeAsync();
+	}
+
+	internal override void UpdateMarkup(int version)
+	{
+		rootComponent.UpdateMarkup(version);
+	}
+}

--- a/src/bunit/Rendering/Internal/BunitRendererV2.cs
+++ b/src/bunit/Rendering/Internal/BunitRendererV2.cs
@@ -1,0 +1,282 @@
+using Microsoft.Extensions.Logging;
+using System.Diagnostics;
+using System.Runtime.ExceptionServices;
+
+namespace Bunit.Rendering.Internal;
+
+public class BunitRendererV2 : Renderer
+{
+	private readonly object renderTreeUpdateLock = new();
+	private readonly SynchronizationContext? usersSyncContext = SynchronizationContext.Current;
+	private readonly ILogger<BunitRendererV2> logger;
+	private readonly TestServiceProvider services;
+	private TaskCompletionSource<Exception> unhandledExceptionTsc = new(TaskCreationOptions.RunContinuationsAsynchronously);
+	private Exception? capturedUnhandledException;
+	private bool isDisposed;
+
+	/// <summary>
+	/// Gets a <see cref="Task{Exception}"/>, which completes when an unhandled exception
+	/// is thrown during the rendering of a component, that is caught by the renderer.
+	/// </summary>
+	public Task<Exception> UnhandledException => unhandledExceptionTsc.Task;
+
+	/// <inheritdoc/>
+	public override Dispatcher Dispatcher { get; } = Dispatcher.CreateDefault();
+
+	/// <summary>
+	/// Gets the number of render cycles that has been performed.
+	/// </summary>
+	internal int RenderCount { get; private set; }
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="BunitRenderer"/> class.
+	/// </summary>
+	public BunitRendererV2(TestServiceProvider services, ILoggerFactory loggerFactory)
+		: base(services, loggerFactory)
+	{
+		logger = loggerFactory.CreateLogger<BunitRendererV2>();
+		ElementReferenceContext = new WebElementReferenceContext(services.GetRequiredService<IJSRuntime>());
+		this.services = services;
+	}
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="BunitRenderer"/> class.
+	/// </summary>
+	public BunitRendererV2(TestServiceProvider services, ILoggerFactory loggerFactory, IComponentActivator componentActivator)
+		: base(services, loggerFactory, componentActivator)
+	{
+		logger = loggerFactory.CreateLogger<BunitRendererV2>();
+		ElementReferenceContext = new WebElementReferenceContext(services.GetRequiredService<IJSRuntime>());
+		this.services = services;
+	}
+
+	/// <summary>
+	/// Renders the <paramref name="renderFragment"/>.
+	/// </summary>
+	/// <param name="renderFragment">The <see cref="Microsoft.AspNetCore.Components.RenderFragment"/> to render.</param>
+	/// <returns>A <see cref="IRenderedFragment"/> that provides access to the rendered <paramref name="renderFragment"/>.</returns>
+	public IRenderedFragment RenderFragment(RenderFragment renderFragment)
+	{
+		ObjectDisposedException.ThrowIf(isDisposed, this);
+
+		lock (renderTreeUpdateLock)
+		{
+			ResetUnhandledException();
+			var rootComponentId = -1;
+
+			_ = Dispatcher.InvokeAsync(() =>
+			{
+				var component = new BunitRootComponent(renderFragment);
+				rootComponentId = AssignRootComponentId(component);
+				RenderRootComponentAsync(rootComponentId);
+			});
+
+			Debug.Assert(rootComponentId >= 0, "ID should have been assigned by now!");
+
+			AssertNoUnhandledExceptions();
+
+			return GetComponentState(rootComponentId).GetRenderedComponent<BunitRootComponent>();
+		}
+	}
+
+	/// <summary>
+	/// Notifies the renderer that an event has occurred.
+	/// </summary>
+	/// <param name="eventHandlerId">The <see cref="RenderTreeFrame.AttributeEventHandlerId"/> value from the original event attribute.</param>
+	/// <param name="fieldInfo">Information that the renderer can use to update the state of the existing render tree to match the UI.</param>
+	/// <param name="eventArgs">Arguments to be passed to the event handler.</param>
+	/// <returns>A <see cref="Task"/> which will complete once all asynchronous processing related to the event has completed.</returns>
+	public override Task DispatchEventAsync(
+		ulong eventHandlerId,
+		EventFieldInfo? fieldInfo,
+		EventArgs eventArgs) => DispatchEventAsync(eventHandlerId, fieldInfo, eventArgs, ignoreUnknownEventHandlers: false);
+
+	/// <summary>
+	/// Notifies the renderer that an event has occurred.
+	/// </summary>
+	/// <param name="eventHandlerId">The <see cref="RenderTreeFrame.AttributeEventHandlerId"/> value from the original event attribute.</param>
+	/// <param name="fieldInfo">Information that the renderer can use to update the state of the existing render tree to match the UI.</param>
+	/// <param name="eventArgs">Arguments to be passed to the event handler.</param>
+	/// <param name="ignoreUnknownEventHandlers">Set to true to ignore the <see cref="UnknownEventHandlerIdException"/>.</param>
+	/// <returns>A <see cref="Task"/> which will complete once all asynchronous processing related to the event has completed.</returns>
+	public new Task DispatchEventAsync(
+		ulong eventHandlerId,
+		EventFieldInfo? fieldInfo,
+		EventArgs eventArgs,
+		bool ignoreUnknownEventHandlers)
+	{
+		ObjectDisposedException.ThrowIf(isDisposed, this);
+		ArgumentNullException.ThrowIfNull(fieldInfo);
+
+		// Calling base.DispatchEventAsync updates the render tree
+		// if the event contains associated data.
+		lock (renderTreeUpdateLock)
+		{
+			var result = Dispatcher.InvokeAsync(() =>
+			{
+				ResetUnhandledException();
+
+				try
+				{
+					return base.DispatchEventAsync(eventHandlerId, fieldInfo, eventArgs);
+				}
+				catch (ArgumentException ex) when (string.Equals(ex.Message, $"There is no event handler associated with this event. EventId: '{eventHandlerId}'. (Parameter 'eventHandlerId')", StringComparison.Ordinal))
+				{
+					if (ignoreUnknownEventHandlers)
+					{
+						return Task.CompletedTask;
+					}
+
+					var betterExceptionMsg = new UnknownEventHandlerIdException(eventHandlerId, fieldInfo, ex);
+					return Task.FromException(betterExceptionMsg);
+				}
+			});
+
+			if (result.IsFaulted && result.Exception is not null)
+			{
+				HandleException(result.Exception);
+			}
+
+			AssertNoUnhandledExceptions();
+
+			return result;
+		}
+	}
+
+	/// <summary>
+	/// Performs a depth-first search for the first <typeparamref name="TComponent"/> child component of the <paramref name="parentComponent"/>.
+	/// </summary>
+	/// <typeparam name="TComponent">Type of component to find.</typeparam>
+	/// <param name="parentComponent">Parent component to search.</param>
+	public IRenderedComponent<TComponent> FindComponent<TComponent>(IRenderedFragment parentComponent)
+		where TComponent : IComponent
+		=> throw new NotImplementedException();
+
+	/// <summary>
+	/// Performs a depth-first search for all <typeparamref name="TComponent"/> child components of the <paramref name="parentComponent"/>.
+	/// </summary>
+	/// <typeparam name="TComponent">Type of components to find.</typeparam>
+	/// <param name="parentComponent">Parent component to search.</param>
+	public IReadOnlyList<IRenderedComponent<TComponent>> FindComponents<TComponent>(IRenderedFragment parentComponent)
+		where TComponent : IComponent
+		=> throw new NotImplementedException();
+
+	/// <inheritdoc/>
+	/// <remarks>This method returns a <see cref="BunitComponentState"/>.</remarks>
+	protected override ComponentState CreateComponentState(int componentId, IComponent component, ComponentState? parentComponentState)
+		=> parentComponentState is null
+		? new BunitRootComponentState(this, componentId, (BunitRootComponent)component)
+		: new BunitChildComponentState(this, componentId, component, (BunitComponentState)parentComponentState);
+
+	/// <inheritdoc/>
+	protected override void ProcessPendingRender()
+	{
+		// Blocks updates to the renderers internal render tree
+		// while the render tree is being read elsewhere.
+		// base.ProcessPendingRender calls UpdateDisplayAsync,
+		// so there is no need to lock in that method.
+		lock (renderTreeUpdateLock)
+		{
+			base.ProcessPendingRender();
+		}
+	}
+
+	/// <inheritdoc/>
+	protected override Task UpdateDisplayAsync(in RenderBatch renderBatch)
+	{
+		RenderCount++;
+
+		for (int i = 0; i < renderBatch.UpdatedComponents.Count; i++)
+		{
+			ref var diff = ref renderBatch.UpdatedComponents.Array[i];
+			GetComponentState(diff.ComponentId).UpdateMarkup(RenderCount);
+		}
+
+		if (usersSyncContext is not null && usersSyncContext != SynchronizationContext.Current)
+		{
+			// The users' sync context, typically one established by
+			// xUnit or another testing framework is used to update any
+			// rendered fragments/dom trees and trigger WaitForX handlers.
+			// This ensures that changes to DOM observed inside a WaitForX handler
+			// will also be visible outside a WaitForX handler, since
+			// they will be running in the same sync context. The theory is that
+			// this should mitigate the issues where Blazor's dispatcher/thread is used
+			// to verify an assertion inside a WaitForX handler, and another thread is
+			// used again to access the DOM/repeat the assertion, where the change
+			// may not be visible yet (another theory about why that may happen is different
+			// CPU cache updates not happening immediately).
+			//
+			// There is no guarantee a caller/test framework has set a sync context.
+			usersSyncContext.Send(static (state) =>
+			{
+			}, null);
+		}
+		else
+		{
+			// TODO
+		}
+
+		return Task.CompletedTask;
+
+
+	}
+
+	/// <inheritdoc/>
+	protected override IComponent ResolveComponentForRenderMode(Type componentType, int? parentComponentId,
+		IComponentActivator componentActivator, IComponentRenderMode componentTypeRenderMode)
+
+	{
+		ArgumentNullException.ThrowIfNull(componentActivator);
+		return componentActivator.CreateInstance(componentType);
+	}
+
+	/// <inheritdoc/>
+	protected override void HandleException(Exception exception)
+	{
+		if (exception is null)
+			return;
+
+		capturedUnhandledException = exception;
+
+		if (!unhandledExceptionTsc.TrySetResult(capturedUnhandledException))
+		{
+			unhandledExceptionTsc = new TaskCompletionSource<Exception>(TaskCreationOptions.RunContinuationsAsynchronously);
+			unhandledExceptionTsc.SetResult(capturedUnhandledException);
+		}
+	}
+
+	internal new BunitComponentState GetComponentState(int componentId)
+	{
+		var result = base.GetComponentState(componentId) as BunitComponentState;
+		Debug.Assert(result is not null, "ComponentState should be of type BunitComponentState");
+		return result;
+	}
+
+	internal new ArrayRange<RenderTreeFrame> GetCurrentRenderTreeFrames(int componentId)
+		=> base.GetCurrentRenderTreeFrames(componentId);
+
+	private void ResetUnhandledException()
+	{
+		capturedUnhandledException = null;
+
+		if (unhandledExceptionTsc.Task.IsCompleted)
+			unhandledExceptionTsc = new TaskCompletionSource<Exception>(TaskCreationOptions.RunContinuationsAsynchronously);
+	}
+
+	private void AssertNoUnhandledExceptions()
+	{
+		if (capturedUnhandledException is Exception unhandled)
+		{
+			capturedUnhandledException = null;
+
+			if (unhandled is AggregateException aggregateException && aggregateException.InnerExceptions.Count == 1)
+			{
+				ExceptionDispatchInfo.Capture(aggregateException.InnerExceptions[0]).Throw();
+			}
+			else
+			{
+				ExceptionDispatchInfo.Capture(unhandled).Throw();
+			}
+		}
+	}
+}

--- a/src/bunit/Rendering/Internal/BunitRootComponent.cs
+++ b/src/bunit/Rendering/Internal/BunitRootComponent.cs
@@ -1,0 +1,21 @@
+namespace Bunit.Rendering.Internal;
+
+internal class BunitRootComponent : IComponent
+{
+	private readonly RenderFragment renderFragment;
+	private RenderHandle renderHandle;
+
+	public BunitRootComponent(RenderFragment renderFragment)
+		=> this.renderFragment = renderFragment;
+
+	public void Attach(RenderHandle renderHandle) 
+	{
+		this.renderHandle = renderHandle;
+	}
+
+	public Task SetParametersAsync(ParameterView parameters) 
+	{
+		renderHandle.Render(renderFragment);
+		return Task.CompletedTask;
+	}
+}

--- a/src/bunit/Rendering/Internal/HtmlizerV2.cs
+++ b/src/bunit/Rendering/Internal/HtmlizerV2.cs
@@ -1,0 +1,373 @@
+// This code/file was originally copied from https://github.com/dotnet/aspnetcore/
+// It's content has been modified from the original.
+// See the NOTICE.md at the root of this repository for a copy
+// of the license from the aspnetcore repository.
+using Bunit.Rendering.Internal;
+using System.Diagnostics;
+using System.Globalization;
+
+namespace Bunit;
+
+/// <summary>
+/// This file is based on
+/// https://source.dot.net/#Microsoft.AspNetCore.Mvc.ViewFeatures/RazorComponents/HtmlRenderer.cs.
+/// </summary>
+internal static class HtmlizerV2
+{
+	private const string BlazorInternalAttrPrefix = "__internal_";
+	private const string BlazorCssScopeAttrPrefix = "b-";
+	internal const string BlazorAttrPrefix = "blazor:";
+	internal const string ElementReferenceAttrName = BlazorAttrPrefix + "elementReference";
+
+	private static readonly HashSet<string> SelfClosingElements =
+		new(StringComparer.OrdinalIgnoreCase)
+		{
+			"area",
+			"base",
+			"br",
+			"col",
+			"embed",
+			"hr",
+			"img",
+			"input",
+			"link",
+			"meta",
+			"param",
+			"source",
+			"track",
+			"wbr",
+		};
+
+	public static void GenerateMarkup(BunitRootComponentState componentState)
+	{
+		var frames = componentState.GetRenderTreeFrames(componentState.ComponentId);
+		var newPosition = RenderFrames(componentState, frames, 0, frames.Count);
+		Debug.Assert(
+			newPosition == frames.Count,
+			$"frames.Length = {frames.Count}. newPosition = {newPosition}"
+		);
+	}
+
+	private static int RenderFrames(
+		BunitRootComponentState componentState,
+		in ArrayRange<RenderTreeFrame> frames,
+		int position,
+		int maxElements
+	)
+	{
+		var nextPosition = position;
+		var endPosition = position + maxElements;
+
+		while (position < endPosition)
+		{
+			nextPosition = RenderCore(componentState, frames, position);
+			if (position == nextPosition)
+			{
+				throw new InvalidOperationException("We didn't consume any input.");
+			}
+
+			position = nextPosition;
+		}
+
+		return nextPosition;
+	}
+
+	private static int RenderCore(
+		BunitRootComponentState componentState,
+		in ArrayRange<RenderTreeFrame> frames,
+		int position
+	)
+	{
+		var frame = frames.Array[position];
+		switch (frame.FrameType)
+		{
+			case RenderTreeFrameType.Element:
+				return RenderElement(componentState, frames, position);
+			case RenderTreeFrameType.Attribute:
+				throw new InvalidOperationException(
+					$"Attributes should only be encountered within {nameof(RenderElement)}"
+				);
+			case RenderTreeFrameType.Text:
+				AppendEscapeText(componentState, frame.TextContent);
+				return position + 1;
+			case RenderTreeFrameType.Markup:
+				componentState.Append(frame.MarkupContent);
+				return position + 1;
+			case RenderTreeFrameType.Component:
+				return RenderChildComponent(componentState, frames, position);
+			case RenderTreeFrameType.Region:
+				return RenderFrames(componentState, frames, position + 1, frame.RegionSubtreeLength - 1);
+			case RenderTreeFrameType.ElementReferenceCapture:
+			case RenderTreeFrameType.ComponentReferenceCapture:
+				return position + 1;
+			default:
+				throw new InvalidOperationException(
+					$"Invalid element frame type '{frame.FrameType}'."
+				);
+		}
+	}
+
+	private static int RenderChildComponent(
+		BunitRootComponentState componentState,
+		in ArrayRange<RenderTreeFrame> frames,
+		int position)
+	{
+		var frame = frames.Array[position];
+		var childFrames = componentState.GetRenderTreeFrames(frame.ComponentId);
+		componentState.MarkComponentStart(frame.ComponentId);
+		RenderFrames(componentState, childFrames, 0, childFrames.Count);
+		componentState.MarkComponentStop(frame.ComponentId);
+		return position + frame.ComponentSubtreeLength;
+	}
+
+	private static int RenderElement(
+		BunitRootComponentState componentState,
+		in ArrayRange<RenderTreeFrame> frames,
+		int position
+	)
+	{
+		var frame = frames.Array[position];
+		componentState.Append('<');
+		componentState.Append(frame.ElementName);
+		var afterAttributes = RenderAttributes(
+			componentState,
+			frames,
+			position + 1,
+			frame.ElementSubtreeLength - 1,
+			out var capturedValueAttribute
+		);
+
+		// When we see an <option> as a descendant of a <select>, and the option's "value" attribute matches the
+		// "value" attribute on the <select>, then we auto-add the "selected" attribute to that option. This is
+		// a way of converting Blazor's select binding feature to regular static HTML.
+		if (
+			componentState.ClosestSelectValueAsString != null
+			&& string.Equals(frame.ElementName, "option", StringComparison.OrdinalIgnoreCase)
+			&& string.Equals(
+				capturedValueAttribute,
+				componentState.ClosestSelectValueAsString,
+				StringComparison.Ordinal
+			)
+		)
+		{
+			componentState.Append(" selected");
+		}
+
+		var remainingElements = frame.ElementSubtreeLength + position - afterAttributes;
+		if (remainingElements > 0)
+		{
+			componentState.Append('>');
+
+			var isSelect = string.Equals(
+				frame.ElementName,
+				"select",
+				StringComparison.OrdinalIgnoreCase
+			);
+			if (isSelect)
+			{
+				componentState.ClosestSelectValueAsString = capturedValueAttribute;
+			}
+
+			var afterElement = RenderChildren(componentState, frames, afterAttributes, remainingElements);
+
+			if (isSelect)
+			{
+				// There's no concept of nested <select> elements, so as soon as we're exiting one of them,
+				// we can safely say there is no longer any value for this
+				componentState.ClosestSelectValueAsString = null;
+			}
+
+			componentState.Append("</");
+			componentState.Append(frame.ElementName);
+			componentState.Append('>');
+			return afterElement;
+		}
+
+		if (SelfClosingElements.Contains(frame.ElementName))
+		{
+			componentState.Append(" />");
+		}
+		else
+		{
+			componentState.Append('>');
+			componentState.Append("</");
+			componentState.Append(frame.ElementName);
+			componentState.Append('>');
+		}
+
+		Debug.Assert(
+			afterAttributes == position + frame.ElementSubtreeLength,
+			$"afterAttributes = {afterAttributes}. position = {position}. frame.ElementSubtreeLength = {frame.ElementSubtreeLength}"
+		);
+		return afterAttributes;
+	}
+
+	private static int RenderChildren(
+		BunitRootComponentState componentState,
+		in ArrayRange<RenderTreeFrame> frames,
+		int position,
+		int maxElements
+	)
+	{
+		if (maxElements == 0)
+		{
+			return position;
+		}
+
+		return RenderFrames(componentState, frames, position, maxElements);
+	}
+
+	private static int RenderAttributes(
+		BunitRootComponentState componentState,
+		in ArrayRange<RenderTreeFrame> frames,
+		int position,
+		int maxElements,
+		out string? capturedValueAttribute
+	)
+	{
+		capturedValueAttribute = null;
+
+		if (maxElements == 0)
+		{
+			return position;
+		}
+
+		for (var i = 0; i < maxElements; i++)
+		{
+			var candidateIndex = position + i;
+			var frame = frames.Array[candidateIndex];
+
+			// Added to write ElementReferenceCaptureId to DOM
+			if (frame.FrameType == RenderTreeFrameType.ElementReferenceCapture)
+			{
+				var value = $" {ElementReferenceAttrName}=\"{frame.ElementReferenceCaptureId}\"";
+				componentState.Append(value);
+			}
+
+			if (frame.FrameType != RenderTreeFrameType.Attribute)
+			{
+				return candidateIndex;
+			}
+
+			if (frame.AttributeName.Equals("value", StringComparison.OrdinalIgnoreCase))
+			{
+				capturedValueAttribute = frame.AttributeValue as string;
+			}
+
+			if (frame.AttributeEventHandlerId > 0)
+			{
+				// NOTE: this was changed to make it more obvious
+				//       that this is a generated/special blazor attribute
+				//       used for tracking event handler id's
+				componentState.Append(' ');
+				componentState.Append(BlazorAttrPrefix);
+				componentState.Append(frame.AttributeName);
+				componentState.Append('=');
+				componentState.Append('"');
+				componentState.Append(frame.AttributeEventHandlerId.ToString(CultureInfo.InvariantCulture));
+				componentState.Append('"');
+				continue;
+			}
+
+			switch (frame.AttributeValue)
+			{
+				case bool flag
+					when flag
+						&& frame.AttributeName.StartsWith(
+							BlazorInternalAttrPrefix,
+							StringComparison.Ordinal
+						):
+					// NOTE: This was added to make it more obvious
+					// that this is a generated/special blazor attribute
+					// for internal usage
+					var nameParts = frame.AttributeName.Split(
+						'_',
+						StringSplitOptions.RemoveEmptyEntries
+					);
+					componentState.Append(' ');
+					componentState.Append(BlazorAttrPrefix);
+					componentState.Append(nameParts[2]);
+					componentState.Append(':');
+					componentState.Append(nameParts[1]);
+					break;
+				case true:
+					componentState.Append(' ');
+					componentState.Append(frame.AttributeName);
+					break;
+				case string value:
+					componentState.Append(' ');
+					componentState.Append(frame.AttributeName);
+					componentState.Append('=');
+					componentState.Append('"');
+					AppendEscapeAttributeValue(componentState, value);
+					componentState.Append('"');
+					break;
+				default:
+					break;
+			}
+		}
+
+		return position + maxElements;
+	}
+
+	private static void AppendEscapeText(BunitRootComponentState componentState, string value)
+	{
+		var valueSpan = value.AsSpan();
+		var copyFromIndex = 0;
+		for (var index = 0; index < valueSpan.Length; index++)
+		{
+			var c = valueSpan[index];
+			if (c is '<' or '>' or '&')
+			{
+				componentState.Append(valueSpan.Slice(copyFromIndex, index - copyFromIndex));
+				switch (c)
+				{
+					case '<':
+						componentState.Append("&lt;");
+						break;
+					case '>':
+						componentState.Append("&gt;");
+						break;
+					case '&':
+						componentState.Append("&amp;");
+						break;
+				}
+				copyFromIndex = index + 1;
+			}
+		}
+
+		if (copyFromIndex < valueSpan.Length)
+		{
+			componentState.Append(valueSpan.Slice(copyFromIndex));
+		}
+	}
+
+	private static void AppendEscapeAttributeValue(BunitRootComponentState componentState, string value)
+	{
+		var valueSpan = value.AsSpan();
+		var copyFromIndex = 0;
+		for (var index = 0; index < valueSpan.Length; index++)
+		{
+			var c = valueSpan[index];
+			if (c is '"' or '&')
+			{
+				componentState.Append(valueSpan.Slice(copyFromIndex, index - copyFromIndex));
+				switch (c)
+				{
+					case '"':
+						componentState.Append("&quot;");
+						break;
+					case '&':
+						componentState.Append("&amp;");
+						break;
+				}
+				copyFromIndex = index + 1;
+			}
+		}
+
+		if (copyFromIndex < valueSpan.Length)
+		{
+			componentState.Append(valueSpan.Slice(copyFromIndex));
+		}
+	}
+}

--- a/src/bunit/Rendering/Internal/RenderedComponentV2.cs
+++ b/src/bunit/Rendering/Internal/RenderedComponentV2.cs
@@ -1,0 +1,43 @@
+using AngleSharp.Dom;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Bunit.Rendering.Internal;
+
+internal class RenderedComponentV2<TComponent> : IRenderedComponent<TComponent>
+	where TComponent : IComponent
+{
+	private readonly BunitComponentState state;
+
+	public TComponent Instance => (TComponent)state.Component;
+
+	public int RenderCount { get; }
+
+	public bool IsDisposed { get; private set; }
+
+	public int ComponentId { get; }
+
+	public IServiceProvider Services { get; }
+
+	public string Markup => state.Markup.ToString();
+
+	public INodeList Nodes { get; }
+
+	public event EventHandler OnAfterRender;
+	public event EventHandler OnMarkupUpdated;
+
+	public RenderedComponentV2(BunitComponentState state)
+	{
+		this.state = state;
+	}
+
+	public void Dispose()
+	{
+		IsDisposed = true;
+	}
+
+	public void OnRender(RenderEvent renderEvent) => throw new NotImplementedException();
+}

--- a/src/bunit/bunit.csproj
+++ b/src/bunit/bunit.csproj
@@ -15,6 +15,7 @@
 			bUnit also includes a complete implementation of Blazor's authentication and authorization logic, navigation manager, and
 			JSInterop.
 		</Description>
+		<RootNamespace>Bunit</RootNamespace>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -1,9 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-
-	<!--
-    Add any shared properties you want for the projects under this directory that need to be set before the auto imported Directory.Build.props
-  -->
 	<Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory).., Directory.Build.props))\Directory.Build.props" />
 
 	<PropertyGroup Label="Compile settings" Condition="$(MSBuildProjectName) != 'bunit.testassets'">
@@ -12,6 +8,7 @@
 		<SonarQubeTestProject>true</SonarQubeTestProject>
 		<IsTestProject>true</IsTestProject>
 		<SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
+		<RootNamespace>Bunit</RootNamespace>
 	</PropertyGroup>
 
 	<ItemGroup Condition="$(MSBuildProjectName) != 'bunit.testassets'">
@@ -38,6 +35,7 @@
 		<Using Include="Moq" />
 		<Using Include="Shouldly" />
 		<Using Include="Xunit" />
+		<Using Include="Xunit.Abstractions"/>
 	</ItemGroup>
 
 </Project>

--- a/tests/bunit.tests/Rendering/BunitRendererV2Test.razor
+++ b/tests/bunit.tests/Rendering/BunitRendererV2Test.razor
@@ -1,0 +1,29 @@
+@using Bunit.Rendering.Internal
+@using Microsoft.Extensions.Logging;
+@code {
+    private readonly TestServiceProvider services;
+
+	public BunitRendererV2Test(ITestOutputHelper output)
+    {
+		services = new TestServiceProvider();
+		services.AddXunitLogger(output);
+		services.AddScoped<IJSRuntime>(_ => new BunitJSInterop().JSRuntime);
+	}
+
+	[Fact]
+	public void MyTestMethod()
+	{
+		var sut = new BunitRendererV2(services, services.GetRequiredService<ILoggerFactory>());
+		var result = sut.RenderFragment(@<Wrapper><Simple1 Header="Foo" /><Simple1 Header="Bar" /></Wrapper>);
+        result.Markup.ShouldNotBeEmpty();
+    }
+
+    // [Fact]
+    // public void MyTestMethod_2()
+    // {
+    //     var sut = new BunitRendererV2(services, services.GetRequiredService<ILoggerFactory>());
+    //     var result = sut.RenderFragment(@<ToggleChildComponent ShowChild="true" />);
+
+    //     result(ps => ps.Add(p => p.ShowChild, false));
+    // }
+}


### PR DESCRIPTION
Draft PR to get some feedback on the direction.

- [x] Uses access to ComponentState to minimize the number of objects created.
- [ ] BunitComponentState tracks children, may be useful with `FindComponents` implementations
- [x] A root component is the only one that actually has markup rendered for it. 
- [x] Child components know what part of the root markup is theirs and makes that visible via a slice of the root markup span.
- [ ] A root component creates and owns AngleSharp nodes (perhaps updated via diffing on re-renders to reuse existing node instances)
- [ ] Child components know the sub-nodes from the root they are responsible for. This could be determined via source information on AngleSharp nodes?
- [ ] Investigate possible simplifications of `TestContext.RenderTree` and usage of `FragmentContainer`.
- [ ] Consider only re-rendering changed components and patch roots markup and update offsets.

The ultimate goal is to replace BunitRendere with BunitRendereV2 without changing anything in all existing tests.