### PR TITLE
feat: Add target sdk for template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@ All notable changes to **bUnit** will be documented in this file. The project ad
 
 ## [Unreleased]
 
-## Changed
+### Added
+
+- Update bunit templates to support the target framework version of the project. By [@linkdotnet](https://github.com/linkdotnet).
+
+### Changed
 
 - Change all bUnit services registration from singleton to scoped. By [@egil](https://github.com/egil). Closes https://github.com/bUnit-dev/bUnit/issues/1138.
 

--- a/src/bunit.template/template/.template.config/dotnetcli.host.json
+++ b/src/bunit.template/template/.template.config/dotnetcli.host.json
@@ -14,8 +14,8 @@
 		}
 	},
 	"usageExamples": [
-		"--framework xunit --sdk net6.0",
-		"--framework nunit --sdk net6.0",
-		"--framework mstest --sdk net6.0"
+		"--framework xunit --sdk net7.0",
+		"--framework nunit --sdk net7.0",
+		"--framework mstest --sdk net7.0"
 	]
 }

--- a/src/bunit.template/template/.template.config/dotnetcli.host.json
+++ b/src/bunit.template/template/.template.config/dotnetcli.host.json
@@ -7,11 +7,15 @@
 		"UnitTestFramework": {
 			"longName": "framework",
 			"shortName": ""
+		},
+		"TargetSdk": {
+			"longName": "sdk",
+			"shortName": ""
 		}
 	},
 	"usageExamples": [
-		"--framework xunit",
-		"--framework nunit",
-		"--framework mstest"
+		"--framework xunit --sdk net6.0",
+		"--framework nunit --sdk net6.0",
+		"--framework mstest --sdk net6.0"
 	]
 }

--- a/src/bunit.template/template/.template.config/template.json
+++ b/src/bunit.template/template/.template.config/template.json
@@ -82,7 +82,7 @@
 			"description": "The target framework sdk for the project.",
 			"displayName": "Target framework sdk",
 			"datatype": "choice",
-			"defaultValue": "net6.0",
+			"defaultValue": "net7.0",
 			"replaces": "targetSdk",
 			"choices": [
 				{

--- a/src/bunit.template/template/.template.config/template.json
+++ b/src/bunit.template/template/.template.config/template.json
@@ -76,6 +76,31 @@
 		"testFramework_mstest": {
 			"type": "computed",
 			"value": "UnitTestFramework == \"mstest\""
+		},
+		"targetSdk": {
+			"type": "parameter",
+			"description": "The target framework sdk for the project.",
+			"displayName": "Target framework sdk",
+			"datatype": "choice",
+			"defaultValue": "net6.0",
+			"replaces": "targetSdk",
+			"choices": [
+				{
+					"choice": "net6.0",
+					"description": ".net 6.0",
+					"displayName": ".net 6.0"
+				},
+				{
+					"choice": "net7.0",
+					"description": ".net 7.0",
+					"displayName": ".net 7.0"
+				},
+				{
+					"choice": "net8.0",
+					"description": ".net 8.0",
+					"displayName": ".net 8.0"
+				}
+			]
 		}
 	},
   "primaryOutputs": [

--- a/src/bunit.template/template/Company.BlazorTests1.csproj
+++ b/src/bunit.template/template/Company.BlazorTests1.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>targetSdk</TargetFramework>
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
 	</PropertyGroup>
@@ -17,29 +17,29 @@
 
 	<ItemGroup>
 		<PackageReference Include="bunit" Version="#{NBGV_NuGetPackageVersion}#" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-		<PackageReference Include="coverlet.collector" Version="3.1.0">
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.12.0" />
+		<PackageReference Include="coverlet.collector" Version="6.0.0">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(testFramework_xunit)' == 'true'">
-		<PackageReference Include="xunit" Version="2.4.2" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+		<PackageReference Include="xunit" Version="2.5.0" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(testFramework_nunit)' == 'true'">
-		<PackageReference Include="NUnit" Version="3.13.2" />
-		<PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
+		<PackageReference Include="NUnit" Version="3.13.3" />
+		<PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(testFramework_mstest)' == 'true'">
-		<PackageReference Include="MSTest.TestAdapter" Version="2.2.7" />
-		<PackageReference Include="MSTest.TestFramework" Version="2.2.7" />
+		<PackageReference Include="MSTest.TestAdapter" Version="3.0.4" />
+		<PackageReference Include="MSTest.TestFramework" Version="3.0.4" />
 	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
This Pull Request does the following additions / changes:
 * Added the target SDK as optional parameter when creating the bUnit project
   * It currently targets `net6.0` as this is the current LTS. I thought about scripting this away, but it seems way easier to bump our default every 2 years and remove obsolete versions and set the default to the current LTS
 * I updated the dependencies to the latest state
 * Fixed an issue with h2/h3 in the changelog.md 

This tackles partially #1093 