### PR TITLE
fix: New up renderer for markup matches

### DIFF
--- a/src/bunit.web/Asserting/MarkupMatchesAssertExtensions.cs
+++ b/src/bunit.web/Asserting/MarkupMatchesAssertExtensions.cs
@@ -3,6 +3,7 @@ using Bunit.Asserting;
 using Bunit.Diffing;
 using Bunit.Extensions;
 using Bunit.Rendering;
+using Microsoft.Extensions.Logging;
 
 namespace Bunit;
 
@@ -299,8 +300,13 @@ public static class MarkupMatchesAssertExtensions
 		if (expected is null)
 			throw new ArgumentNullException(nameof(expected));
 
-		var testContext = actual.Services.GetRequiredService<TestContextBase>();
-		var renderedFragment = (IRenderedFragment)testContext.RenderInsideRenderTree(expected);
+		// TODO: This will be obsolete with: https://github.com/bUnit-dev/bUnit/issues/1018
+		// As the renderer would be transient we don't have to new up an instance
+		using var renderer = new TestRenderer(
+			actual.Services.GetRequiredService<IRenderedComponentActivator>(),
+			actual.Services.GetRequiredService<TestServiceProvider>(),
+			actual.Services.GetRequiredService<ILoggerFactory>());
+		var renderedFragment = (IRenderedFragment)renderer.RenderFragment(expected);
 		MarkupMatches(actual, renderedFragment, userMessage);
 	}
 

--- a/tests/.editorconfig
+++ b/tests/.editorconfig
@@ -7,7 +7,7 @@
 ##########################################
 # Code Analyzers Rules
 ##########################################
-[*.{cs,csx,cake,razor}]
+[*.{cs,csx,cake}]
 
 # AsyncFixer
 # http://www.asyncfixer.com

--- a/tests/.editorconfig
+++ b/tests/.editorconfig
@@ -7,7 +7,7 @@
 ##########################################
 # Code Analyzers Rules
 ##########################################
-[*.{cs,csx,cake}]
+[*.{cs,csx,cake,razor}]
 
 # AsyncFixer
 # http://www.asyncfixer.com

--- a/tests/bunit.testassets/SampleComponents/InvokeAsyncInsideContinueWith.razor
+++ b/tests/bunit.testassets/SampleComponents/InvokeAsyncInsideContinueWith.razor
@@ -1,0 +1,50 @@
+@if (Task != null)
+{
+	@if (Task.IsCompleted)
+	{
+		<span>done</span>
+	}
+	else
+	{
+		<span>waiting</span>
+	}
+}
+@code {
+	[Parameter] public Task? Task { get; set; }
+
+	private Task? registeredTask;
+	private Task? delegatedTask;
+
+	protected override void OnParametersSet()
+	{
+		var task = Task;
+		if (task != registeredTask)
+		{
+			registeredTask = task;
+			delegatedTask = task == null ? null : DelegateTo(task);
+			RenderWhenDone();
+		}
+
+		base.OnParametersSet();
+	}
+
+	private async void RenderWhenDone()
+	{
+		var task = delegatedTask;
+		if (task != null)
+		{
+			_ = await Task.WhenAny(task).ConfigureAwait(false);
+
+			if (task == delegatedTask)
+			{
+				_ = InvokeAsync(StateHasChanged);
+			}
+		}
+	}
+
+	private static async Task<object?> DelegateTo(Task task)
+	{
+		await task;//.ConfigureAwait(false);
+		return null;
+	}
+}

--- a/tests/bunit.web.tests/Asserting/MarkupMatchesTests.razor
+++ b/tests/bunit.web.tests/Asserting/MarkupMatchesTests.razor
@@ -17,6 +17,7 @@
 		cut.WaitForAssertion(() => cut.MarkupMatches(@<span>done</span>));
 	}
 
+	[SuppressMessage("Usage", "xUnit1026:Theory method does not use parameter")]
 	[Theory]
 	[Repeat(2)]
 	public void MarkupMatchesShouldNotBeBlockedByRendererComplex(int repeatCount)

--- a/tests/bunit.web.tests/Asserting/MarkupMatchesTests.razor
+++ b/tests/bunit.web.tests/Asserting/MarkupMatchesTests.razor
@@ -2,6 +2,7 @@
 @inherits TestContext
 
 @code {
+
 	[Fact]
 	public void MarkupMatchesShouldNotBeBlockedByRenderer()
 	{
@@ -10,6 +11,21 @@
 		var cut = Render(@<LoadingComponent Task="@tcs.Task"/> );
 
 		cut.MarkupMatches(@<span>loading</span>);
+
+		tcs.SetResult(true);
+
+		cut.WaitForAssertion(() => cut.MarkupMatches(@<span>done</span>));
+	}
+
+	[Theory]
+	[Repeat(2)]
+	public void MarkupMatchesShouldNotBeBlockedByRendererComplex(int repeatCount)
+	{
+		var tcs = new TaskCompletionSource<object?>();
+
+		var cut = Render(@<InvokeAsyncInsideContinueWith Task="@tcs.Task"/> );
+
+		cut.MarkupMatches(@<span>waiting</span>);
 
 		tcs.SetResult(true);
 


### PR DESCRIPTION
Newing up a renderer for `MarkupMatches` to prevent being deadlocked to renderer the expected `RenderFragment`.