### PR TITLE
refactor: Move from moq to NSubstitute

### DIFF
--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -18,7 +18,7 @@
 		<PackageReference Include="AutoFixture" Version="4.18.0" />
 		<PackageReference Include="AutoFixture.Xunit2" Version="4.18.0" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
-		<PackageReference Include="Moq" Version="4.18.4" />
+		<PackageReference Include="NSubstitute" Version="5.0.0" />
 		<PackageReference Include="Shouldly" Version="4.2.1" />
 		<PackageReference Include="xunit" Version="2.5.0" />
 		<PackageReference Include="Xunit.Combinatorial" Version="1.5.25" />
@@ -39,7 +39,7 @@
 		<Using Include="Microsoft.AspNetCore.Components.Web" />
 		<Using Include="Microsoft.AspNetCore.Components.Routing" />
 		<Using Include="System.Reflection" />
-		<Using Include="Moq" />
+		<Using Include="NSubstitute" />
 		<Using Include="Shouldly" />
 		<Using Include="Xunit" />
 		<Using Include="Xunit.Abstractions" />

--- a/tests/bunit.core.tests/ComponentFactories/ConditionalComponentFactoryTest.cs
+++ b/tests/bunit.core.tests/ComponentFactories/ConditionalComponentFactoryTest.cs
@@ -22,7 +22,7 @@ public class ConditionalComponentFactoryTest : TestContext
 	[Fact(DisplayName = "Component is replaced in render tree with component from factory when matches returns true")]
 	public void Test010()
 	{
-		var mockComponent = Mock.Of<Simple1>();
+		var mockComponent = Substitute.For<Simple1>();
 		ComponentFactories.Add(type => type == typeof(Simple1), _ => mockComponent);
 
 		var cut = RenderComponent<Wrapper>(ps => ps.AddChildContent<Simple1>());
@@ -34,17 +34,21 @@ public class ConditionalComponentFactoryTest : TestContext
 	[Fact(DisplayName = "Component is replaced in render tree with component from factory when matches returns true")]
 	public void Test011()
 	{
-		var mockRepo = new MockRepository(MockBehavior.Loose);
+		var mockSimple1 = Substitute.For<Simple1>();
+		var mockNoArgs = Substitute.For<NoArgs>();
 		ComponentFactories.Add(
 			type => type != typeof(TwoComponentWrapper),
-			mockRepo.CreateComponent);
+			type => CreateComponent(type, mockSimple1, mockNoArgs)
+		);
 
+		// Act
 		var cut = RenderComponent<TwoComponentWrapper>(ps => ps
-		   .Add<Simple1>(p => p.First)
-		   .Add<NoArgs>(p => p.Second));
+			.Add<Simple1>(p => p.First)
+			.Add<NoArgs>(p => p.Second));
 
-		cut.FindComponents<Simple1>().ShouldAllBe(x => Mock.Get(x.Instance));
-		cut.FindComponents<NoArgs>().ShouldAllBe(x => Mock.Get(x.Instance));
+		// Assert
+		cut.FindComponents<Simple1>().ShouldAllBe(x => x.Instance == mockSimple1);
+		cut.FindComponents<NoArgs>().ShouldAllBe(x => x.Instance == mockNoArgs);
 	}
 
 	[Fact(DisplayName = "When matches returns false, factory is never called")]
@@ -54,19 +58,12 @@ public class ConditionalComponentFactoryTest : TestContext
 
 		Should.NotThrow(() => RenderComponent<Wrapper>(ps => ps.AddChildContent<Simple1>()));
 	}
-}
-
-internal static class MockRepositoryExtensions
-{
-	private static readonly MethodInfo CreateMethodInfo = typeof(MockRepository)
-		.GetMethod(nameof(MockRepository.Create), Array.Empty<Type>());
-
-	public static IComponent CreateComponent(this MockRepository repository, Type type)
+	
+	private static IComponent CreateComponent(Type type, Simple1 simple1, NoArgs noArgs)
 	{
-		var genericCreateMethod = CreateMethodInfo.MakeGenericMethod(type);
-		var mock = (Mock)genericCreateMethod.Invoke(repository, null);
-		return (IComponent)mock.Object;
+		if (type == typeof(Simple1)) return simple1;
+		if (type == typeof(NoArgs)) return noArgs;
+		throw new NotImplementedException($"No mock implementation provided for type {type.FullName}");
 	}
 }
-
 #endif

--- a/tests/bunit.core.tests/ComponentFactories/InstanceComponentFactoryTest.cs
+++ b/tests/bunit.core.tests/ComponentFactories/InstanceComponentFactoryTest.cs
@@ -15,20 +15,20 @@ public class InstanceComponentFactoryTest : TestContext
 	[Fact(DisplayName = "Factory replaces one TComponent with instance in the render tree")]
 	public void Test010()
 	{
-		var simple1Mock = new Mock<Simple1>();
-		ComponentFactories.Add<Simple1>(simple1Mock.Object);
+		var simple1Mock = Substitute.For<Simple1>();
+		ComponentFactories.Add(simple1Mock);
 
 		var cut = RenderComponent<Wrapper>(ps => ps.AddChildContent<Simple1>());
 
 		cut.FindComponent<Simple1>()
-			.Instance.ShouldBeSameAs(simple1Mock.Object);
+			.Instance.ShouldBeSameAs(simple1Mock);
 	}
 
 	[Fact(DisplayName = "Factory throws if component instance is requested twice for TComponent that inherits from ComponentBase")]
 	public void Test020()
 	{
-		var simple1Mock = new Mock<Simple1>();
-		ComponentFactories.Add<Simple1>(simple1Mock.Object);
+		var simple1Mock = Substitute.For<Simple1>();
+		ComponentFactories.Add(simple1Mock);
 
 		Should.Throw<InvalidOperationException>(() => RenderComponent<TwoComponentWrapper>(ps => ps
 			   .Add<Simple1>(p => p.First)
@@ -38,8 +38,8 @@ public class InstanceComponentFactoryTest : TestContext
 	[Fact(DisplayName = "Factory throws if component instance is requested twice for TComponent that implements from IComponent")]
 	public void Test021()
 	{
-		var simple1Mock = new Mock<BasicComponent>();
-		ComponentFactories.Add<BasicComponent>(simple1Mock.Object);
+		var simple1Mock = Substitute.For<BasicComponent>();
+		ComponentFactories.Add(simple1Mock);
 
 		Should.Throw<InvalidOperationException>(() => RenderComponent<TwoComponentWrapper>(ps => ps
 			.Add<BasicComponent>(p => p.First)

--- a/tests/bunit.core.tests/ComponentFactories/TypeBasedComponentFactoryTest.cs
+++ b/tests/bunit.core.tests/ComponentFactories/TypeBasedComponentFactoryTest.cs
@@ -16,7 +16,7 @@ public class TypeBasedComponentFactoryTest : TestContext
 	[Fact(DisplayName = "TComponent replaced in render tree with component from factory method")]
 	public void Test010()
 	{
-		var simple1Mock = Mock.Of<Simple1>();
+		var simple1Mock = Substitute.For<Simple1>();
 		ComponentFactories.Add<Simple1>(() => simple1Mock);
 
 		var cut = RenderComponent<Wrapper>(ps => ps.AddChildContent<Simple1>());
@@ -28,17 +28,17 @@ public class TypeBasedComponentFactoryTest : TestContext
 	[Fact(DisplayName = "Multiple TComponent replaced in render tree with component from factory method")]
 	public void Test011()
 	{
-		var mockRepo = new MockRepository(MockBehavior.Loose);
-		ComponentFactories.Add<Simple1>(() => mockRepo.Create<Simple1>().Object);
+		ComponentFactories.Add(() => Substitute.For<Simple1>());
 
 		var cut = RenderComponent<TwoComponentWrapper>(ps => ps
 			   .Add<Simple1>(p => p.First)
 			   .Add<Simple1>(p => p.Second));
 
-		cut.FindComponents<Simple1>()
-			.ShouldAllBe(
-				x => Mock.Get(x.Instance),
-				x => Mock.Get(x.Instance));
+		foreach (var component in cut.FindComponents<Simple1>())
+		{
+			Action checkIfSubstitute = () => component.Instance.Received();
+			checkIfSubstitute.ShouldNotThrow();
+		}
 	}
 }
 

--- a/tests/bunit.core.tests/Rendering/TestRendererTest.net5.cs
+++ b/tests/bunit.core.tests/Rendering/TestRendererTest.net5.cs
@@ -7,7 +7,6 @@ using System.Threading.Tasks;
 using Bunit.TestAssets.SampleComponents;
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.Logging.Abstractions;
-using Moq;
 using Xunit;
 
 namespace Bunit.Rendering;
@@ -19,17 +18,17 @@ public partial class TestRendererTest : TestContext
 						"then it used to create components")]
 	public void Test1000()
 	{
-		var activatorMock = new Mock<IComponentActivator>();
-		activatorMock.Setup(x => x.CreateInstance(typeof(Wrapper))).Returns(new Wrapper());
+		var activatorMock = Substitute.For<IComponentActivator>();
+		activatorMock.CreateInstance(typeof(Wrapper)).Returns(new Wrapper());
 		using var renderer = new TestRenderer(
 			Services.GetService<IRenderedComponentActivator>(),
 			Services,
 			NullLoggerFactory.Instance,
-			activatorMock.Object);
+			activatorMock);
 
 		renderer.RenderComponent<Wrapper>(new ComponentParameterCollection());
 
-		activatorMock.Verify(x => x.CreateInstance(typeof(Wrapper)), Times.Once());
+		activatorMock.Received(1).CreateInstance(typeof(Wrapper));
 	}
 }
 #endif

--- a/tests/bunit.web.testcomponents.tests/RazorTesting/RazorTestDiscovererTest.cs
+++ b/tests/bunit.web.testcomponents.tests/RazorTesting/RazorTestDiscovererTest.cs
@@ -13,8 +13,8 @@ public class RazorTestDiscovererTest
 	public RazorTestDiscovererTest()
 	{
 		options = TestFrameworkOptions.ForDiscovery();
-		messageBus = Mock.Of<IMessageSink>();
-		attribute = Mock.Of<IReflectionAttributeInfo>();
+		messageBus = Substitute.For<IMessageSink>();
+		attribute = Substitute.For<IReflectionAttributeInfo>();
 	}
 
 	[Fact(DisplayName = "Can find single razor test in test component")]

--- a/tests/bunit.web.testcomponents.tests/RazorTesting/RazorTestSourceInformationProviderTest.cs
+++ b/tests/bunit.web.testcomponents.tests/RazorTesting/RazorTestSourceInformationProviderTest.cs
@@ -8,7 +8,7 @@ namespace Bunit.RazorTesting;
 public sealed class RazorTestSourceInformationProviderTest : IDisposable
 {
 	private readonly TestComponentRenderer renderer = new();
-	private readonly IMessageSink messageBus = Mock.Of<IMessageSink>();
+	private readonly IMessageSink messageBus = Substitute.For<IMessageSink>();
 
 	private RazorTestBase GetTest(Type testComponent, int testIndex)
 	{

--- a/tests/bunit.web.tests/Asserting/CompareToDiffingExtensionsTest.cs
+++ b/tests/bunit.web.tests/Asserting/CompareToDiffingExtensionsTest.cs
@@ -22,8 +22,8 @@ public class CompareToDiffingExtensionsTest : TestContext
 			object p1 = p1Info.ParameterType.ToMockInstance();
 			object p2 = p2Info.ParameterType.ToMockInstance();
 
-			yield return new object[] { method, p1Info.Name!, new object[] { null!, p2! } };
-			yield return new object[] { method, p2Info.Name!, new object[] { p1!, null! } };
+			yield return new object[] { method, p1Info.Name!, new[] { null!, p2! } };
+			yield return new object[] { method, p2Info.Name!, new[] { p1!, null! } };
 		}
 	}
 

--- a/tests/bunit.web.tests/Asserting/DiffAssertExtensionsTest.cs
+++ b/tests/bunit.web.tests/Asserting/DiffAssertExtensionsTest.cs
@@ -44,7 +44,7 @@ public class DiffAssertExtensionsTest
 	[Fact(DisplayName = "ShouldHaveSingleChange returns the single diff in input when there is only one")]
 	public void Test003()
 	{
-		var input = new IDiff[] { Mock.Of<IDiff>() };
+		var input = new[] { Substitute.For<IDiff>() };
 
 		var output = input.ShouldHaveSingleChange();
 
@@ -58,8 +58,8 @@ public class DiffAssertExtensionsTest
 		{
 				new IDiff[]
 				{
-					Mock.Of<IDiff>(),
-					Mock.Of<IDiff>(),
+					Substitute.For<IDiff>(),
+					Substitute.For<IDiff>(),
 				},
 		};
 	}

--- a/tests/bunit.web.tests/Asserting/JSRuntimeAssertExtensionsTest.cs
+++ b/tests/bunit.web.tests/Asserting/JSRuntimeAssertExtensionsTest.cs
@@ -103,7 +103,7 @@ public class JSRuntimeAssertExtensionsTest
 	public void Test201()
 	{
 		var obj = new object();
-		Should.Throw<ActualExpectedAssertException>(() => obj.ShouldBeElementReferenceTo(Mock.Of<IElement>()));
+		Should.Throw<ActualExpectedAssertException>(() => obj.ShouldBeElementReferenceTo(Substitute.For<IElement>()));
 	}
 
 	[Fact(DisplayName = "ShouldBeElementReferenceTo throws if element reference does not point to the provided element")]

--- a/tests/bunit.web.tests/EventDispatchExtensions/GeneralEventDispatchExtensionsTest.cs
+++ b/tests/bunit.web.tests/EventDispatchExtensions/GeneralEventDispatchExtensionsTest.cs
@@ -50,16 +50,16 @@ public class GeneralEventDispatchExtensionsTest : EventDispatchExtensionsTest<Ev
 	[Fact(DisplayName = "TriggerEventAsync throws if element was not rendered through blazor (has a TestRendere in its context)")]
 	public void Test003()
 	{
-		var elmMock = new Mock<IElement>();
-		var docMock = new Mock<IDocument>();
-		var ctxMock = new Mock<IBrowsingContext>();
+		var elmMock = Substitute.For<IElement>();
+		var docMock = Substitute.For<IDocument>();
+		var ctxMock = Substitute.For<IBrowsingContext>();
 
-		elmMock.Setup(x => x.GetAttribute(It.IsAny<string>())).Returns("1");
-		elmMock.SetupGet(x => x.Owner).Returns(docMock.Object);
-		docMock.SetupGet(x => x.Context).Returns(ctxMock.Object);
-		ctxMock.Setup(x => x.GetService<ITestRenderer>()).Returns(() => null!);
+		elmMock.GetAttribute(Arg.Any<string>()).Returns("1");
+		elmMock.Owner.Returns(docMock);
+		docMock.Context.Returns(ctxMock);
+		ctxMock.GetService<ITestRenderer>().Returns(x => null!);
 
-		Should.Throw<InvalidOperationException>(() => elmMock.Object.TriggerEventAsync("click", EventArgs.Empty));
+		Should.Throw<InvalidOperationException>(() => elmMock.TriggerEventAsync("click", EventArgs.Empty));
 	}
 
 	[Fact(DisplayName = "When clicking on an element with an event handler, " +

--- a/tests/bunit.web.tests/TestDoubles/FakeSignOutSessionStateManagerTest.cs
+++ b/tests/bunit.web.tests/TestDoubles/FakeSignOutSessionStateManagerTest.cs
@@ -18,7 +18,7 @@ public class FakeSignOutSessionStateManagerTest : TestContext
 	[Fact]
 	public void ShouldReturnSignOutStateOnValidateSignOutState()
 	{
-		var cut = new FakeSignOutSessionStateManager(Mock.Of<IJSRuntime>());
+		var cut = new FakeSignOutSessionStateManager(Substitute.For<IJSRuntime>());
 		cut.SetSignOutState();
 
 		var wasValidate = cut.ValidateSignOutState().Result;

--- a/tests/bunit.web.tests/TestUtilities/MockingHelpers.cs
+++ b/tests/bunit.web.tests/TestUtilities/MockingHelpers.cs
@@ -5,10 +5,6 @@ namespace Bunit.TestUtilities;
 /// </summary>
 public static class MockingHelpers
 {
-	private static readonly MethodInfo MockOfInfo = typeof(Mock)
-		.GetMethods()
-		.First(x => string.Equals(x.Name, nameof(Mock.Of), StringComparison.Ordinal) && x.GetParameters().Length == 0);
-
 	private static readonly Type DelegateType = typeof(MulticastDelegate);
 	private static readonly Type StringType = typeof(string);
 
@@ -24,15 +20,11 @@ public static class MockingHelpers
 
 		if (type.IsMockable())
 		{
-			var result = MockOfInfo.MakeGenericMethod(type).Invoke(null, Array.Empty<object>());
-
-			if (result is null)
-				throw new NotSupportedException($"Cannot create an mock of {type.FullName}.");
-
-			return result;
+			var result = Substitute.For(new[] { type }, Array.Empty<object>());
+			return result ?? throw new NotSupportedException($"Cannot create an mock of {type.FullName}.");
 		}
 
-		if (type.Equals(StringType))
+		if (type == StringType)
 		{
 			return string.Empty;
 		}
@@ -48,16 +40,11 @@ public static class MockingHelpers
 		if (type is null)
 			throw new ArgumentNullException(nameof(type));
 
-		if (type.IsSealed)
-			return type.IsDelegateType();
-		return true;
+		return !type.IsSealed || type.IsDelegateType();
 	}
 
 	/// <summary>
 	/// Gets whether a type is a delegate type.
 	/// </summary>
-	public static bool IsDelegateType(this Type type)
-	{
-		return Equals(type, DelegateType);
-	}
+	public static bool IsDelegateType(this Type type) => type == DelegateType;
 }


### PR DESCRIPTION
This PR removes Moq in favor of NSubstitute.

Closes #1174 

I did refrain from changing the docs as many people are still using Moq, so I am fine with having Moq there for the time being.