### PR TITLE
feat: Easier handling of triggering stub events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to **bUnit** will be documented in this file. The project ad
 
 - `net8.0` support
 - Increased timeout of `WaitForAssertion` to infinite when a debugger is attached. By [@linkdotnet](https://github.com/linkdotnet).
+- Easier overloads for Stub's to invoke `EventCallback`s
 
 ### Fixed
 

--- a/src/bunit.web/Extensions/RenderedComponentStubExtensions.cs
+++ b/src/bunit.web/Extensions/RenderedComponentStubExtensions.cs
@@ -1,0 +1,48 @@
+#if NET5_0_OR_GREATER
+using System.Linq.Expressions;
+using Bunit.TestDoubles;
+
+namespace Bunit;
+
+/// <summary>
+/// Extension methods for using component doubles.
+/// </summary>
+public static class RenderedComponentStubExtensions
+{
+	/// <summary>
+	/// Invokes the event callback from the stub.
+	/// </summary>
+	public static Task InvokeEventCallback<TComponent>(this IRenderedComponent<Stub<TComponent>> component,
+		Expression<Func<TComponent, EventCallback>> selector) where TComponent : IComponent
+	{
+		if (component is null)
+			throw new ArgumentNullException(nameof(component));
+
+		return component.Instance.InvokeEventCallback(selector);
+	}
+
+	/// <summary>
+	/// Invokes the event callback from the stub.
+	/// </summary>
+	public static Task InvokeEventCallback<TComponent, T>(this IRenderedComponent<Stub<TComponent>> component,
+		Expression<Func<TComponent, EventCallback<T>>> selector, T value) where TComponent : IComponent
+	{
+		if (component is null)
+			throw new ArgumentNullException(nameof(component));
+
+		return component.Instance.InvokeEventCallback(selector, value);
+	}
+
+	/// <summary>
+	/// Gets the parameters that was passed to the <typeparamref name="TComponent"/>
+	/// </summary>
+	public static T GetParameter<TComponent, T>(this IRenderedComponent<Stub<TComponent>> component,
+		Expression<Func<TComponent, T>> selector) where TComponent : IComponent
+	{
+		if (component is null)
+			throw new ArgumentNullException(nameof(component));
+
+		return component.Instance.Parameters.Get(selector);
+	}
+}
+#endif

--- a/src/bunit.web/Extensions/RenderedFragmentExtensions.cs
+++ b/src/bunit.web/Extensions/RenderedFragmentExtensions.cs
@@ -1,5 +1,7 @@
+using System.Linq.Expressions;
 using AngleSharp.Dom;
 using Bunit.Rendering;
+using Bunit.TestDoubles;
 
 namespace Bunit;
 

--- a/src/bunit.web/TestDoubles/Components/ComponentDoubleBase{TComponent}.cs
+++ b/src/bunit.web/TestDoubles/Components/ComponentDoubleBase{TComponent}.cs
@@ -16,6 +16,11 @@ public abstract class ComponentDoubleBase<TComponent> : IComponent
 	protected static readonly Type DoubledType = typeof(TComponent);
 
 	/// <summary>
+	/// Invokes the given <see cref="Func{TResult}"/> in the context of the associated <see cref="Renderer"/>.
+	/// </summary>
+	protected Task InvokeAsync(Func<Task> workItem) => renderHandle.Dispatcher.InvokeAsync(workItem);
+
+	/// <summary>
 	/// Gets the parameters that was passed to the <typeparamref name="TComponent"/>
 	/// that this stub replaced in the component tree.
 	/// </summary>

--- a/src/bunit.web/TestDoubles/Components/Stub{TComponent}.cs
+++ b/src/bunit.web/TestDoubles/Components/Stub{TComponent}.cs
@@ -1,5 +1,6 @@
 #if NET5_0_OR_GREATER
 using System.Diagnostics;
+using System.Linq.Expressions;
 
 namespace Bunit.TestDoubles;
 
@@ -31,6 +32,27 @@ public sealed class Stub<TComponent> : ComponentDoubleBase<TComponent>
 			replacementFragment = replacementRenderFragment;
 		else if (replacement is not null)
 			throw new ArgumentException($"The type of replacement is not supported. Replacement type = {replacement.GetType()}", nameof(replacement));
+	}
+
+	/// <summary>
+	/// Triggers an event callback from the stub.
+	/// </summary>
+	/// <param name="selector">Event to trigger.</param>
+	public Task InvokeEventCallback(Expression<Func<TComponent, EventCallback>> selector)
+	{
+		var callback = Parameters.Get(selector);
+		return InvokeAsync(callback.InvokeAsync);
+	}
+
+	/// <summary>
+	/// Triggers an event callback from the stub.
+	/// </summary>
+	/// <param name="selector">Event to trigger.</param>
+	/// <param name="value">Value to pass to the event callback.</param>
+	public Task InvokeEventCallback<T>(Expression<Func<TComponent, EventCallback<T>>> selector, T? value)
+	{
+		var callback = Parameters.Get(selector);
+		return InvokeAsync(() => callback.InvokeAsync(value));
 	}
 
 	/// <inheritdoc/>

--- a/tests/bunit.testassets/SampleComponents/DisposeComponents/DisplayInput.razor
+++ b/tests/bunit.testassets/SampleComponents/DisposeComponents/DisplayInput.razor
@@ -1,0 +1,5 @@
+<p>User wrote: @value</p>
+<InputText @bind-Value="value" />
+@code {
+	private string value;
+}

--- a/tests/bunit.web.tests/TestDoubles/Components/StubTest.cs
+++ b/tests/bunit.web.tests/TestDoubles/Components/StubTest.cs
@@ -1,3 +1,6 @@
+using Bunit.TestAssets.SampleComponents.DisposeComponents;
+using Microsoft.AspNetCore.Components.Forms;
+
 #if NET5_0_OR_GREATER
 namespace Bunit.TestDoubles.Components;
 
@@ -25,6 +28,18 @@ public class StubTest : TestContext
 				ps => ps.ShouldContain(x => x.Key == nameof(Simple1.Header) && header.Equals(x.Value)),
 				ps => ps.ShouldContain(x => x.Key == nameof(Simple1.AttrValue) && attrValue.Equals(x.Value)),
 				ps => ps.Count.ShouldBe(2));
+	}
+
+	[Fact(DisplayName = "Stub<TComponent> can invoke event callbacks")]
+	public async Task Test003()
+	{
+		ComponentFactories.AddStub<InputText>();
+		var cut = RenderComponent<DisplayInput>();
+		var stubbedInput = cut.FindComponent<Stub<InputText>>();
+		
+		await stubbedInput.InvokeEventCallback(t => t.ValueChanged, "Hello World");
+		
+		cut.Find("p").MarkupMatches("<p>User wrote: Hello World</p>");
 	}
 }
 #endif


### PR DESCRIPTION
Building on top of #1186 here is a proposal from my side.

The main use we want to cover is invoking `EventCallback`'s - so I would go into the race with only supporting those in the beginning. The new and easy way of doing so would be:
```csharp
ComponentFactories.AddStub<InputText>();
var cut = RenderComponent<DisplayInput>();
var stubbedInput = cut.FindComponent<Stub<InputText>>();

await stubbedInput.InvokeEventCallback(t => t.ValueChanged, "Hello World");

cut.Find("p").MarkupMatches("<p>User wrote: Hello World</p>");
```

If the `EventCallback` has no value, then the second parameter can be omitted. 

In theory we could built source generators that sit on top of `Stub<InputText>` and call the methods the same name - but that seems far more complex and less stable.