### PR TITLE
Block until SetParametersAndRender / Render calls complete

### DIFF
--- a/.github/workflows/release-preview.yml
+++ b/.github/workflows/release-preview.yml
@@ -12,7 +12,7 @@ on:
       nugetRelease:
         description: 'Release to NuGet? Set to "true" to release to NuGet.org as well as GPR.'
         required: true
-        default: 'false'
+        default: 'true'
 
 jobs:
   release-preview:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to **bUnit** will be documented in this file. The project ad
 
 ## [Unreleased]
 
+### Fixed
+
+- If the renderer was not idle when calling `SetParametersAndRender`, the method could return before the parameters were set and the component under test had finished rendering. This was a regression that happened in v1.21.9. Reported by [@Skintkingle](https://github.com/Skintkingle]) in <https://github.com/bUnit-dev/bUnit/issues/1188>. Fixed by [@egil](https://github.com/egil).
+
 ### Added
 
 - `net8.0` support

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -51,7 +51,7 @@
 	<!-- Shared code analyzers used for all projects in the solution -->
 	<ItemGroup Label="Code Analyzers">
 		<PackageReference Include="AsyncFixer" Version="1.6.0" PrivateAssets="All" />
-		<PackageReference Include="SonarAnalyzer.CSharp" Version="9.7.0.75501" PrivateAssets="All" />
+		<PackageReference Include="SonarAnalyzer.CSharp" Version="9.9.0.77355" PrivateAssets="All" />
 	</ItemGroup>
 
 	<ItemGroup Label="Implicit usings"

--- a/src/bunit.core/Extensions/RenderedComponentRenderExtensions.cs
+++ b/src/bunit.core/Extensions/RenderedComponentRenderExtensions.cs
@@ -30,7 +30,15 @@ public static class RenderedComponentRenderExtensions
 			throw new ArgumentNullException(nameof(renderedComponent));
 
 		var renderer = renderedComponent.Services.GetRequiredService<TestRenderer>();
-		renderer.SetDirectParameters(renderedComponent, parameters);
+
+		try
+		{
+			renderer.SetDirectParametersAsync(renderedComponent, parameters).GetAwaiter().GetResult();
+		}
+		catch (AggregateException e) when (e.InnerExceptions.Count == 1)
+		{
+			ExceptionDispatchInfo.Capture(e.InnerExceptions[0]).Throw();
+		}
 	}
 
 	/// <summary>

--- a/src/bunit.web.testcomponents/bunit.web.testcomponents.csproj
+++ b/src/bunit.web.testcomponents/bunit.web.testcomponents.csproj
@@ -21,8 +21,8 @@
 	<ItemGroup>
 		<PackageReference Include="SourceFileFinder" Version="1.1.0" />
 		<PackageReference Include="xunit.assert" Version="2.4.2" />
-		<PackageReference Include="xunit.extensibility.core" Version="2.5.0" />
-		<PackageReference Include="xunit.extensibility.execution" Version="2.5.0" />
+		<PackageReference Include="xunit.extensibility.core" Version="2.4.2" />
+		<PackageReference Include="xunit.extensibility.execution" Version="2.4.2" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">

--- a/src/bunit.web/JSInterop/InvocationHandlers/Implementation/VirtualizeJSRuntimeInvocationHandler.cs
+++ b/src/bunit.web/JSInterop/InvocationHandlers/Implementation/VirtualizeJSRuntimeInvocationHandler.cs
@@ -24,11 +24,10 @@ namespace Bunit.JSInterop.InvocationHandlers.Implementation
 
 			var dotNetObjectReferenceVirtualizeJsInteropType = typeof(DotNetObjectReference<>).MakeGenericType(virtualizeJsInteropType);
 
-			var dotNetObjectReferenceValuePropertyInfo = dotNetObjectReferenceVirtualizeJsInteropType
-				.GetProperty("Value", BindingFlags.Public | BindingFlags.Instance)
+			var dotNetObjectReferenceValuePropertyInfo = dotNetObjectReferenceVirtualizeJsInteropType.GetProperty("Value", BindingFlags.Public | BindingFlags.Instance)
 				?? throw new InvalidOperationException("Did not find the Value property on the DotNetObjectReference<VirtualizeJsInterop> type.");
 
-			var onSpacerBeforeVisibleMethodInfo = virtualizeJsInteropType?.GetMethod("OnSpacerBeforeVisible")
+			var onSpacerBeforeVisibleMethodInfo = virtualizeJsInteropType.GetMethod("OnSpacerBeforeVisible")
 				?? throw new InvalidOperationException("Did not find the OnSpacerBeforeVisible method on the VirtualizeJsInterop type.");
 
 			return (dotNetObjectReferenceValuePropertyInfo, onSpacerBeforeVisibleMethodInfo);

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -20,10 +20,14 @@
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
 		<PackageReference Include="NSubstitute" Version="5.0.0" />
 		<PackageReference Include="Shouldly" Version="4.2.1" />
-		<PackageReference Include="xunit" Version="2.5.0" />
-		<PackageReference Include="Xunit.Combinatorial" Version="1.6.24" />
 		<PackageReference Include="coverlet.msbuild" Version="6.0.0" PrivateAssets="All" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+		<PackageReference Include="Xunit.Combinatorial" Version="1.6.24" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<!-- DO NOT UPGRADE TO versions > 2.4.2 as they do not support .net5 or older -->
+		<PackageReference Include="xunit" Version="2.4.2" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 			<NoWarn>NU1701</NoWarn>

--- a/tests/bunit.core.tests/Rendering/TestRendererTest.cs
+++ b/tests/bunit.core.tests/Rendering/TestRendererTest.cs
@@ -488,7 +488,7 @@ public partial class TestRendererTest : TestContext
 		cut.Instance.AfterRenderCount.ShouldBe(2);
 		cut.Instance.AfterRenderAsyncCount.ShouldBe(2);
 	}
-	
+
 #if NET8_0_OR_GREATER
 	[Fact(DisplayName = "Can render components that have a RenderMode attribute")]
 	public void Test209()
@@ -632,7 +632,7 @@ public partial class TestRendererTest : TestContext
 			throw new InvalidOperationException();
 		}
 	}
-	
+
 #if NET8_0_OR_GREATER
 	[RenderModeServer]
 	private sealed class RenderModeServerComponent : ComponentBase

--- a/tests/bunit.web.testcomponents.tests/RazorTesting/RazorTestSourceInformationProviderTest.cs
+++ b/tests/bunit.web.testcomponents.tests/RazorTesting/RazorTestSourceInformationProviderTest.cs
@@ -32,8 +32,8 @@ public sealed class RazorTestSourceInformationProviderTest : IDisposable
 		var sourceInfo = sut.GetSourceInformation(target, GetTest(target, testNumber), testNumber);
 
 		sourceInfo.ShouldNotBeNull();
-		sourceInfo?.FileName.ShouldEndWith($"SampleComponents{Path.DirectorySeparatorChar}{target.Name}.razor", Case.Insensitive);
-		sourceInfo?.LineNumber.ShouldBe(expectedLineNumber);
+		sourceInfo.FileName.ShouldEndWith($"SampleComponents{Path.DirectorySeparatorChar}{target.Name}.razor", Case.Insensitive);
+		sourceInfo.LineNumber.ShouldBe(expectedLineNumber);
 	}
 
 	public void Dispose() => renderer.Dispose();

--- a/tests/bunit.web.testcomponents.tests/bunit.web.testcomponents.tests.csproj
+++ b/tests/bunit.web.testcomponents.tests/bunit.web.testcomponents.tests.csproj
@@ -8,9 +8,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="xunit.extensibility.core" Version="2.5.0" />
-		<PackageReference Include="xunit.extensibility.execution" Version="2.5.0" />
-		<PackageReference Include="xunit.runner.utility" Version="2.5.0" />
+		<PackageReference Include="xunit.runner.utility" Version="2.4.2" />
 		<PackageReference Update="Shouldly" Version="4.1.0">
 			<!-- some test fails with > 4.1.0 -->
 			<NoWarn>NU1605</NoWarn>

--- a/tests/bunit.web.testcomponents.tests/bunit.web.testcomponents.tests.csproj
+++ b/tests/bunit.web.testcomponents.tests/bunit.web.testcomponents.tests.csproj
@@ -15,7 +15,6 @@
 			<!-- some test fails with > 4.1.0 -->
 			<NoWarn>NU1605</NoWarn>
 		</PackageReference>
-		<PackageReference Update="SonarAnalyzer.CSharp" Version="9.7.0.75501" />	
 	</ItemGroup>
 
 	<ItemGroup>

--- a/tests/bunit.web.tests/TestDoubles/Authorization/FakeAuthenticationStateProviderTest.cs
+++ b/tests/bunit.web.tests/TestDoubles/Authorization/FakeAuthenticationStateProviderTest.cs
@@ -15,8 +15,8 @@ public class FakeAuthenticationStateProviderTest
 		// assert
 		Assert.NotNull(authState.User);
 		Assert.NotNull(authState.User.Identity);
-		Assert.Equal("TestUser", authState?.User?.Identity?.Name);
-		Assert.True(authState?.User?.Identity?.IsAuthenticated);
+		Assert.Equal("TestUser", authState.User?.Identity?.Name);
+		Assert.True(authState.User?.Identity?.IsAuthenticated);
 	}
 
 	[Fact(DisplayName = "Create unauthenticated AuthenticationState")]

--- a/tests/bunit.web.tests/TestDoubles/Authorization/FakeAuthorizationPolicyProviderTest.cs
+++ b/tests/bunit.web.tests/TestDoubles/Authorization/FakeAuthorizationPolicyProviderTest.cs
@@ -45,10 +45,10 @@ public class FakeAuthorizationPolicyProviderTest
 
 		// assert
 		Assert.NotNull(policy);
-		Assert.Equal(1, policy?.AuthenticationSchemes?.Count);
-		Assert.Equal("TestScheme:FooBar", policy?.AuthenticationSchemes?[0]);
-		Assert.Equal(1, policy?.Requirements?.Count);
-		Assert.IsType<TestPolicyRequirement>(policy?.Requirements?[0]);
+		Assert.Equal(1, policy.AuthenticationSchemes?.Count);
+		Assert.Equal("TestScheme:FooBar", policy.AuthenticationSchemes?[0]);
+		Assert.Equal(1, policy.Requirements?.Count);
+		Assert.IsType<TestPolicyRequirement>(policy.Requirements?[0]);
 	}
 
 	[Fact(DisplayName = "Get policy based on name not in the PolicyProvider.")]
@@ -63,10 +63,10 @@ public class FakeAuthorizationPolicyProviderTest
 
 		// assert
 		Assert.NotNull(policy);
-		Assert.Equal(1, policy?.AuthenticationSchemes?.Count);
-		Assert.Equal("TestScheme:OtherPolicy", policy?.AuthenticationSchemes?[0]);
-		Assert.Equal(1, policy?.Requirements?.Count);
-		Assert.IsType<TestPolicyRequirement>(policy?.Requirements?[0]);
+		Assert.Equal(1, policy.AuthenticationSchemes?.Count);
+		Assert.Equal("TestScheme:OtherPolicy", policy.AuthenticationSchemes?[0]);
+		Assert.Equal(1, policy.Requirements?.Count);
+		Assert.IsType<TestPolicyRequirement>(policy.Requirements?[0]);
 	}
 
 	[Fact(DisplayName = "Set Policies with empty scheme name.")]


### PR DESCRIPTION
If the renderer was not idle when calling `SetParametersAndRender`, the method could return before the parameters were set and the component under test had finished rendering. This was a regression that happened in v1.21.9.

### PR meta checklist
- [x] Pull request is targeted at `main` branch for code   
  or targeted at `stable` branch for documentation that is live on bunit.dev.
- [x] Pull request is linked to all related issues, if any.
- [x] I have read the _CONTRIBUTING.md_ document.

### Code PR specific checklist
- [x] My code follows the code style of this project and AspNetCore coding guidelines.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] I have updated the appropriate sub section in the _CHANGELOG.md_.
- [x] I have added, updated or removed tests to according to my changes.
  - [x] All tests passed.

fixes #1188
