### PR TITLE
fix: use xunit.runner.visualstudio 2.4.5 with xunit 2.5.0

### DIFF
--- a/src/bunit.web.testcomponents/bunit.web.testcomponents.csproj
+++ b/src/bunit.web.testcomponents/bunit.web.testcomponents.csproj
@@ -20,9 +20,9 @@
 
 	<ItemGroup>
 		<PackageReference Include="SourceFileFinder" Version="1.1.0" />
-		<PackageReference Include="xunit.assert" Version="2.4.2" />
-		<PackageReference Include="xunit.extensibility.core" Version="2.4.2" />
-		<PackageReference Include="xunit.extensibility.execution" Version="2.4.2" />
+		<PackageReference Include="xunit.assert" Version="2.5.0" />
+		<PackageReference Include="xunit.extensibility.core" Version="2.5.0" />
+		<PackageReference Include="xunit.extensibility.execution" Version="2.5.0" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -25,9 +25,9 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<!-- DO NOT UPGRADE TO versions > 2.4.2 as they do not support .net5 or older -->
-		<PackageReference Include="xunit" Version="2.4.2" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
+		<PackageReference Include="xunit" Version="2.5.0" />
+		<!-- DO NOT UPGRADE TO versions > 2.4.5 as they do not support .net5 or older -->
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 			<NoWarn>NU1701</NoWarn>

--- a/tests/bunit.web.testcomponents.tests/bunit.web.testcomponents.tests.csproj
+++ b/tests/bunit.web.testcomponents.tests/bunit.web.testcomponents.tests.csproj
@@ -8,7 +8,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="xunit.runner.utility" Version="2.4.2" />
+		<PackageReference Include="xunit.runner.utility" Version="2.5.0" />
 		<PackageReference Update="Shouldly" Version="4.1.0">
 			<!-- some test fails with > 4.1.0 -->
 			<NoWarn>NU1605</NoWarn>


### PR DESCRIPTION
Attempting to use a mix of xunit versions together