### PR TITLE
Access component

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -67,3 +67,9 @@ The `TestContext` and `TestContextBase` classes have been merged into a single `
 ## `TestContext` implements `IDisposable` and `IAsyncDisposable`
 The `TestContext` now implements `IDisposable` and `IAsyncDisposable`. In version 1.x, `TestContext` only implemented `IDisposable` and cleaned up asynchronous objects in the synchronous `Dispose` method. This is no longer the case, and asynchronous objects are now cleaned up in the `DisposeAsync` method.
 If you register services into the container that implement `IAsyncDisposable` make sure that the test framework calls the right method.
+
+## Removed `IRenderedComponent<TComponent>.Instance`
+The `IRenderedComponent<TComponent>.Instance` property has been removed. If you used `Instance`, you should replace it with `IRenderedComponent<TComponent>.AccessInstance` method.
+
+## Removed `IRenderedFragment.InvokeAsync`
+With the introduction of `AccessInstance`, the direct call to `IRenderedFragment.InvokeAsync` has been removed.

--- a/docs/samples/tests/xunit/ReRenderTest.cs
+++ b/docs/samples/tests/xunit/ReRenderTest.cs
@@ -47,7 +47,7 @@ public class ReRenderTest : TestContext
 
     // Indirectly re-renders through the call to StateHasChanged
     // in the Calculate(x, y) method.
-    cut.InvokeAsync(() => cut.Instance.Calculate(1, 2));
+    cut.AccessInstance(c => c.Calculate(1, 2));
 
     cut.MarkupMatches("<output>3</output>");
   }

--- a/docs/samples/tests/xunit/WeatherForecastsTest.cs
+++ b/docs/samples/tests/xunit/WeatherForecastsTest.cs
@@ -21,6 +21,8 @@ public class WeatherForecastsTest : TestContext
     var cut = Render<WeatherForecasts>();
 
     // Assert that service is injected
-    Assert.NotNull(cut.Instance.Forecasts);
+    WeatherForecast[] weatherForecast = null;
+    cut.AccessInstance(c => weatherForecast = c.Forecasts);
+    Assert.NotNull(weatherForecast);
   }
 }

--- a/docs/site/docs/interaction/trigger-renders.md
+++ b/docs/site/docs/interaction/trigger-renders.md
@@ -11,7 +11,7 @@ In `.razor` based tests, using the <xref:Bunit.TestContext>'s <xref:Bunit.TestCo
 
 If you have a <xref:Bunit.IRenderedFragment> or a <xref:Bunit.IRenderedComponent`1> in a test, but need a child component's <xref:Bunit.IRenderedComponent`1>, then use the `FindComponent<TComponent>()` or the `FindComponents<TComponent>()` methods, which traverse down the render tree and finds rendered components.
 
-With a <xref:Bunit.IRenderedComponent`1>, it is possible to cause the component to render again directly through the <xref:Bunit.RenderedComponentRenderExtensions.Render``1(Bunit.IRenderedComponent{``0},System.Nullable{Action{Bunit.ComponentParameterCollectionBuilder{``0}}})> method, or indirectly through the [`InvokeAsync()`](xref:Bunit.IRenderedFragment.Bunit.RenderedFragmentInvokeAsyncExtensions.InvokeAsync(Action)) method.
+With a <xref:Bunit.IRenderedComponent`1>, it is possible to cause the component to render again directly through the <xref:Bunit.RenderedComponentRenderExtensions.Render``1(Bunit.IRenderedComponent{``0},System.Nullable{Action{Bunit.ComponentParameterCollectionBuilder{``0}}})> method.
 
 Let's look at how to use each of these methods to cause a re-render.
 
@@ -36,24 +36,3 @@ The highlighted line shows the call to [`Render()`](xref:Bunit.RenderedComponent
 
 > [!NOTE]
 > Passing parameters to components through the [`Render(...)`](xref:Bunit.RenderedComponentRenderExtensions.Render``1(Bunit.IRenderedComponent{``0},System.Nullable{Action{Bunit.ComponentParameterCollectionBuilder{``0}}})) methods is identical to doing it with the `Render<TComponent>(...)` methods, described in detail on the <xref:passing-parameters-to-components> page.
-
-## InvokeAsync
-
-Invoking methods on a component under test, which causes a render, e.g. by calling `StateHasChanged`, can result in the following error, if the caller is running on another thread than the renderer's thread:
-
-> The current thread is not associated with the Dispatcher. Use `InvokeAsync()` to switch execution to the Dispatcher when triggering rendering or component state.
-
-If you receive this error, you need to invoke your method inside an `Action` delegate passed to the `InvokeAsync()` method.
-
-Let’s look at an example of this, using the `<Calc>` component listed below:
-
-[!code-cshtml[Calc.razor](../../../samples/components/Calc.razor)]
-
-To invoke the `Calculate()` method on the component instance, do the following:
-
-[!code-csharp[](../../../samples/tests/xunit/ReRenderTest.cs?start=47&end=53&highlight=5)]
-
-The highlighted line shows the call to `InvokeAsync()`, which is passed an `Action` delegate that calls the `Calculate` method.
-
-> [!TIP]
-> The instance of a component under test is available through the <xref:Bunit.IRenderedComponent`1.Instance> property.

--- a/docs/site/docs/providing-input/substituting-components.md
+++ b/docs/site/docs/providing-input/substituting-components.md
@@ -181,8 +181,8 @@ public void Foo_Doesnt_Have_A_Bar_But_Mock()
  
   // Verify that the Bar component has 
   // been substituted in the render tree
-  IRenderedComponent<Bar> bar = cut.FindComponent<Bar>();  
-  Assert.Same(barMock.Object, bar.Instance);
+  IRenderedComponent<Bar> bar = cut.FindComponent<Bar>();
+  bar.AccessInstance(c => Assert.Same(barMock.Object, c));
 }
 ```
 
@@ -204,7 +204,7 @@ public void Foo_Doesnt_Have_A_Bar_But_Mock()
   // Verify that the Bar component has 
   // been substituted in the render tree
   IRenderedComponent<Bar> bar = cut.FindComponent<Bar>();  
-  Assert.Same(barMock, bar.Instance);
+  bar.AccessInstance(c => Assert.Same(barMock.Object, c));
 }
 ```
 

--- a/docs/site/docs/verification/verify-component-state.md
+++ b/docs/site/docs/verification/verify-component-state.md
@@ -5,7 +5,7 @@ title: Verifying the state of a component under test
 
 # Verifying the state of a component
 
-The instance of a component under test is available through the <xref:Bunit.IRenderedComponent`1.Instance> property on the <xref:Bunit.IRenderedComponent`1> type. When using the <xref:Bunit.TestContext>'s `Render<TComponent>()` method, this is the type returned.
+The instance of a component under test is available through the <xref:Bunit.IRenderedComponent`1.AccessInstance> method on the <xref:Bunit.IRenderedComponent`1> type. When using the <xref:Bunit.TestContext>'s `Render<TComponent>()` method, this is the type returned.
 
 In `.razor` based tests, using the <xref:Bunit.TestContext>'s <xref:Bunit.TestContext.Render``1(RenderFragment)> method also returns an <xref:Bunit.IRenderedComponent`1> (as opposed to the <xref:Bunit.TestContext.Render(RenderFragment)> method which returns the more simple <xref:Bunit.IRenderedFragment>).
 
@@ -14,18 +14,17 @@ In `.razor` based tests, using the <xref:Bunit.TestContext>'s <xref:Bunit.TestCo
 
 ## Inspecting the Component Under Test
 
-The <xref:Bunit.IRenderedComponent`1.Instance> property on the <xref:Bunit.IRenderedComponent`1> type provides access to the component under test. For example:
+The <xref:Bunit.IRenderedComponent`1.AccessInstance> method on the <xref:Bunit.IRenderedComponent`1> type provides access to the component under test. For example:
 
 ```csharp
 IRenderedComponent<Alert> cut = Render<Alert>();
 
-Alert alert = cut.Instance;
-
 // Assert against <Alert /> instance
+cut.AccessInstance(c => Assert.Equal(c.Message, "Foo"));
 ```
 
 > [!WARNING]
-> While it is possible to set `[Parameter]` and `[CascadingParameter]` properties directly through the <xref:Bunit.IRenderedComponent`1.Instance> property on the <xref:Bunit.IRenderedComponent`1> type, doing so does not implicitly trigger a render and the component life-cycle methods are not called. 
+> While it is possible to set `[Parameter]` and `[CascadingParameter]` properties directly through the <xref:Bunit.IRenderedComponent`1.AccessInstance> method on the <xref:Bunit.IRenderedComponent`1> type, doing so does not implicitly trigger a render and the component life-cycle methods are not called. 
 > 
 > The correct approach is to set parameters through the [`Render()`](xref:Bunit.RenderedComponentRenderExtensions.Render``1(Bunit.IRenderedComponent{``0},System.Nullable{Action{Bunit.ComponentParameterCollectionBuilder{``0}}})) methods. See the <xref:trigger-renders> page for more on this.
 

--- a/src/bunit/Extensions/InputFile/InputFileExtensions.cs
+++ b/src/bunit/Extensions/InputFile/InputFileExtensions.cs
@@ -30,6 +30,6 @@ public static class InputFileExtensions
 			file.Content));
 
 		var args = new InputFileChangeEventArgs(browserFiles.ToArray());
-		inputFileComponent.InvokeAsync(() => inputFileComponent.Instance.OnChange.InvokeAsync(args));
+		inputFileComponent.AccessInstance(i => i.OnChange.InvokeAsync(args));
 	}
 }

--- a/src/bunit/Extensions/RenderedFragmentInvokeAsyncExtensions.cs
+++ b/src/bunit/Extensions/RenderedFragmentInvokeAsyncExtensions.cs
@@ -5,7 +5,7 @@ namespace Bunit;
 /// <summary>
 /// InvokeAsync extensions methods on <see cref="IRenderedFragment"/>.
 /// </summary>
-public static class RenderedFragmentInvokeAsyncExtensions
+internal static class RenderedFragmentInvokeAsyncExtensions
 {
 	/// <summary>
 	/// Invokes the given <paramref name="workItem"/> in the context of the associated <see cref="BunitRenderer"/>.
@@ -14,21 +14,6 @@ public static class RenderedFragmentInvokeAsyncExtensions
 	/// <param name="workItem">The work item to execute on the renderer's thread.</param>
 	/// <returns>A <see cref="Task"/> that will be completed when the action has finished executing or is suspended by an asynchronous operation.</returns>
 	public static Task InvokeAsync(this IRenderedFragment renderedFragment, Action workItem)
-	{
-		ArgumentNullException.ThrowIfNull(renderedFragment);
-
-		var renderer = renderedFragment.Services.GetRequiredService<BunitRenderer>();
-		renderer.UnblockRendering();
-		return renderer.Dispatcher.InvokeAsync(workItem);
-	}
-
-	/// <summary>
-	/// Invokes the given <paramref name="workItem"/> in the context of the associated <see cref="BunitRenderer"/>.
-	/// </summary>
-	/// <param name="renderedFragment">The rendered component whose dispatcher to invoke with.</param>
-	/// <param name="workItem">The work item to execute on the renderer's thread.</param>
-	/// <returns>A <see cref="Task"/> that will be completed when the action has finished executing.</returns>
-	public static Task InvokeAsync(this IRenderedFragment renderedFragment, Func<Task> workItem)
 	{
 		ArgumentNullException.ThrowIfNull(renderedFragment);
 

--- a/src/bunit/Extensions/WaitForHelpers/RenderedFragmentWaitForHelperExtensions.cs
+++ b/src/bunit/Extensions/WaitForHelpers/RenderedFragmentWaitForHelperExtensions.cs
@@ -29,6 +29,27 @@ public static class RenderedFragmentWaitForHelperExtensions
 	}
 
 	/// <summary>
+	/// Wait until the provided <paramref name="statePredicate"/> action returns true,
+	/// or the <paramref name="timeout"/> is reached (default is one second).
+	///
+	/// The <paramref name="statePredicate"/> is evaluated initially, and then each time
+	/// the <paramref name="renderedComponent"/> renders.
+	/// </summary>
+	/// <param name="renderedComponent">The render fragment or component to attempt to verify state against.</param>
+	/// <param name="statePredicate">The predicate to invoke after each render, which must returns <c>true</c> when the desired state has been reached.</param>
+	/// <param name="timeout">The maximum time to wait for the desired state.</param>
+	/// <exception cref="WaitForFailedException">Thrown if the <paramref name="statePredicate"/> throw an exception during invocation, or if the timeout has been reached. See the inner exception for details.</exception>
+	public static async Task WaitForStateAsync<TComponent>(this IRenderedComponent<TComponent> renderedComponent, Func<TComponent, bool> statePredicate, TimeSpan? timeout = null)
+		where TComponent : IComponent
+	{
+		//// TODO stgi/egil: Do we want this?
+		//// It is a convenience method, but it is not clear that it is a good idea to have it.
+		using var waiter = new WaitForStateHelper<TComponent>(renderedComponent, statePredicate, timeout);
+
+		await waiter.WaitTask;
+	}
+
+	/// <summary>
 	/// Wait until the provided <paramref name="assertion"/> passes (i.e. does not throw an
 	/// exception), or the <paramref name="timeout"/> is reached (default is one second).
 	///

--- a/src/bunit/Extensions/WaitForHelpers/WaitForStateHelper{TComponent}.cs
+++ b/src/bunit/Extensions/WaitForHelpers/WaitForStateHelper{TComponent}.cs
@@ -1,0 +1,41 @@
+using Bunit.Rendering;
+
+namespace Bunit.Extensions.WaitForHelpers;
+
+/// <summary>
+/// Represents an async wait helper, that will wait for a specified time for a state predicate to pass.
+/// </summary>
+public class WaitForStateHelper<TComponent> : WaitForHelper<object?>
+	where TComponent : IComponent
+{
+	internal const string TimeoutBeforePassMessage = "The state predicate did not pass before the timeout period passed.";
+	internal const string ExceptionInPredicateMessage = "The state predicate throw an unhandled exception.";
+
+	/// <inheritdoc/>
+	protected override string? TimeoutErrorMessage => TimeoutBeforePassMessage;
+
+	/// <inheritdoc/>
+	protected override string? CheckThrowErrorMessage => ExceptionInPredicateMessage;
+
+	/// <inheritdoc/>
+	protected override bool StopWaitingOnCheckException => true;
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="WaitForStateHelper"/> class,
+	/// which will wait until the provided <paramref name="statePredicate"/> action returns true,
+	/// or the <paramref name="timeout"/> is reached (default is one second).
+	/// </summary>
+	/// <remarks>
+	/// The <paramref name="statePredicate"/> is evaluated initially, and then each time the <paramref name="renderedFragment"/> renders.
+	/// </remarks>
+	/// <param name="renderedFragment">The render fragment or component to attempt to verify state against.</param>
+	/// <param name="statePredicate">The predicate to invoke after each render, which must returns <c>true</c> when the desired state has been reached.</param>
+	/// <param name="timeout">The maximum time to wait for the desired state.</param>
+	/// <exception cref="WaitForFailedException">Thrown if the <paramref name="statePredicate"/> throw an exception during invocation, or if the timeout has been reached. See the inner exception for details.</exception>
+	public WaitForStateHelper(IRenderedComponent<TComponent> renderedFragment, Func<TComponent, bool> statePredicate, TimeSpan? timeout = null)
+		: base(renderedFragment, () => (statePredicate(GetInstance(renderedFragment)), default), timeout)
+	{
+	}
+
+	private static TComponent GetInstance(IRenderedComponent<TComponent> component) => ((RenderedComponent<TComponent>)component).Instance;
+}

--- a/src/bunit/IRenderedComponent.cs
+++ b/src/bunit/IRenderedComponent.cs
@@ -4,7 +4,6 @@ namespace Bunit;
 public interface IRenderedComponent<out TComponent> : IRenderedFragment
 	where TComponent : IComponent
 {
-
 	/// <summary>
 	/// Invokes an action on the component under test inside the Dispatcher.
 	/// </summary>

--- a/src/bunit/IRenderedComponent.cs
+++ b/src/bunit/IRenderedComponent.cs
@@ -4,8 +4,9 @@ namespace Bunit;
 public interface IRenderedComponent<out TComponent> : IRenderedFragment
 	where TComponent : IComponent
 {
+
 	/// <summary>
-	/// Gets the component under test.
+	/// Invokes an action on the component under test inside the Dispatcher.
 	/// </summary>
-	TComponent Instance { get; }
+	void AccessInstance(Action<TComponent> action);
 }

--- a/src/bunit/Rendering/RenderedComponent.cs
+++ b/src/bunit/Rendering/RenderedComponent.cs
@@ -9,8 +9,7 @@ internal sealed class RenderedComponent<TComponent> : RenderedFragment, IRendere
 {
 	private TComponent? instance;
 
-	/// <inheritdoc/>
-	public TComponent Instance
+	internal TComponent Instance
 	{
 		get
 		{
@@ -28,6 +27,12 @@ internal sealed class RenderedComponent<TComponent> : RenderedFragment, IRendere
 		this.instance = instance;
 		RenderCount++;
 		UpdateMarkup(componentFrames);
+	}
+
+	/// <inheritdoc/>
+	public void AccessInstance(Action<TComponent> action)
+	{
+		this.InvokeAsync(() => action(Instance)).GetAwaiter().GetResult();
 	}
 
 	protected override void OnRender(RenderEvent renderEvent)

--- a/tests/bunit.tests/ComponentFactories/ConditionalComponentFactoryTest.cs
+++ b/tests/bunit.tests/ComponentFactories/ConditionalComponentFactoryTest.cs
@@ -25,8 +25,7 @@ public class ConditionalComponentFactoryTest : TestContext
 
 		var cut = Render<Wrapper>(ps => ps.AddChildContent<Simple1>());
 
-		cut.FindComponent<Simple1>()
-			.Instance.ShouldBeSameAs(mockComponent);
+		cut.FindComponent<Simple1>().AccessInstance(s => s.ShouldBeSameAs(mockComponent));
 	}
 
 	[Fact(DisplayName = "Component is replaced in render tree with component from factory when matches returns true")]
@@ -44,8 +43,8 @@ public class ConditionalComponentFactoryTest : TestContext
 		   .Add<NoArgs>(p => p.Second));
 
 		// Assert
-		cut.FindComponents<Simple1>().ShouldAllBe(x => x.Instance == mockSimple1);
-		cut.FindComponents<NoArgs>().ShouldAllBe(x => x.Instance == mockNoArgs);
+		cut.FindComponents<Simple1>().ShouldAllBe(x => IsOfInstance(x, mockSimple1).ShouldBeTrue());
+		cut.FindComponents<NoArgs>().ShouldAllBe(x => IsOfInstance(x, mockNoArgs).ShouldBeTrue());
 	}
 
 	[Fact(DisplayName = "When matches returns false, factory is never called")]
@@ -61,5 +60,13 @@ public class ConditionalComponentFactoryTest : TestContext
 		if (type == typeof(Simple1)) return simple1;
 		if (type == typeof(NoArgs)) return noArgs;
 		throw new NotImplementedException($"No mock implementation provided for type {type.FullName}");
+	}
+	
+	private static bool IsOfInstance<TComponent>(IRenderedComponent<TComponent> component, TComponent instance)
+		where TComponent : class, IComponent
+	{
+		var isSame = false;
+		component.AccessInstance(x => isSame = x == instance);
+		return isSame;
 	}
 }

--- a/tests/bunit.tests/ComponentFactories/InstanceComponentFactoryTest.cs
+++ b/tests/bunit.tests/ComponentFactories/InstanceComponentFactoryTest.cs
@@ -18,8 +18,7 @@ public class InstanceComponentFactoryTest : TestContext
 
 		var cut = Render<Wrapper>(ps => ps.AddChildContent<Simple1>());
 
-		cut.FindComponent<Simple1>()
-			.Instance.ShouldBeSameAs(simple1Mock);
+		cut.FindComponent<Simple1>().AccessInstance(s => s.ShouldBeSameAs(simple1Mock));
 	}
 
 	[Fact(DisplayName = "Factory throws if component instance is requested twice for TComponent that inherits from ComponentBase")]

--- a/tests/bunit.tests/ComponentFactories/TypeBasedComponentFactoryTest.cs
+++ b/tests/bunit.tests/ComponentFactories/TypeBasedComponentFactoryTest.cs
@@ -19,8 +19,7 @@ public class TypeBasedComponentFactoryTest : TestContext
 
 		var cut = Render<Wrapper>(ps => ps.AddChildContent<Simple1>());
 
-		cut.FindComponent<Simple1>()
-			.Instance.ShouldBeSameAs(simple1Mock);
+		cut.FindComponent<Simple1>().AccessInstance(i => i.ShouldBeSameAs(simple1Mock));
 	}
 
 	[Fact(DisplayName = "Multiple TComponent replaced in render tree with component from factory method")]
@@ -34,7 +33,7 @@ public class TypeBasedComponentFactoryTest : TestContext
 
 		foreach (var component in cut.FindComponents<Simple1>())
 		{
-			Action checkIfSubstitute = () => component.Instance.Received();
+			Action checkIfSubstitute = () => component.AccessInstance(s => s.Received());
 			checkIfSubstitute.ShouldNotThrow();
 		}
 	}

--- a/tests/bunit.tests/ComponentParameterCollectionBuilderTests.cs
+++ b/tests/bunit.tests/ComponentParameterCollectionBuilderTests.cs
@@ -2,7 +2,7 @@ using System.Linq.Expressions;
 
 namespace Bunit;
 
-public partial class ComponentParameterCollectionBuilderTests : TestContext
+public class ComponentParameterCollectionBuilderTests : TestContext
 {
 	private ComponentParameterCollectionBuilder<Params> Builder { get; } = new();
 
@@ -248,7 +248,7 @@ public partial class ComponentParameterCollectionBuilderTests : TestContext
 		var actual = Builder.Build().ShouldHaveSingleItem()
 			.ShouldBeParameter<RenderFragment>("ChildContent", isCascadingValue: false);
 		var actualComponent = RenderWithRenderFragment<InhertedParams>(actual);
-		actualComponent.Instance.ValueTypeParam.ShouldBe(42);
+		actualComponent.AccessInstance(c => c.ValueTypeParam.ShouldBe(42));
 	}
 
 	[Fact(DisplayName = "ChildContent can be passed as a child component without parameters")]
@@ -259,7 +259,7 @@ public partial class ComponentParameterCollectionBuilderTests : TestContext
 		var actual = Builder.Build().ShouldHaveSingleItem()
 			.ShouldBeParameter<RenderFragment>("ChildContent", isCascadingValue: false);
 		var actualComponent = RenderWithRenderFragment<NoParams>(actual);
-		actualComponent.Instance.ShouldBeOfType<NoParams>();
+		actualComponent.AccessInstance(c => c.ShouldBeOfType<NoParams>());
 	}
 
 	[Fact(DisplayName = "ChildContent can be passed as a markup string")]
@@ -282,7 +282,7 @@ public partial class ComponentParameterCollectionBuilderTests : TestContext
 		var actual = Builder.Build().ShouldHaveSingleItem()
 			.ShouldBeParameter<RenderFragment>("OtherFragment", isCascadingValue: false);
 		var actualComponent = RenderWithRenderFragment<InhertedParams>(actual);
-		actualComponent.Instance.ValueTypeParam.ShouldBe(42);
+		actualComponent.AccessInstance(c => c.ValueTypeParam.ShouldBe(42));
 	}
 
 	[Fact(DisplayName = "RenderFragment can be passed as a child component without parameters")]
@@ -293,7 +293,7 @@ public partial class ComponentParameterCollectionBuilderTests : TestContext
 		var actual = Builder.Build().ShouldHaveSingleItem()
 			.ShouldBeParameter<RenderFragment>("OtherFragment", isCascadingValue: false);
 		var actualComponent = RenderWithRenderFragment<NoParams>(actual);
-		actualComponent.Instance.ShouldBeOfType<NoParams>();
+		actualComponent.AccessInstance(c => c.ShouldBeOfType<NoParams>());
 	}
 
 	[Fact(DisplayName = "RenderFragment can be passed as a markup string")]
@@ -371,7 +371,7 @@ public partial class ComponentParameterCollectionBuilderTests : TestContext
 			.ShouldBeParameter<RenderFragment<string>>("Template", isCascadingValue: false);
 
 		var actualComponent = RenderWithRenderFragment<InhertedParams>(actual(input));
-		actualComponent.Instance.Param.ShouldBe(input);
+		actualComponent.AccessInstance(c => c.Param.ShouldBe(input));
 	}
 
 	[Fact(DisplayName = "RenderFragment<T> can be passed multiple times")]

--- a/tests/bunit.tests/ComponentParameterCollectionBuilderTests.razor
+++ b/tests/bunit.tests/ComponentParameterCollectionBuilderTests.razor
@@ -1,7 +1,7 @@
 @inherits Bunit.TestContext
 @code {
     [Fact(DisplayName = "Bind method should behave like bind-directive")]
-    public async Task Test400()
+    public void Test400()
     {
         // arrange
         var initialValue = "Hello";
@@ -16,15 +16,20 @@
         var bindDirective = Render<FullBind>(@<FullBind @bind-Foo="initialValue" />);
 
         // assert
-        bindMethod.Instance.Foo.ShouldBe(bindDirective.Instance.Foo);
+	    FullBind bindInstance = default!;
+	    FullBind bindDirectiveInstance = default!;
+	    bindMethod.AccessInstance(c => bindInstance = c);
+	    bindDirective.AccessInstance(c => bindDirectiveInstance = c);
+	    
+	    bindInstance.Foo.ShouldBe(bindDirectiveInstance.Foo);
 
-        await bindMethod.Instance.FooChanged.InvokeAsync(nameof(bindMethod));
+        bindMethod.AccessInstance(c => c.FooChanged.InvokeAsync(nameof(bindMethod)));
         initialValue.ShouldBe(nameof(bindMethod));
 
-        await bindDirective.Instance.FooChanged.InvokeAsync(nameof(bindDirective));
+        bindDirective.AccessInstance(c => c.FooChanged.InvokeAsync(nameof(bindDirective)));
         initialValue.ShouldBe(nameof(bindDirective));
 
-        bindMethod.Instance.FooExpression.ToString()
-            .ShouldBe(bindDirective.Instance.FooExpression.ToString());
+	    bindInstance.FooExpression.ToString()
+            .ShouldBe(bindDirectiveInstance.FooExpression.ToString());
     }
 }

--- a/tests/bunit.tests/ComponentParameterCollectionTest.cs
+++ b/tests/bunit.tests/ComponentParameterCollectionTest.cs
@@ -36,8 +36,7 @@ public class ComponentParameterCollectionTest : TestContext
 
 		var rf = sut.ToRenderFragment<Params>();
 
-		var c = RenderWithRenderFragment(rf).Instance;
-		c.VerifyParamsHaveDefaultValues();
+		RenderWithRenderFragment(rf).AccessInstance(s => s.VerifyParamsHaveDefaultValues());
 	}
 
 	[Fact(DisplayName = "ToComponentRenderFragment passes regular params to component in RenderFragment")]
@@ -52,10 +51,12 @@ public class ComponentParameterCollectionTest : TestContext
 
 		var rf = sut.ToRenderFragment<Params>();
 
-		var c = RenderWithRenderFragment(rf).Instance;
-		c.Param.ShouldBe("FOO");
-		c.ValueTypeParam.ShouldBe(42);
-		c.NullableValueTypeParam.ShouldBe(1337);
+		RenderWithRenderFragment(rf).AccessInstance(c =>
+		{
+			c.Param.ShouldBe("FOO");
+			c.ValueTypeParam.ShouldBe(42);
+			c.NullableValueTypeParam.ShouldBe(1337);
+		});
 	}
 
 	[Fact(DisplayName = "ToComponentRenderFragment passes single ChildContent param to component in RenderFragment")]
@@ -128,8 +129,7 @@ public class ComponentParameterCollectionTest : TestContext
 
 		var rf = sut.ToRenderFragment<Params>();
 
-		var c = RenderWithRenderFragment(rf).Instance;
-		c.Attributes?.ContainsKey("attr").ShouldBeTrue();
+		RenderWithRenderFragment(rf).AccessInstance(c => c.Attributes?.ContainsKey("attr").ShouldBeTrue());
 	}
 
 	[Fact(DisplayName = "ToComponentRenderFragment passes EventCallback params to component in RenderFragment")]
@@ -152,11 +152,13 @@ public class ComponentParameterCollectionTest : TestContext
 		var rf = sut.ToRenderFragment<Params>();
 
 		// assert
-		var c = RenderWithRenderFragment(rf).Instance;
-		c.NullableEC.ShouldBe(ec1);
-		c.EC.ShouldBe(ec2);
-		c.NullableECWithArgs.ShouldBe(ec3);
-		c.ECWithArgs.ShouldBe(ec4);
+		RenderWithRenderFragment(rf).AccessInstance(c =>
+		{
+			c.NullableEC.ShouldBe(ec1);
+			c.EC.ShouldBe(ec2);
+			c.NullableECWithArgs.ShouldBe(ec3);
+			c.ECWithArgs.ShouldBe(ec4);
+		});
 	}
 
 	[Fact(DisplayName = "ToComponentRenderFragment passes single template param to component in RenderFragment")]
@@ -255,8 +257,7 @@ public class ComponentParameterCollectionTest : TestContext
 
 		var rf = sut.ToRenderFragment<Params>();
 
-		var c = RenderWithRenderFragment(rf).Instance;
-		c.NullableCC.ShouldBe("FOO");
+		RenderWithRenderFragment(rf).AccessInstance(c => c.NullableCC.ShouldBe("FOO"));
 	}
 
 	[Fact(DisplayName = "ToComponentRenderFragment wraps component in multiple unnamed cascading values in RenderFragment")]
@@ -270,9 +271,11 @@ public class ComponentParameterCollectionTest : TestContext
 
 		var rf = sut.ToRenderFragment<Params>();
 
-		var c = RenderWithRenderFragment(rf).Instance;
-		c.NullableCC.ShouldBe("FOO");
-		c.CC.ShouldBe(42);
+		RenderWithRenderFragment(rf).AccessInstance(c =>
+		{
+			c.NullableCC.ShouldBe("FOO");
+			c.CC.ShouldBe(42);
+		});
 	}
 
 	[Fact(DisplayName = "ToComponentRenderFragment throws when multiple unnamed cascading values with same type is added")]
@@ -299,8 +302,7 @@ public class ComponentParameterCollectionTest : TestContext
 
 		var rf = sut.ToRenderFragment<Params>();
 
-		var c = RenderWithRenderFragment(rf).Instance;
-		c.NullableNamedCC.ShouldBe("FOO");
+		RenderWithRenderFragment(rf).AccessInstance(c => c.NullableNamedCC.ShouldBe("FOO"));
 	}
 
 	[Fact(DisplayName = "ToComponentRenderFragment wraps component in multiple named cascading values in RenderFragment")]
@@ -315,10 +317,12 @@ public class ComponentParameterCollectionTest : TestContext
 
 		var rf = sut.ToRenderFragment<Params>();
 
-		var c = RenderWithRenderFragment(rf).Instance;
-		c.NullableNamedCC.ShouldBe("FOO");
-		c.NamedCC.ShouldBe(42);
-		c.AnotherNamedCC.ShouldBe(1337);
+		RenderWithRenderFragment(rf).AccessInstance(c =>
+		{
+			c.NullableNamedCC.ShouldBe("FOO");
+			c.NamedCC.ShouldBe(42);
+			c.AnotherNamedCC.ShouldBe(1337);
+		});
 	}
 
 	[Fact(DisplayName = "ToComponentRenderFragment throws when multiple named cascading values with same name and type is added")]

--- a/tests/bunit.tests/EventDispatchExtensions/GeneralEventDispatchExtensionsTest.cs
+++ b/tests/bunit.tests/EventDispatchExtensions/GeneralEventDispatchExtensionsTest.cs
@@ -312,7 +312,7 @@ public class GeneralEventDispatchExtensionsTest : EventDispatchExtensionsTest<Ev
 
 		await cut.WaitForAssertionAsync(() => cut.Find("[data-id=1]"));
 
-		await cut.InvokeAsync(() => cut.Find("[data-id=1]").Click());
+		cut.Find("[data-id=1]").Click();
 
 		await cut.WaitForAssertionAsync(() => cut.Find("[data-id=2]"));
 	}

--- a/tests/bunit.tests/EventDispatchExtensions/GeneralEventDispatchExtensionsTest.cs
+++ b/tests/bunit.tests/EventDispatchExtensions/GeneralEventDispatchExtensionsTest.cs
@@ -67,8 +67,8 @@ public class GeneralEventDispatchExtensionsTest : EventDispatchExtensionsTest<Ev
 
 		cut.Find("span").Click();
 
-		cut.Instance.SpanClickCount.ShouldBe(1);
-		cut.Instance.HeaderClickCount.ShouldBe(1);
+		cut.AccessInstance(c => c.SpanClickCount.ShouldBe(1));
+		cut.AccessInstance(c => c.HeaderClickCount.ShouldBe(1));
 	}
 
 	[Fact(DisplayName = "When clicking on an element without an event handler attached, " +
@@ -79,9 +79,7 @@ public class GeneralEventDispatchExtensionsTest : EventDispatchExtensionsTest<Ev
 
 		cut.Find("button").Click();
 
-		cut.Instance.SpanClickCount.ShouldBe(0);
-		cut.Instance.HeaderClickCount.ShouldBe(1);
-	}
+		cut.AccessInstance(c => c.SpanClickCount.ShouldBe(0));		cut.AccessInstance(c => c.HeaderClickCount.ShouldBe(1));	}
 
 	[Theory(DisplayName = "When clicking element with non-bubbling events, the event does not bubble")]
 	[InlineData("onabort")]
@@ -111,9 +109,9 @@ public class GeneralEventDispatchExtensionsTest : EventDispatchExtensionsTest<Ev
 
 		await cut.Find("#child").TriggerEventAsync(eventName, EventArgs.Empty);
 
-		cut.Instance.ChildTriggerCount.ShouldBe(1);
-		cut.Instance.ParentTriggerCount.ShouldBe(0);
-		cut.Instance.GrandParentTriggerCount.ShouldBe(0);
+		cut.AccessInstance(c => c.ChildTriggerCount.ShouldBe(1));
+		cut.AccessInstance(c => c.ParentTriggerCount.ShouldBe(0));
+		cut.AccessInstance(c => c.GrandParentTriggerCount.ShouldBe(0));
 	}
 
 	[Fact(DisplayName = "When event has StopPropergation modifier, events does not bubble from target")]
@@ -125,9 +123,9 @@ public class GeneralEventDispatchExtensionsTest : EventDispatchExtensionsTest<Ev
 
 		await cut.Find("#child").TriggerEventAsync("onclick", EventArgs.Empty);
 
-		cut.Instance.ChildTriggerCount.ShouldBe(1);
-		cut.Instance.ParentTriggerCount.ShouldBe(0);
-		cut.Instance.GrandParentTriggerCount.ShouldBe(0);
+		cut.AccessInstance(c => c.ChildTriggerCount.ShouldBe(1));
+		cut.AccessInstance(c => c.ParentTriggerCount.ShouldBe(0));
+		cut.AccessInstance(c => c.GrandParentTriggerCount.ShouldBe(0));
 	}
 
 	[Fact(DisplayName = "When event has StopPropergation modifier, events does not bubble from parent of target")]
@@ -139,9 +137,9 @@ public class GeneralEventDispatchExtensionsTest : EventDispatchExtensionsTest<Ev
 
 		await cut.Find("#child").TriggerEventAsync("onclick", EventArgs.Empty);
 
-		cut.Instance.ChildTriggerCount.ShouldBe(1);
-		cut.Instance.ParentTriggerCount.ShouldBe(1);
-		cut.Instance.GrandParentTriggerCount.ShouldBe(0);
+		cut.AccessInstance(c => c.ChildTriggerCount.ShouldBe(1));
+		cut.AccessInstance(c => c.ParentTriggerCount.ShouldBe(1));
+		cut.AccessInstance(c => c.GrandParentTriggerCount.ShouldBe(0));
 	}
 
 	[Theory(DisplayName = "Disabled input elements does not bubble for event type"), PairwiseData]
@@ -156,9 +154,9 @@ public class GeneralEventDispatchExtensionsTest : EventDispatchExtensionsTest<Ev
 
 		await cut.Find("#child").TriggerEventAsync(eventName, EventArgs.Empty);
 
-		cut.Instance.ChildTriggerCount.ShouldBe(1);
-		cut.Instance.ParentTriggerCount.ShouldBe(0);
-		cut.Instance.GrandParentTriggerCount.ShouldBe(0);
+		cut.AccessInstance(c => c.ChildTriggerCount.ShouldBe(1));
+		cut.AccessInstance(c => c.ParentTriggerCount.ShouldBe(0));
+		cut.AccessInstance(c => c.GrandParentTriggerCount.ShouldBe(0));	
 	}
 
 	[Theory(DisplayName = "Enabled input elements does not bubble for event type"), PairwiseData]
@@ -173,10 +171,7 @@ public class GeneralEventDispatchExtensionsTest : EventDispatchExtensionsTest<Ev
 
 		await cut.Find("#child").TriggerEventAsync(eventName, EventArgs.Empty);
 
-		cut.Instance.ChildTriggerCount.ShouldBe(1);
-		cut.Instance.ParentTriggerCount.ShouldBe(1);
-		cut.Instance.GrandParentTriggerCount.ShouldBe(1);
-	}
+		cut.AccessInstance(c => c.ChildTriggerCount.ShouldBe(1));		cut.AccessInstance(c => c.ParentTriggerCount.ShouldBe(1));		cut.AccessInstance(c => c.GrandParentTriggerCount.ShouldBe(1));	}
 
 	[Fact(DisplayName = "TriggerEvent can trigger custom events")]
 	public void Test201()
@@ -212,10 +207,7 @@ public class GeneralEventDispatchExtensionsTest : EventDispatchExtensionsTest<Ev
 		// When middle div clicked event handlers is disposed, the
 		// NoEventHandlerException is ignored and the top div clicked event
 		// handler is still invoked.
-		cut.Instance.BtnClicked.ShouldBeTrue();
-		cut.Instance.MiddleDivClicked.ShouldBeFalse();
-		cut.Instance.TopDivClicked.ShouldBeTrue();
-	}
+		cut.AccessInstance(c => c.BtnClicked.ShouldBeTrue());		cut.AccessInstance(c => c.MiddleDivClicked.ShouldBeFalse());		cut.AccessInstance(c => c.TopDivClicked.ShouldBeTrue());	}
 
 	[Theory(DisplayName = "When bubbling event throws, no other event handlers are triggered")]
 	[AutoData]
@@ -226,9 +218,8 @@ public class GeneralEventDispatchExtensionsTest : EventDispatchExtensionsTest<Ev
 		Should.Throw<Exception>(() => cut.Find("button").Click())
 			.Message.ShouldBe(exceptionMessage);
 
-		cut.Instance.BtnClicked.ShouldBeTrue();
-		cut.Instance.MiddleDivClicked.ShouldBeFalse();
-		cut.Instance.TopDivClicked.ShouldBeFalse();
+		cut.AccessInstance(c => c.BtnClicked.ShouldBeTrue());
+		cut.AccessInstance(c => c.MiddleDivClicked.ShouldBeFalse());		cut.AccessInstance(c => c.TopDivClicked.ShouldBeFalse());
 	}
 
 	[Theory(DisplayName = "When event handler throws, the exception is passed up to test")]
@@ -248,8 +239,8 @@ public class GeneralEventDispatchExtensionsTest : EventDispatchExtensionsTest<Ev
 
 		cut.Find("button").Click();
 
-		cut.Instance.FormSubmitted.ShouldBeTrue();
-		cut.Instance.Clicked.ShouldBeTrue();
+		cut.AccessInstance(c => c.FormSubmitted.ShouldBeTrue());		
+		cut.AccessInstance(c => c.Clicked.ShouldBeTrue());	
 	}
 
 	[Fact(DisplayName = "Should handle click event first and submit form afterwards for input when type button")]
@@ -259,9 +250,7 @@ public class GeneralEventDispatchExtensionsTest : EventDispatchExtensionsTest<Ev
 
 		cut.Find("#inside-form-input").Click();
 
-		cut.Instance.FormSubmitted.ShouldBeTrue();
-		cut.Instance.Clicked.ShouldBeTrue();
-	}
+		cut.AccessInstance(c => c.FormSubmitted.ShouldBeTrue());		cut.AccessInstance(c => c.Clicked.ShouldBeTrue());	}
 
 	[Fact(DisplayName = "Should throw exception when invoking onsubmit from non form")]
 	public void Test306()
@@ -282,9 +271,7 @@ public class GeneralEventDispatchExtensionsTest : EventDispatchExtensionsTest<Ev
 
 		cut.Find(submitElementSelector).Click();
 
-		cut.Instance.FormSubmitted.ShouldBeFalse();
-		cut.Instance.Clicked.ShouldBeTrue();
-	}
+		cut.AccessInstance(c => c.FormSubmitted.ShouldBeFalse());		cut.AccessInstance(c => c.Clicked.ShouldBeTrue());	}
 
 	[Theory(DisplayName = "Should submit a form when submit button clicked")]
 	[InlineData("#inside-form-input")]
@@ -299,7 +286,7 @@ public class GeneralEventDispatchExtensionsTest : EventDispatchExtensionsTest<Ev
 
 		cut.Find(submitElementSelector).Click();
 
-		cut.Instance.FormSubmitted.ShouldBeTrue();
+		cut.AccessInstance(c => c.FormSubmitted.ShouldBeTrue());	
 	}
 
 	[Theory(DisplayName = "Should trigger click handler of buttons inside form")]
@@ -312,7 +299,7 @@ public class GeneralEventDispatchExtensionsTest : EventDispatchExtensionsTest<Ev
 
 		cut.Find(submitElementSelector).Click();
 
-		cut.Instance.Clicked.ShouldBeTrue();
+		cut.AccessInstance(c => c.Clicked.ShouldBeTrue());	
 	}
 
 	// Runs the test multiple times to trigger the race condition

--- a/tests/bunit.tests/EventDispatchExtensions/InputEventDispatchExtensionsTest.cs
+++ b/tests/bunit.tests/EventDispatchExtensions/InputEventDispatchExtensionsTest.cs
@@ -275,9 +275,12 @@ public class InputEventDispatchExtensionsTest : EventDispatchExtensionsTest<Chan
 		cut.Find("#onChangeInput").Change(values);
 		cut.Find("#onInputInput").Input(values);
 
-		cut.Instance.BindValues.ShouldBe(values);
-		cut.Instance.OnChangeValue.ShouldBe(FormatValues(values));
-		cut.Instance.OnInputValue.ShouldBe(FormatValues(values));
+		cut.AccessInstance(c =>
+		{
+			c.BindValues.ShouldBe(values);
+			c.OnChangeValue.ShouldBe(FormatValues(values));
+			c.OnInputValue.ShouldBe(FormatValues(values));
+		});
 	}
 
 	private void VerifySingleBindValue<T>(T value)
@@ -291,9 +294,12 @@ public class InputEventDispatchExtensionsTest : EventDispatchExtensionsTest<Chan
 		cut.Find("#onChangeInput").Change(value);
 		cut.Find("#onInputInput").Input(value);
 
-		cut.Instance.BindValue.ShouldBeEquivalentTo(value);
-		cut.Instance.OnChangeValue.ShouldBeEquivalentTo(FormatValue(value));
-		cut.Instance.OnInputValue.ShouldBeEquivalentTo(FormatValue(value));
+		cut.AccessInstance(c =>
+		{
+			c.BindValue.ShouldBeEquivalentTo(value);
+			c.OnChangeValue.ShouldBeEquivalentTo(FormatValue(value));
+			c.OnInputValue.ShouldBeEquivalentTo(FormatValue(value));
+		});
 	}
 
 	private static object?[] FormatValues<T>(T[] values)

--- a/tests/bunit.tests/Extensions/InputFile/InputFileTests.cs
+++ b/tests/bunit.tests/Extensions/InputFile/InputFileTests.cs
@@ -17,10 +17,13 @@ public class InputFileTests : TestContext
 
 		cut.FindComponent<InputFile>().UploadFiles(file);
 
-		cut.Instance.Content.ShouldBe("Hello World");
-		cut.Instance.Filename.ShouldBe("Hey.txt");
-		cut.Instance.Size.ShouldBe(11);
-		cut.Instance.LastChanged.ShouldBe(lastModified);
+		cut.AccessInstance(c =>
+		{
+			c.Content.ShouldBe("Hello World");
+			c.Filename.ShouldBe("Hey.txt");
+			c.Size.ShouldBe(11);
+			c.LastChanged.ShouldBe(lastModified);
+		});
 	}
 
 	[Fact(DisplayName = "InputFile can upload a single byte file")]
@@ -31,7 +34,7 @@ public class InputFileTests : TestContext
 
 		cut.FindComponent<InputFile>().UploadFiles(file);
 
-		cut.Instance.Content.ShouldBe("Hello World");
+		cut.AccessInstance(c => c.Content.ShouldBe("Hello World"));
 	}
 
 	[Fact(DisplayName = "InputFile can upload multiple files")]
@@ -44,17 +47,21 @@ public class InputFileTests : TestContext
 
 		cut.FindComponent<InputFile>().UploadFiles(file1, file2);
 
-		cut.Instance.Files.Count.ShouldBe(2);
-		cut.Instance.Files[0].FileContent.ShouldBe("Hello World");
-		cut.Instance.Files[0].Filename.ShouldBe("Hey.txt");
-		cut.Instance.Files[0].LastChanged.ShouldBe(lastModified);
-		cut.Instance.Files[0].Size.ShouldBe(11);
-		cut.Instance.Files[0].Type.ShouldBe("test");
-		cut.Instance.Files[1].FileContent.ShouldBe("World Hey");
-		cut.Instance.Files[1].Filename.ShouldBe("Test.txt");
-		cut.Instance.Files[1].LastChanged.ShouldBe(lastModified);
-		cut.Instance.Files[1].Size.ShouldBe(9);
-		cut.Instance.Files[1].Type.ShouldBe("unit");
+		cut.AccessInstance(c =>
+		{
+			c.Files.Count.ShouldBe(2);
+			c.Files[0].FileContent.ShouldBe("Hello World");
+			c.Files[0].Filename.ShouldBe("Hey.txt");
+			c.Files[0].LastChanged.ShouldBe(lastModified);
+			c.Files[0].Size.ShouldBe(11);
+			c.Files[0].Type.ShouldBe("test");
+			c.Files[1].FileContent.ShouldBe("World Hey");
+			c.Files[1].Filename.ShouldBe("Test.txt");
+			c.Files[1].LastChanged.ShouldBe(lastModified);
+			c.Files[1].Size.ShouldBe(9);
+			c.Files[1].Type.ShouldBe("unit");
+		});
+		
 	}
 
 	[Fact(DisplayName = "UploadFile throws exception when InputFile is null")]

--- a/tests/bunit.tests/Extensions/RenderedComponentInvokeAsyncExtensionsTest.cs
+++ b/tests/bunit.tests/Extensions/RenderedComponentInvokeAsyncExtensionsTest.cs
@@ -2,26 +2,6 @@ namespace Bunit.Extensions;
 
 public class RenderedComponentInvokeAsyncExtensionsTest : TestContext
 {
-	[Fact(DisplayName = "Dispatcher awaits Task-returning callback")]
-	public async Task Test003()
-	{
-		// Arrange
-		var cut = Render<Simple1>();
-		bool delegateFinished = false;
-
-		async Task Callback()
-		{
-			await Task.Delay(10);
-			delegateFinished = true;
-		}
-
-		// Act
-		await cut.InvokeAsync(Callback);
-
-		// Assert
-		delegateFinished.ShouldBeTrue();
-	}
-
 	[Fact(DisplayName = "Dispatcher does not await void-returning callback")]
 	public async Task Test004()
 	{
@@ -31,7 +11,7 @@ public class RenderedComponentInvokeAsyncExtensionsTest : TestContext
 
 		async void Callback()
 		{
-			await Task.Delay(10);
+			await Task.Delay(20).ConfigureAwait(ConfigureAwaitOptions.ForceYielding);
 			delegateFinished = true;
 		}
 

--- a/tests/bunit.tests/Extensions/WaitForHelpers/RenderedFragmentWaitForHelperExtensionsTest.cs
+++ b/tests/bunit.tests/Extensions/WaitForHelpers/RenderedFragmentWaitForHelperExtensionsTest.cs
@@ -95,18 +95,18 @@ public class RenderedFragmentWaitForHelperExtensionsTest : TestContext
 	public async Task Test200()
 	{
 		var cut = Render<AsyncRenderChangesProperty>();
-		cut.Instance.Counter.ShouldBe(0);
+		cut.AccessInstance(c => c.Counter.ShouldBe(0));
 
 		// Clicking 'tick' changes the counter, and starts a task
 		cut.Find("#tick").Click();
-		cut.Instance.Counter.ShouldBe(1);
+		cut.AccessInstance(c => c.Counter.ShouldBe(1));
 
 		// Clicking 'tock' completes the task, which updates the counter
 		// This click causes two renders, thus something is needed to await here.
 		cut.Find("#tock").Click();
-		await cut.WaitForStateAsync(() => cut.Instance.Counter == 2);
+		await cut.WaitForStateAsync(c => c.Counter == 2);
 
-		cut.Instance.Counter.ShouldBe(2);
+		cut.AccessInstance(c => c.Counter.ShouldBe(2));
 	}
 
 	[Fact(DisplayName = "WaitForAssertion rethrows unhandled exception from a components async operation's methods")]

--- a/tests/bunit.tests/JSInterop/InvocationHandlers/FocusAsyncInvocationHandlerTest.cs
+++ b/tests/bunit.tests/JSInterop/InvocationHandlers/FocusAsyncInvocationHandlerTest.cs
@@ -28,7 +28,7 @@ public class FocusAsyncInvocationHandlerTest : TestContext
 	public void Test003()
 	{
 		var cut = Render<FocusingComponent>();
-		Assert.True(cut.Instance.AfterFirstRender);
+		cut.AccessInstance(c => c.AfterFirstRender.ShouldBeTrue());
 	}
 
 	private sealed class FocusingComponent : ComponentBase

--- a/tests/bunit.tests/JSInterop/InvocationHandlers/FocusOnNavigateHandlerTest.cs
+++ b/tests/bunit.tests/JSInterop/InvocationHandlers/FocusOnNavigateHandlerTest.cs
@@ -13,10 +13,9 @@ public class FocusOnNavigateHandlerTest : TestContext
 
 		var focusOnNavigateComponent = cut.FindComponent<FocusOnNavigate>();
 
-		Assert.Equal("h1", JSInterop.VerifyFocusOnNavigateInvoke().Arguments[0]);
-		JSInterop.VerifyFocusOnNavigateInvoke()
-			.Arguments[0]
-			.ShouldBe(focusOnNavigateComponent.Instance.Selector);
+		var argument = JSInterop.VerifyFocusOnNavigateInvoke().Arguments[0];
+		Assert.Equal("h1", argument);
+		focusOnNavigateComponent.AccessInstance(c => c.Selector.ShouldBe(argument));
 	}
 
 	[Fact(DisplayName = "Will return completed task")]
@@ -28,7 +27,7 @@ public class FocusOnNavigateHandlerTest : TestContext
 				.Add(x => x.Selector, "h1")));
 
 		var focusOnNavigateComponent = cut.FindComponent<FocusOnNavigateInternal>();
-		Assert.True(focusOnNavigateComponent.Instance.AfterFirstRender);
+		focusOnNavigateComponent.AccessInstance(c => c.AfterFirstRender.ShouldBeTrue());
 	}
 
 	private sealed class FocusOnNavigateInternal : FocusOnNavigate

--- a/tests/bunit.tests/Rendering/BunitComponentActivatorTest.cs
+++ b/tests/bunit.tests/Rendering/BunitComponentActivatorTest.cs
@@ -12,7 +12,7 @@ public class BunitComponentActivatorTest : TestContext
 
 		var cut = Render<Simple1>();
 
-		cut.Instance.ShouldBeOfType<Simple1>();
+		cut.AccessInstance(c => c.ShouldBeOfType<Simple1>());
 	}
 
 	[Fact(DisplayName = "Custom singleton IComponentActivator registered in Services")]

--- a/tests/bunit.tests/Rendering/BunitRendererTest.cs
+++ b/tests/bunit.tests/Rendering/BunitRendererTest.cs
@@ -256,7 +256,7 @@ public class BunitRendererTest : TestContext
 	}
 
 	[Fact(DisplayName = "Rendered component updates on re-renders from child components with changes in render tree")]
-	public async Task Test050()
+	public void Test050()
 	{
 		// arrange
 		var sut = Services.GetRequiredService<BunitRenderer>();
@@ -266,7 +266,7 @@ public class BunitRendererTest : TestContext
 		var child = sut.FindComponent<RenderTrigger>(cut);
 
 		// act
-		await cut.InvokeAsync(() => child.AccessInstance(c => c.TriggerWithValue("X")));
+		child.AccessInstance(c => c.TriggerWithValue("X"));
 
 		// assert
 		cut.RenderCount.ShouldBe(2);

--- a/tests/bunit.tests/Rendering/BunitRendererTest.cs
+++ b/tests/bunit.tests/Rendering/BunitRendererTest.cs
@@ -51,7 +51,7 @@ public class BunitRendererTest : TestContext
 
 		cut.RenderCount.ShouldBe(1);
 		cut.Markup.ShouldBe(NoChildNoParams.MARKUP);
-		cut.Instance.ShouldBeOfType<NoChildNoParams>();
+		cut.AccessInstance(c => c.ShouldBeOfType<NoChildNoParams>());
 	}
 
 	[Fact(DisplayName = "Can render component with parameters")]
@@ -63,7 +63,7 @@ public class BunitRendererTest : TestContext
 		var cut = sut.Render<HasParams>(ps => ps
 			.Add(p => p.Value, VALUE));
 
-		cut.Instance.Value.ShouldBe(VALUE);
+		cut.AccessInstance(c => c.Value.ShouldBe(VALUE));
 	}
 
 	[Fact(DisplayName = "Can render component with child component")]
@@ -83,7 +83,7 @@ public class BunitRendererTest : TestContext
 	}
 
 	[Fact(DisplayName = "Rendered component gets RenderCount updated on re-render")]
-	public async Task Test010()
+	public void Test010()
 	{
 		var sut = Services.GetRequiredService<BunitRenderer>();
 
@@ -91,13 +91,13 @@ public class BunitRendererTest : TestContext
 
 		cut.RenderCount.ShouldBe(1);
 
-		await cut.InvokeAsync(() => cut.Instance.Trigger());
+		cut.AccessInstance(c => c.Trigger());
 
 		cut.RenderCount.ShouldBe(2);
 	}
 
 	[Fact(DisplayName = "Rendered component gets Markup updated on re-render")]
-	public async Task Test011()
+	public void Test011()
 	{
 		// arrange
 		const string EXPECTED = "NOW VALUE";
@@ -107,7 +107,7 @@ public class BunitRendererTest : TestContext
 		cut.RenderCount.ShouldBe(1);
 
 		// act
-		await cut.InvokeAsync(async () => await cut.Instance.TriggerWithValue(EXPECTED));
+		cut.AccessInstance(c => c.TriggerWithValue(EXPECTED));
 
 		// assert
 		cut.RenderCount.ShouldBe(2);
@@ -218,7 +218,7 @@ public class BunitRendererTest : TestContext
 	}
 
 	[Fact(DisplayName = "Retrieved rendered child component with FindComponent gets updated on re-render")]
-	public async Task Test040()
+	public void Test040()
 	{
 		var sut = Services.GetRequiredService<BunitRenderer>();
 
@@ -230,14 +230,14 @@ public class BunitRendererTest : TestContext
 
 		cut.RenderCount.ShouldBe(1);
 
-		await cut.InvokeAsync(() => cut.Instance.TriggerWithValue("X"));
+		cut.AccessInstance(c => c.TriggerWithValue("X"));
 
 		cut.RenderCount.ShouldBe(2);
 		cut.Markup.ShouldBe("X");
 	}
 
 	[Fact(DisplayName = "Retrieved rendered child component with FindComponents gets updated on re-render")]
-	public async Task Test041()
+	public void Test041()
 	{
 		var sut = Services.GetRequiredService<BunitRenderer>();
 
@@ -249,7 +249,7 @@ public class BunitRendererTest : TestContext
 
 		cut.RenderCount.ShouldBe(1);
 
-		await cut.InvokeAsync(() => cut.Instance.TriggerWithValue("X"));
+		cut.AccessInstance(c => c.TriggerWithValue("X"));
 
 		cut.RenderCount.ShouldBe(2);
 		cut.Markup.ShouldBe("X");
@@ -266,7 +266,7 @@ public class BunitRendererTest : TestContext
 		var child = sut.FindComponent<RenderTrigger>(cut);
 
 		// act
-		await cut.InvokeAsync(() => child.Instance.TriggerWithValue("X"));
+		await cut.InvokeAsync(() => child.AccessInstance(c => c.TriggerWithValue("X")));
 
 		// assert
 		cut.RenderCount.ShouldBe(2);
@@ -274,7 +274,7 @@ public class BunitRendererTest : TestContext
 	}
 
 	[Fact(DisplayName = "When component is disposed by renderer, getting Markup throws and IsDisposed returns true")]
-	public async Task Test060()
+	public void Test060()
 	{
 		// arrange
 		var sut = Services.GetRequiredService<BunitRenderer>();
@@ -284,7 +284,7 @@ public class BunitRendererTest : TestContext
 		var child = sut.FindComponent<NoChildNoParams>(cut);
 
 		// act
-		await cut.InvokeAsync(() => cut.Instance.DisposeChild());
+		cut.AccessInstance(c => c.DisposeChild());
 
 		// assert
 		child.IsDisposed.ShouldBeTrue();
@@ -292,7 +292,7 @@ public class BunitRendererTest : TestContext
 	}
 
 	[Fact(DisplayName = "Rendered component updates itself if a child's child is disposed")]
-	public async Task Test061()
+	public void Test061()
 	{
 		// arrange
 		var sut = Services.GetRequiredService<BunitRenderer>();
@@ -304,7 +304,7 @@ public class BunitRendererTest : TestContext
 		var childChild = sut.FindComponent<NoChildNoParams>(cut);
 
 		// act
-		await child.InvokeAsync(() => cut.Instance.DisposeChild());
+		child.AccessInstance(c => c.DisposeChild());
 
 		// assert
 		childChild.IsDisposed.ShouldBeTrue();
@@ -447,12 +447,15 @@ public class BunitRendererTest : TestContext
 		cut.Render();
 
 		cut.RenderCount.ShouldBe(2);
-		cut.Instance.InitilizedCount.ShouldBe(1);
-		cut.Instance.InitilizedAsyncCount.ShouldBe(1);
-		cut.Instance.ParametersSetCount.ShouldBe(2);
-		cut.Instance.ParametersSetAsyncCount.ShouldBe(2);
-		cut.Instance.AfterRenderCount.ShouldBe(2);
-		cut.Instance.AfterRenderAsyncCount.ShouldBe(2);
+		cut.AccessInstance(c =>
+		{
+			c.InitilizedCount.ShouldBe(1);
+			c.InitilizedAsyncCount.ShouldBe(1);
+			c.ParametersSetCount.ShouldBe(2);
+			c.ParametersSetAsyncCount.ShouldBe(2);
+			c.AfterRenderCount.ShouldBe(2);
+			c.AfterRenderAsyncCount.ShouldBe(2);
+		});
 	}
 
 	internal sealed class LifeCycleMethodInvokeCounter : ComponentBase
@@ -523,12 +526,12 @@ public class BunitRendererTest : TestContext
 	{
 		[Parameter] public string? Value { get; set; }
 
-		public Task Trigger() => InvokeAsync(StateHasChanged);
+		public void Trigger() => InvokeAsync(StateHasChanged);
 
-		public Task TriggerWithValue(string value)
+		public void TriggerWithValue(string value)
 		{
 			Value = value;
-			return InvokeAsync(StateHasChanged);
+			InvokeAsync(StateHasChanged);
 		}
 
 		protected override void BuildRenderTree(RenderTreeBuilder builder)
@@ -543,10 +546,10 @@ public class BunitRendererTest : TestContext
 
 		[Parameter] public RenderFragment? ChildContent { get; set; }
 
-		public Task DisposeChild()
+		public void DisposeChild()
 		{
 			showing = false;
-			return InvokeAsync(StateHasChanged);
+			InvokeAsync(StateHasChanged);
 		}
 
 		protected override void BuildRenderTree(RenderTreeBuilder builder)

--- a/tests/bunit.tests/Rendering/DeterministicRenderTests.cs
+++ b/tests/bunit.tests/Rendering/DeterministicRenderTests.cs
@@ -12,7 +12,7 @@ public class DeterministicRenderTests : TestContext
 		cut.Find("p").TextContent.ShouldBe("Rendering");
 
 		// Set the task to finished
-		cut.Instance.CompleteTask();
+		cut.AccessInstance(c => c.CompleteTask());
 		await cut.WaitForAssertionAsync(() => cut.Find("p").TextContent.ShouldBe("Rendered"));
 
 		cut.Find("p").TextContent.ShouldBe("Rendered");
@@ -25,7 +25,7 @@ public class DeterministicRenderTests : TestContext
 
 		cut.Find("p").TextContent.ShouldBe("False");
 
-		cut.Instance.CompleteTask();
+		cut.AccessInstance(c => c.CompleteTask());
 		await cut.WaitForAssertionAsync(() => cut.Find("p").TextContent.ShouldBe("True"));
 	}
 
@@ -135,7 +135,7 @@ public class DeterministicRenderTests : TestContext
 	public async Task CallingInvokeAsyncWrappedInTaskRun()
 	{
 		var cut = Render<RenderOnDemandComponent>();
-		var renderTask = Task.Run(() => cut.Instance.Render(10));
+		var renderTask = Task.Run(() => cut.AccessInstance(c => c.Render(10)));
 
 		await cut.WaitForAssertionAsync(() => cut.Find("p").TextContent.ShouldBe("10"));
 		await renderTask;
@@ -144,7 +144,7 @@ public class DeterministicRenderTests : TestContext
 	[Fact]
 	public async Task ConfigureAwaitComponent()
 	{
-		var cut = Render<AsyncConfigureAwaitComponent>();
+		var cut = (RenderedComponent<AsyncConfigureAwaitComponent>)Render<AsyncConfigureAwaitComponent>();
 		cut.Find("p").TextContent.ShouldBe("0");
 
 		cut.Instance.Tcs.SetResult();
@@ -169,9 +169,9 @@ public class DeterministicRenderTests : TestContext
 			return Task.CompletedTask;
 		}
 
-		public Task Render(int number)
+		public void Render(int number)
 		{
-			return renderHandle.Dispatcher.InvokeAsync(() =>
+			renderHandle.Dispatcher.InvokeAsync(() =>
 			{
 				renderHandle.Render(builder =>
 				{

--- a/tests/bunit.tests/Rendering/Internal/HtmlizerTests.cs
+++ b/tests/bunit.tests/Rendering/Internal/HtmlizerTests.cs
@@ -26,7 +26,7 @@ public class HtmlizerTests : TestContext
 
 		var elmRefValue = cut.Find("button").GetAttribute("blazor:elementreference");
 
-		elmRefValue.ShouldBe(cut.Instance.ButtomElmRef.Id);
+		cut.AccessInstance(c => c.ButtomElmRef.Id.ShouldBe(elmRefValue));
 	}
 
 	[Fact(DisplayName = "Blazor ElementReferences start in markup on rerenders")]

--- a/tests/bunit.tests/Rendering/RenderedComponentTest.cs
+++ b/tests/bunit.tests/Rendering/RenderedComponentTest.cs
@@ -55,6 +55,6 @@ public class RenderedComponentTest : TestContext
 		// Disposes of <Simple1 />
 		cut.Render(ps => ps.Add(p => p.ShowChild, false));
 
-		Should.Throw<ComponentDisposedException>(() => target.Instance);
+		Should.Throw<ComponentDisposedException>(() => target.AccessInstance(_ => { }));
 	}
 }

--- a/tests/bunit.tests/Rendering/RenderedFragmentTest.cs
+++ b/tests/bunit.tests/Rendering/RenderedFragmentTest.cs
@@ -61,7 +61,7 @@ public class RenderedFragmentTest : TestContext
 
 		cut.Find("button").Click();
 
-		cut.Instance.RenderCount.ShouldBe(2);
+		cut.AccessInstance(c => c.RenderCount.ShouldBe(2));
 		Assert.Same(initialNodes, cut.Nodes);
 	}
 
@@ -71,13 +71,13 @@ public class RenderedFragmentTest : TestContext
 		var cut = Render<ToggleClickHandler>();
 		cut.Find("#btn").Click();
 
-		cut.Instance.Counter.ShouldBe(1);
+		cut.AccessInstance(c => c.Counter.ShouldBe(1));
 
 		cut.Render(ps => ps.Add(p => p.HandleClicks, false));
 
 		cut.Find("#btn").Click();
 
-		cut.Instance.Counter.ShouldBe(1);
+		cut.AccessInstance(c => c.Counter.ShouldBe(1));
 	}
 
 	[Fact(DisplayName = "FindComponent<TComponent> returns component from first branch of tree in first depth first search")]
@@ -92,7 +92,7 @@ public class RenderedFragmentTest : TestContext
 
 		var cut = wrapper.FindComponent<Simple1>();
 
-		cut.Instance.Header.ShouldBe("First");
+		cut.AccessInstance(c => c.Header.ShouldBe("First"));
 	}
 
 	[Fact(DisplayName = "FindComponent<TComponent> finds components when first tree branch is empty")]
@@ -105,7 +105,7 @@ public class RenderedFragmentTest : TestContext
 
 		var cut = wrapper.FindComponent<Simple1>();
 
-		cut.Instance.Header.ShouldBe("Second");
+		cut.AccessInstance(c => c.Header.ShouldBe("Second"));
 	}
 
 	[Fact(DisplayName = "GetComponent throws when component of requested type is not in the render tree")]
@@ -129,8 +129,8 @@ public class RenderedFragmentTest : TestContext
 		var cuts = wrapper.FindComponents<Simple1>();
 
 		cuts.Count.ShouldBe(2);
-		cuts[0].Instance.Header.ShouldBe("First");
-		cuts[1].Instance.Header.ShouldBe("Second");
+		cuts[0].AccessInstance(c => c.Header.ShouldBe("First"));
+		cuts[1].AccessInstance(c => c.Header.ShouldBe("Second"));
 	}
 
 	[Fact(DisplayName = "Render events for non-rendered sub components are not emitted")]

--- a/tests/bunit.tests/Rendering/RootRenderTreeTest.cs
+++ b/tests/bunit.tests/Rendering/RootRenderTreeTest.cs
@@ -91,7 +91,7 @@ public class RootRenderTreeTest : TestContext
 		var cut = Render<CascadingValue<string>>(parameters => parameters
 			.Add(p => p.Value, "FOO"));
 
-		cut.Instance.Value.ShouldBe("FOO");
+		cut.AccessInstance(c => c.Value.ShouldBe("FOO"));
 	}
 
 	[Fact(DisplayName = "Multiple RenderTree.Add<T> calls are added to render tree in call order")]

--- a/tests/bunit.tests/TestContextTest.cs
+++ b/tests/bunit.tests/TestContextTest.cs
@@ -106,7 +106,8 @@ public class TestContextTest : TestContext
 	public async Task Test202()
 	{
 		var cut = Render<AsyncDisposableComponent>();
-		var wasDisposedTask = cut.Instance.DisposedTask;
+		var wasDisposedTask = Task.FromException(new Exception());
+		cut.FindComponent<AsyncDisposableComponent>().AccessInstance(c => wasDisposedTask = c.DisposedTask);
 
 		DisposeComponents();
 
@@ -118,7 +119,8 @@ public class TestContextTest : TestContext
 	{
 		ComponentFactories.Add<ChildDispose, MyChildDisposeStub>();
 		var cut = Render<ParentDispose>(ps => ps.Add(p => p.CallStack, new List<string>()));
-		var instance = cut.FindComponent<MyChildDisposeStub>().Instance;
+		MyChildDisposeStub instance = default!;
+		cut.FindComponent<MyChildDisposeStub>().AccessInstance(c => instance = c);
 
 		DisposeComponents();
 
@@ -183,10 +185,9 @@ public class TestContextTest : TestContext
 			b.CloseComponent();
 		});
 
-		cut.FindComponent<ReceivesCascadingValue>()
-			.Instance
+		cut.FindComponent<ReceivesCascadingValue>().AccessInstance(c => c
 			.Value
-			.ShouldBe("FOO");
+			.ShouldBe("FOO"));
 	}
 
 	[Fact(DisplayName = "Render<TComponent>() renders fragment inside RenderTree")]
@@ -199,9 +200,9 @@ public class TestContextTest : TestContext
 			b.CloseComponent();
 		});
 
-		cut.Instance
+		cut.AccessInstance(c => c
 			.Value
-			.ShouldBe("FOO");
+			.ShouldBe("FOO"));
 	}
 
 	[Fact(DisplayName = "Render<TComponent>(builder) renders TComponent inside RenderTree")]
@@ -210,9 +211,9 @@ public class TestContextTest : TestContext
 		RenderTree.Add<CascadingValue<string>>(ps => ps.Add(p => p.Value, "FOO"));
 		var cut = Render<ReceivesCascadingValue>(ps => ps.Add(p => p.Dummy, null));
 
-		cut.Instance
+		cut.AccessInstance(c => c
 			.Value
-			.ShouldBe("FOO");
+			.ShouldBe("FOO"));
 	}
 
 	[Fact(DisplayName = "Render<TComponent>(factories) renders TComponent inside RenderTree")]
@@ -222,9 +223,9 @@ public class TestContextTest : TestContext
 		var cut = Render<ReceivesCascadingValue>(ps => ps
 			.Add(p => p.Dummy, null!));
 
-		cut.Instance
+		cut.AccessInstance(c => c
 			.Value
-			.ShouldBe("FOO");
+			.ShouldBe("FOO"));
 	}
 
 	[Fact(DisplayName = "Can raise events from markup rendered with TestContext")]

--- a/tests/bunit.tests/TestDoubles/Components/ComponentDoubleBaseTest.cs
+++ b/tests/bunit.tests/TestDoubles/Components/ComponentDoubleBaseTest.cs
@@ -13,6 +13,6 @@ public class ComponentDoubleBaseTest : TestContext
 		var cut = Render<ComponentDouble<AllTypesOfParams<string>>>(ps => ps
 			.AddUnmatched(attrName, attrValue));
 
-		cut.Instance.Parameters[attrName].ShouldBe(attrValue);
+		cut.AccessInstance(c => c.Parameters[attrName].ShouldBe(attrValue));
 	}
 }

--- a/tests/bunit.tests/TestDoubles/Components/StubTest.cs
+++ b/tests/bunit.tests/TestDoubles/Components/StubTest.cs
@@ -18,11 +18,11 @@ public class StubTest : TestContext
 			.AddUnmatched(nameof(Simple1.Header), header)
 			.AddUnmatched(nameof(Simple1.AttrValue), attrValue));
 
-		cut.Instance
+		cut.AccessInstance(c => c
 			.Parameters
 			.ShouldSatisfyAllConditions(
 				ps => ps.ShouldContain(x => x.Key == nameof(Simple1.Header) && header.Equals(x.Value)),
 				ps => ps.ShouldContain(x => x.Key == nameof(Simple1.AttrValue) && attrValue.Equals(x.Value)),
-				ps => ps.Count.ShouldBe(2));
+				ps => ps.Count.ShouldBe(2)));
 	}
 }

--- a/tests/bunit.tests/TestDoubles/NavigationManager/BunitNavigationManagerTest.cs
+++ b/tests/bunit.tests/TestDoubles/NavigationManager/BunitNavigationManagerTest.cs
@@ -167,7 +167,7 @@ public class BunitNavigationManagerTest : TestContext
 
 		cut.Find("button").Click();
 
-		cut.Instance.NavigationIntercepted.ShouldBeTrue();
+		cut.AccessInstance(c => c.NavigationIntercepted.ShouldBeTrue());
 		bunitNavigationManager.History.Single().State.ShouldBe(NavigationState.Prevented);
 	}
 

--- a/tests/bunit.tests/TestDoubles/PersistentComponentState/BunitPersistentComponentStateTest.cs
+++ b/tests/bunit.tests/TestDoubles/PersistentComponentState/BunitPersistentComponentStateTest.cs
@@ -1,5 +1,3 @@
-using Xunit.Abstractions;
-
 namespace Bunit.TestDoubles;
 
 public class BunitPersistentComponentStateTest : TestContext
@@ -26,7 +24,7 @@ public class BunitPersistentComponentStateTest : TestContext
 
 		var cut = Render<PersistentComponentStateSample>();
 
-		cut.Instance.State.ShouldNotBeNull();
+		cut.AccessInstance(c => c.State.ShouldNotBeNull());
 	}
 
 	[Theory(DisplayName = "Persist stores state in store for components to consume")]
@@ -51,7 +49,7 @@ public class BunitPersistentComponentStateTest : TestContext
 		fakeState.TriggerOnPersisting();
 
 		fakeState.TryTake<WeatherForecast[]>(PersistentComponentStateSample.PersistenceKey, out var actual).ShouldBeTrue();
-		actual.ShouldBeEquivalentTo(cut.Instance.Forecasts);
+		cut.AccessInstance(c => c.Forecasts.ShouldBeEquivalentTo(actual));
 	}
 
 	[Theory(DisplayName = "TryTake returns false if key is not in store")]


### PR DESCRIPTION
This PR removed `IRenderedComponent<TComponent>.Instance` method in favour of `IRenderedComponent<TComponent>.AccessComponent`.

On top, I removed `cut.InvokeAsync` as without a direct instance (and `AccessInstance` wrapped in `InvokeAsync`) there should be no need anymore.