### PR TITLE
refactor: use UnsafeAccessorAttribute instead of reflection for .NET 8

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -19,7 +19,7 @@
 
 	<PropertyGroup Label="Compile settings">
 		<Nullable>enable</Nullable>
-		<LangVersion>11.0</LangVersion>
+		<LangVersion>preview</LangVersion>
 		<AccelerateBuildsInVisualStudio>false</AccelerateBuildsInVisualStudio>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<NoWarn>CA1014,NU5104,NETSDK1138,SYSLIB0051</NoWarn>

--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -38,3 +38,4 @@
 ##########################################
 
 dotnet_diagnostic.S1133.severity = none # S1133: Deprecated code should be removed
+dotnet_diagnostic.S3011.severity = none # S3011: Reflection should not be used to increase accessibility of classes, methods, or fields


### PR DESCRIPTION
Use the UnsafeAccessorAttribute instead of reflection for .NET 8 code paths. More here: https://github.com/dotnet/runtime/issues/81741