### PR TITLE
fix: Added missing namespace for doc reference

### DIFF
--- a/docs/site/docs/getting-started/writing-tests.md
+++ b/docs/site/docs/getting-started/writing-tests.md
@@ -137,7 +137,7 @@ This is a simple example of writing tests in `.cs` files which tests the followi
 The test above does the following:
 
 1. Inherits from the bUnit's `TestContext`. This base class offers the majority of functions.
-2. Renders the `<HelloWorld>` component using <xref:Bunit.TestContext>, which is done through the <xref:Bunit.TestContext.RenderComponent``1(Action{Bunit.ComponentParameterCollectionBuilder{``0}})> method. We cover passing parameters to components on the <xref:passing-parameters-to-components> page.
+2. Renders the `<HelloWorld>` component using <xref:Bunit.TestContext>, which is done through the <xref:Bunit.TestContext.RenderComponent``1(System.Action{Bunit.ComponentParameterCollectionBuilder{``0}})> method. We cover passing parameters to components on the <xref:passing-parameters-to-components> page.
 3. Verifies the rendered markup from the `<HelloWorld>` component using the `MarkupMatches` method. The `MarkupMatches` method performs a semantic comparison of the expected markup with the rendered markup.
 
 # [NUnit](#tab/nunit)
@@ -151,7 +151,7 @@ Since NUnit instantiates a test class only once for all tests inside it, we cann
 The test above does the following:
 
 1. Inherits from the `BunitTestContext` listed above. This base class offers the majority of functions.
-2. Renders the `<HelloWorld>` component using <xref:Bunit.TestContext>, which is done through the <xref:Bunit.TestContext.RenderComponent``1(Action{Bunit.ComponentParameterCollectionBuilder{``0}})> method. We cover passing parameters to components on the <xref:passing-parameters-to-components> page.
+2. Renders the `<HelloWorld>` component using <xref:Bunit.TestContext>, which is done through the <xref:Bunit.TestContext.RenderComponent``1(System.Action{Bunit.ComponentParameterCollectionBuilder{``0}})> method. We cover passing parameters to components on the <xref:passing-parameters-to-components> page.
 3. Verifies the rendered markup from the `<HelloWorld>` component using the `MarkupMatches` method. The `MarkupMatches` method performs a semantic comparison of the expected markup with the rendered markup.
 
 Alternatively, use the [LifeCycle.InstancePerTestCase](https://docs.nunit.org/articles/nunit/writing-tests/attributes/fixturelifecycle.html) attribute (introduced in NUnit 3.13) so that a new instance of the test class is created for each test removing the need for the wrapper.
@@ -169,7 +169,7 @@ Since MSTest instantiates a test class only once for all tests inside it, we can
 The test above does the following:
 
 1. Inherits from the `BunitTestContext` listed above. This base class offers the majority of functions.
-2. Renders the `<HelloWorld>` component using <xref:Bunit.TestContext>, which is done through the <xref:Bunit.TestContext.RenderComponent``1(Action{Bunit.ComponentParameterCollectionBuilder{``0}})> method. We cover passing parameters to components on the <xref:passing-parameters-to-components> page.
+2. Renders the `<HelloWorld>` component using <xref:Bunit.TestContext>, which is done through the <xref:Bunit.TestContext.RenderComponent``1(System.Action{Bunit.ComponentParameterCollectionBuilder{``0}})> method. We cover passing parameters to components on the <xref:passing-parameters-to-components> page.
 3. Verifies the rendered markup from the `<HelloWorld>` component using the `MarkupMatches` method. The `MarkupMatches` method performs a semantic comparison of the expected markup with the rendered markup.
 
 ***


### PR DESCRIPTION
Added missing `System` namespace.

See:
<img width="834" alt="image" src="https://github.com/bUnit-dev/bUnit/assets/26365461/7ebf7191-05f3-499e-81e0-1fb441072aee">

See also: https://bunit.dev/docs/getting-started/writing-tests.html