### PR TITLE
docs: add section about InvaldOperationException when using razor tests

### DIFF
--- a/docs/site/docs/providing-input/passing-parameters-to-components.md
+++ b/docs/site/docs/providing-input/passing-parameters-to-components.md
@@ -427,7 +427,9 @@ When the razor syntax is used and the test throws the following exception:
 
 > System.InvalidOperationException: The render handle is not yet assigned.
 
-This usually means that the test is direclty inheriting from `ComponentBase` and not from `TestContext`. The solution is to inherit from `TestContext` instead.
+This usually means that the test class (Blazor component where the tests is declared in) is direclty inheriting from `ComponentBase`, as is the default for all Blazor components.
+
+The solution is to inherit from bUnits `TestContext` instead, i.e.:
 ```razor
 @inherits TestContext
 

--- a/docs/site/docs/providing-input/passing-parameters-to-components.md
+++ b/docs/site/docs/providing-input/passing-parameters-to-components.md
@@ -422,6 +422,24 @@ There are scenarios where it is not possible or not desirable to inherit from `T
 
 ***
 
+## Getting an `InvalidOperationException`
+When the razor syntax is used and the test throws the following exception:
+
+> System.InvalidOperationException: The render handle is not yet assigned.
+
+This usually means that the test is direclty inheriting from `ComponentBase` and not from `TestContext`. The solution is to inherit from `TestContext` instead.
+```razor
+@inherits TestContext
+
+@code {
+    [Fact]
+    public void Test1()
+    {
+        // test code
+    }
+}
+```
+
 ## Further Reading
 
 - <xref:inject-services>


### PR DESCRIPTION
Adding IOE text when using razor syntax for tests.