### PR TITLE
refactor: Remove obsolete docfx tools-dep

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -7,12 +7,6 @@
       "commands": [
         "dotnet-serve"
       ]
-    },
-    "docfx": {
-      "version": "2.74.0",
-      "commands": [
-        "docfx"
-      ]
     }
   }
 }


### PR DESCRIPTION
Removes docfx from `.config/dotnet-tools.json`