### PR TITLE
docs: Fix wrong link marker

### DIFF
--- a/docs/site/docs/toc.md
+++ b/docs/site/docs/toc.md
@@ -30,7 +30,7 @@
 ## [Faking IWebAssemblyHostEnvironment](xref:fake-webassemblyhostenvironment)
 ## [Testing with InputFile component](xref:input-file)
 
-# [Extensions][xref:extensions]
+# [Extensions](xref:extensions)
 ## [bunit.generators](xref:bunit-generators)
 
 # [Miscellaneous testing tips](xref:misc-test-tips)


### PR DESCRIPTION
Wrong link:
<img width="244" alt="image" src="https://github.com/bUnit-dev/bUnit/assets/26365461/ac6ed23a-8848-4e0e-8d4f-3fabfa9a942a">
