### PR TITLE
fix: Use preview instead of alpha tag

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "2.0-alpha",
+  "version": "2.0-preview",
   "assemblyVersion": {
     "precision": "revision"
   },
@@ -17,7 +17,7 @@
   },
   "release": {
     "branchName": "release/v{version}",
-    "firstUnstableTag": "alpha"
+    "firstUnstableTag": "preview"
   },
   "pathFilters": [
     "./src"


### PR DESCRIPTION
I really would go for "beta" (or even "preview" as we already have it and as the dotnet team does it) instead of "alpha".
Mainly because I don't believe we are that unstable, and secondly, it is easier for folks to try a beta than an alpha (alpha conveys a certain meaning).

PS: Settled on preview.