### PR TITLE
feat: Add flag to actively wait for async disposal

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -79,3 +79,6 @@ Or use the `BunitContext` directly and manage the lifecycle yourself.
 
 ## `TestServiceProvider` renamed to `BunitTestServiceProvider`
 The `TestServiceProvider` class has been renamed to `BunitTestServiceProvider`. If you used `TestServiceProvider`, you should replace it with `BunitTestServiceProvider`.
+
+## `DisposeComponents` is now asynchronous and called `DisposeComponentsAsync`
+`DisposeComponentsAsync` allows to await `DisposeAsync` of components under test. If you used `DisposeComponents`, you should replace it with `DisposeComponentsAsync`.

--- a/docs/samples/components/AsyncDisposableComponent.razor
+++ b/docs/samples/components/AsyncDisposableComponent.razor
@@ -1,0 +1,10 @@
+@using Microsoft.JSInterop
+@implements IAsyncDisposable
+@inject IJSRuntime JSRuntime
+@code {
+
+  public async ValueTask DisposeAsync()
+  {
+    await JSRuntime.InvokeVoidAsync("dispose");
+  }
+}

--- a/docs/samples/tests/xunit/DisposeComponentsTest.cs
+++ b/docs/samples/tests/xunit/DisposeComponentsTest.cs
@@ -8,14 +8,14 @@ namespace Bunit.Docs.Samples;
 public class DisposeComponentsTest : BunitContext
 {
   [Fact]
-  public void DisposeElements()
+  public async Task DisposeElements()
   {
     var calledTimes = 0;
     var cut = Render<DisposableComponent>(parameters => parameters
       .Add(p => p.LocationChangedCallback, url => calledTimes++)
     );
 
-    DisposeComponents();
+    await DisposeComponentsAsync();
 
     Services.GetRequiredService<NavigationManager>().NavigateTo("newurl");
 
@@ -23,22 +23,33 @@ public class DisposeComponentsTest : BunitContext
   }
 
   [Fact]
-  public void ShouldCatchExceptionInDispose()
+  public async Task ShouldCatchExceptionInDispose()
   {
     Render<ExceptionInDisposeComponent>();
 
-    var act = DisposeComponents;
+    Func<Task> act = () => DisposeComponentsAsync();
 
-    Assert.Throws<NotSupportedException>(act);
+    await Assert.ThrowsAsync<NotSupportedException>(act);
   }
 
   [Fact]
-  public void ShouldCatchExceptionInDisposeAsync()
+  public async Task ShouldCatchExceptionInDisposeAsync()
   {
     Render<ExceptionInDisposeAsyncComponent>();
 
-    DisposeComponents();
+    await DisposeComponentsAsync();
     var exception = Renderer.UnhandledException.Result;
     Assert.IsType<NotSupportedException>(exception);
+  }
+
+  [Fact]
+  public async Task ShouldDisposeJSObject()
+  {
+    JSInterop.SetupVoid("dispose").SetVoidResult();
+    Render<AsyncDisposableComponent>();
+
+    await DisposeComponentsAsync();
+
+    JSInterop.VerifyInvoke("dispose");
   }
 }

--- a/docs/site/docs/interaction/dispose-components.md
+++ b/docs/site/docs/interaction/dispose-components.md
@@ -4,22 +4,33 @@ title: Disposing components and their children
 ---
 
 # Disposing components
-To dispose all components rendered with a `BunitContext`, use the [`DisposeComponents`](xref:Bunit.BunitContext.DisposeComponents) method.  Calling this method will dispose all rendered components, calling any `IDisposable.Dispose` or/and `IAsyncDisposable.DisposeAsync` methods they might have, and remove the components from the render tree, starting with the root components and then walking down the render tree to all the child components.
+To dispose all components rendered with a `BunitContext`, use the [`DisposeComponents`](xref:Bunit.BunitContext.DisposeComponentsAsync) method.  Calling this method will dispose all rendered components, calling any `IDisposable.Dispose` or/and `IAsyncDisposable.DisposeAsync` methods they might have, and remove the components from the render tree, starting with the root components and then walking down the render tree to all the child components.
 
 Disposing rendered components enables testing of logic in `Dispose` methods, e.g., event handlers, that should be detached to avoid memory leaks.
 
 The following example of this:
 
-[!code-csharp[](../../../samples/tests/xunit/DisposeComponentsTest.cs#L13-L22)]
+[!code-csharp[DisposeComponentsTest.cs](../../../samples/tests/xunit/DisposeComponentsTest.cs#L13-L22)]
 
 > [!WARNING]
 > For `IAsyncDisposable` (since .net5) relying on [`WaitForState()`](xref:Bunit.RenderedFragmentWaitForHelperExtensions.WaitForState(Bunit.RenderedFragment,System.Func{System.Boolean},System.Nullable{System.TimeSpan})) or [`WaitForAssertion()`](xref:Bunit.RenderedFragmentWaitForHelperExtensions.WaitForAssertion(Bunit.RenderedFragment,System.Action,System.Nullable{System.TimeSpan})) will not work as a disposed component will not trigger a new render cycle.
 
-## Checking for exceptions
-`Dispose` as well as `DisposeAsync` can throw exceptions which can be asserted as well. If a component under test throws an exception in `Dispose` the [`DisposeComponents`](xref:Bunit.BunitContext.DisposeComponents) will throw the exception to the user code:
+## Disposing components asynchronously
+If a component implements `IAsyncDisposable`, `DisposeComponentsAsync` can be awaited to wait for all asynchronous `DisposeAsync` methods. Sometimes interacting with JavaScript in Blazor WebAssembly requires disposing or resetting state in `DisposeAsync`.
 
-[!code-csharp[](../../../samples/tests/xunit/DisposeComponentsTest.cs#L28-L32)]
+[!code-csharp[DisposeComponentsTest.cs](../../../samples/tests/xunit/DisposeComponentsTest.cs#L48-L53)]
+
+To omit this behavior, discard the returned task
+
+```csharp
+_ = DisposeComponentsAsync();
+```
+
+## Checking for exceptions
+`Dispose` as well as `DisposeAsync` can throw exceptions which can be asserted as well. If a component under test throws an exception in `Dispose` the [`DisposeComponents`](xref:Bunit.BunitContext.DisposeComponentsAsync) will throw the exception to the user code:
+
+[!code-csharp[DisposeComponentsTest.cs](../../../samples/tests/xunit/DisposeComponentsTest.cs#L28-L32)]
 
 `DisposeAsync` behaves a bit different. The following example will demonstrate how to assert an exception in `DisposeAsync`:
 
-[!code-csharp[](../../../samples/tests/xunit/DisposeComponentsTest.cs#L39-L43)]
+[!code-csharp[DisposeComponentsTest.cs](../../../samples/tests/xunit/DisposeComponentsTest.cs#L38-L42)]

--- a/src/bunit/BunitContext.cs
+++ b/src/bunit/BunitContext.cs
@@ -130,10 +130,7 @@ public partial class BunitContext : IDisposable, IAsyncDisposable
 	/// <summary>
 	/// Disposes all components rendered via this <see cref="BunitContext"/>.
 	/// </summary>
-	public void DisposeComponents()
-	{
-		Renderer.DisposeComponents();
-	}
+	public Task DisposeComponentsAsync() => Renderer.DisposeComponents();
 
 	/// <summary>
 	/// Instantiates and performs a first render of a component of type <typeparamref name="TComponent"/>.

--- a/tests/bunit.testassets/AssertExtensions/TaskAssertionExtensions.cs
+++ b/tests/bunit.testassets/AssertExtensions/TaskAssertionExtensions.cs
@@ -1,9 +1,0 @@
-namespace Bunit;
-
-public static class TaskAssertionExtensions
-{
-	public static async Task ShouldCompleteWithin(this Task task, TimeSpan timeout)
-	{
-		await task.WaitAsync(timeout);
-	}
-}


### PR DESCRIPTION
This Pull Request tackles and closes #1232

The idea is to hook into the queue and "collect" the disposal tasks in our renderer. 
I would like your opinion on the API design. I went back and forth and settled on the current shape (with an optional boolean flag).