### PR TITLE
feat: extend mouse event extension methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,12 @@ All notable changes to **bUnit** will be documented in this file. The project ad
 ## [Unreleased]
 
 ### Changed
+
 - `NavigationManager` is again registered as a singleton instead of scoped.
+
+### Added
+
+- More asynchronous extension methods to the `MouseEventDispatcher` to enable awaiting the event handlers. By [@Qwertyluk](https://github.com/Qwertyluk)
 
 ## [1.27.17] - 2024-03-02
 

--- a/src/bunit.web/EventDispatchExtensions/MouseEventDispatchExtensions.cs
+++ b/src/bunit.web/EventDispatchExtensions/MouseEventDispatchExtensions.cs
@@ -48,6 +48,37 @@ public static class MouseEventDispatchExtensions
 		=> _ = MouseOverAsync(element, eventArgs);
 
 	/// <summary>
+	/// Raises the <c>@onmouseover</c> event on <paramref name="element"/>,  passing the provided
+	/// properties to the event handler via a <see cref="MouseEventArgs"/> object.
+	/// </summary>
+	/// <param name="element">The element to raise the event on.</param>
+	/// <param name="detail">A count of consecutive clicks that happened in a short amount of time, incremented by one.</param>
+	/// <param name="screenX">The X coordinate of the mouse pointer in global (screen) coordinates.</param>
+	/// <param name="screenY">The Y coordinate of the mouse pointer in global (screen) coordinates.</param>
+	/// <param name="clientX">The X coordinate of the mouse pointer in local (DOM content) coordinates.</param>
+	/// <param name="clientY">The Y coordinate of the mouse pointer in local (DOM content) coordinates.</param>
+	/// <param name="button">
+	///     The button number that was pressed when the mouse event was fired: Left button=0,
+	///     middle button=1 (if present), right button=2. For mice configured for left handed
+	///     use in which the button actions are reversed the values are instead read from
+	///     right to left.
+	/// </param>
+	/// <param name="buttons">
+	///     The buttons being pressed when the mouse event was fired: Left button=1, Right
+	///     button=2, Middle (wheel) button=4, 4th button (typically, "Browser Back" button)=8,
+	///     5th button (typically, "Browser Forward" button)=16. If two or more buttons are
+	///     pressed, returns the logical sum of the values. E.g., if Left button and Right
+	///     button are pressed, returns 3 (=1 | 2).
+	/// </param>
+	/// <param name="ctrlKey">true if the control key was down when the event was fired. false otherwise.</param>
+	/// <param name="shiftKey">true if the shift key was down when the event was fired. false otherwise.</param>
+	/// <param name="altKey">true if the alt key was down when the event was fired. false otherwise.</param>
+	/// <param name="metaKey">true if the meta key was down when the event was fired. false otherwise.</param>
+	/// <param name="type">Gets or sets the type of the event.</param>
+	public static Task MouseOverAsync(this IElement element, long detail = default, double screenX = default, double screenY = default, double clientX = default, double clientY = default, long button = default, long buttons = default, bool ctrlKey = default, bool shiftKey = default, bool altKey = default, bool metaKey = default, string? type = default)
+		=> MouseOverAsync(element, new MouseEventArgs { Detail = detail, ScreenX = screenX, ScreenY = screenY, ClientX = clientX, ClientY = clientY, Button = button, Buttons = buttons, CtrlKey = ctrlKey, ShiftKey = shiftKey, AltKey = altKey, MetaKey = metaKey, Type = type! });
+
+	/// <summary>
 	/// Raises the <c>@onmouseover</c> event on <paramref name="element"/>, passing the provided <paramref name="eventArgs"/>
 	/// to the event handler.
 	/// </summary>
@@ -95,6 +126,37 @@ public static class MouseEventDispatchExtensions
 	/// <param name="eventArgs">The event arguments to pass to the event handler.</param>
 	public static void MouseOut(this IElement element, MouseEventArgs eventArgs)
 		=> _ = MouseOutAsync(element, eventArgs);
+
+	/// <summary>
+	/// Raises the <c>@onmouseout</c> event on <paramref name="element"/>,  passing the provided
+	/// properties to the event handler via a <see cref="MouseEventArgs"/> object.
+	/// </summary>
+	/// <param name="element">The element to raise the event on.</param>
+	/// <param name="detail">A count of consecutive clicks that happened in a short amount of time, incremented by one.</param>
+	/// <param name="screenX">The X coordinate of the mouse pointer in global (screen) coordinates.</param>
+	/// <param name="screenY">The Y coordinate of the mouse pointer in global (screen) coordinates.</param>
+	/// <param name="clientX">The X coordinate of the mouse pointer in local (DOM content) coordinates.</param>
+	/// <param name="clientY">The Y coordinate of the mouse pointer in local (DOM content) coordinates.</param>
+	/// <param name="button">
+	///     The button number that was pressed when the mouse event was fired: Left button=0,
+	///     middle button=1 (if present), right button=2. For mice configured for left handed
+	///     use in which the button actions are reversed the values are instead read from
+	///     right to left.
+	/// </param>
+	/// <param name="buttons">
+	///     The buttons being pressed when the mouse event was fired: Left button=1, Right
+	///     button=2, Middle (wheel) button=4, 4th button (typically, "Browser Back" button)=8,
+	///     5th button (typically, "Browser Forward" button)=16. If two or more buttons are
+	///     pressed, returns the logical sum of the values. E.g., if Left button and Right
+	///     button are pressed, returns 3 (=1 | 2).
+	/// </param>
+	/// <param name="ctrlKey">true if the control key was down when the event was fired. false otherwise.</param>
+	/// <param name="shiftKey">true if the shift key was down when the event was fired. false otherwise.</param>
+	/// <param name="altKey">true if the alt key was down when the event was fired. false otherwise.</param>
+	/// <param name="metaKey">true if the meta key was down when the event was fired. false otherwise.</param>
+	/// <param name="type">Gets or sets the type of the event.</param>
+	public static Task MouseOutAsync(this IElement element, long detail = default, double screenX = default, double screenY = default, double clientX = default, double clientY = default, long button = default, long buttons = default, bool ctrlKey = default, bool shiftKey = default, bool altKey = default, bool metaKey = default, string? type = default)
+		=> MouseOutAsync(element, new MouseEventArgs { Detail = detail, ScreenX = screenX, ScreenY = screenY, ClientX = clientX, ClientY = clientY, Button = button, Buttons = buttons, CtrlKey = ctrlKey, ShiftKey = shiftKey, AltKey = altKey, MetaKey = metaKey, Type = type! });
 
 	/// <summary>
 	/// Raises the <c>@onmouseout</c> event on <paramref name="element"/>, passing the provided <paramref name="eventArgs"/>
@@ -146,6 +208,37 @@ public static class MouseEventDispatchExtensions
 		=> _ = MouseMoveAsync(element, eventArgs);
 
 	/// <summary>
+	/// Raises the <c>@onmousemove</c> event on <paramref name="element"/>,  passing the provided
+	/// properties to the event handler via a <see cref="MouseEventArgs"/> object.
+	/// </summary>
+	/// <param name="element">The element to raise the event on.</param>
+	/// <param name="detail">A count of consecutive clicks that happened in a short amount of time, incremented by one.</param>
+	/// <param name="screenX">The X coordinate of the mouse pointer in global (screen) coordinates.</param>
+	/// <param name="screenY">The Y coordinate of the mouse pointer in global (screen) coordinates.</param>
+	/// <param name="clientX">The X coordinate of the mouse pointer in local (DOM content) coordinates.</param>
+	/// <param name="clientY">The Y coordinate of the mouse pointer in local (DOM content) coordinates.</param>
+	/// <param name="button">
+	///     The button number that was pressed when the mouse event was fired: Left button=0,
+	///     middle button=1 (if present), right button=2. For mice configured for left handed
+	///     use in which the button actions are reversed the values are instead read from
+	///     right to left.
+	/// </param>
+	/// <param name="buttons">
+	///     The buttons being pressed when the mouse event was fired: Left button=1, Right
+	///     button=2, Middle (wheel) button=4, 4th button (typically, "Browser Back" button)=8,
+	///     5th button (typically, "Browser Forward" button)=16. If two or more buttons are
+	///     pressed, returns the logical sum of the values. E.g., if Left button and Right
+	///     button are pressed, returns 3 (=1 | 2).
+	/// </param>
+	/// <param name="ctrlKey">true if the control key was down when the event was fired. false otherwise.</param>
+	/// <param name="shiftKey">true if the shift key was down when the event was fired. false otherwise.</param>
+	/// <param name="altKey">true if the alt key was down when the event was fired. false otherwise.</param>
+	/// <param name="metaKey">true if the meta key was down when the event was fired. false otherwise.</param>
+	/// <param name="type">Gets or sets the type of the event.</param>
+	public static Task MouseMoveAsync(this IElement element, long detail = default, double screenX = default, double screenY = default, double clientX = default, double clientY = default, long button = default, long buttons = default, bool ctrlKey = default, bool shiftKey = default, bool altKey = default, bool metaKey = default, string? type = default)
+		=> MouseMoveAsync(element, new MouseEventArgs { Detail = detail, ScreenX = screenX, ScreenY = screenY, ClientX = clientX, ClientY = clientY, Button = button, Buttons = buttons, CtrlKey = ctrlKey, ShiftKey = shiftKey, AltKey = altKey, MetaKey = metaKey, Type = type! });
+
+	/// <summary>
 	/// Raises the <c>@onmousemove</c> event on <paramref name="element"/>, passing the provided <paramref name="eventArgs"/>
 	/// to the event handler.
 	/// </summary>
@@ -193,6 +286,37 @@ public static class MouseEventDispatchExtensions
 	/// <param name="eventArgs">The event arguments to pass to the event handler.</param>
 	public static void MouseDown(this IElement element, MouseEventArgs eventArgs)
 		=> _ = MouseDownAsync(element, eventArgs);
+
+	/// <summary>
+	/// Raises the <c>@onmousedown</c> event on <paramref name="element"/>,  passing the provided
+	/// properties to the event handler via a <see cref="MouseEventArgs"/> object.
+	/// </summary>
+	/// <param name="element">The element to raise the event on.</param>
+	/// <param name="detail">A count of consecutive clicks that happened in a short amount of time, incremented by one.</param>
+	/// <param name="screenX">The X coordinate of the mouse pointer in global (screen) coordinates.</param>
+	/// <param name="screenY">The Y coordinate of the mouse pointer in global (screen) coordinates.</param>
+	/// <param name="clientX">The X coordinate of the mouse pointer in local (DOM content) coordinates.</param>
+	/// <param name="clientY">The Y coordinate of the mouse pointer in local (DOM content) coordinates.</param>
+	/// <param name="button">
+	///     The button number that was pressed when the mouse event was fired: Left button=0,
+	///     middle button=1 (if present), right button=2. For mice configured for left handed
+	///     use in which the button actions are reversed the values are instead read from
+	///     right to left.
+	/// </param>
+	/// <param name="buttons">
+	///     The buttons being pressed when the mouse event was fired: Left button=1, Right
+	///     button=2, Middle (wheel) button=4, 4th button (typically, "Browser Back" button)=8,
+	///     5th button (typically, "Browser Forward" button)=16. If two or more buttons are
+	///     pressed, returns the logical sum of the values. E.g., if Left button and Right
+	///     button are pressed, returns 3 (=1 | 2).
+	/// </param>
+	/// <param name="ctrlKey">true if the control key was down when the event was fired. false otherwise.</param>
+	/// <param name="shiftKey">true if the shift key was down when the event was fired. false otherwise.</param>
+	/// <param name="altKey">true if the alt key was down when the event was fired. false otherwise.</param>
+	/// <param name="metaKey">true if the meta key was down when the event was fired. false otherwise.</param>
+	/// <param name="type">Gets or sets the type of the event.</param>
+	public static Task MouseDownAsync(this IElement element, long detail = default, double screenX = default, double screenY = default, double clientX = default, double clientY = default, long button = default, long buttons = default, bool ctrlKey = default, bool shiftKey = default, bool altKey = default, bool metaKey = default, string? type = default)
+		=> MouseDownAsync(element, new MouseEventArgs { Detail = detail, ScreenX = screenX, ScreenY = screenY, ClientX = clientX, ClientY = clientY, Button = button, Buttons = buttons, CtrlKey = ctrlKey, ShiftKey = shiftKey, AltKey = altKey, MetaKey = metaKey, Type = type! });
 
 	/// <summary>
 	/// Raises the <c>@onmousedown</c> event on <paramref name="element"/>, passing the provided <paramref name="eventArgs"/>
@@ -244,6 +368,37 @@ public static class MouseEventDispatchExtensions
 		=> _ = MouseUpAsync(element, eventArgs);
 
 	/// <summary>
+	/// Raises the <c>@onmouseup</c> event on <paramref name="element"/>,  passing the provided
+	/// properties to the event handler via a <see cref="MouseEventArgs"/> object.
+	/// </summary>
+	/// <param name="element">The element to raise the event on.</param>
+	/// <param name="detail">A count of consecutive clicks that happened in a short amount of time, incremented by one.</param>
+	/// <param name="screenX">The X coordinate of the mouse pointer in global (screen) coordinates.</param>
+	/// <param name="screenY">The Y coordinate of the mouse pointer in global (screen) coordinates.</param>
+	/// <param name="clientX">The X coordinate of the mouse pointer in local (DOM content) coordinates.</param>
+	/// <param name="clientY">The Y coordinate of the mouse pointer in local (DOM content) coordinates.</param>
+	/// <param name="button">
+	///     The button number that was pressed when the mouse event was fired: Left button=0,
+	///     middle button=1 (if present), right button=2. For mice configured for left handed
+	///     use in which the button actions are reversed the values are instead read from
+	///     right to left.
+	/// </param>
+	/// <param name="buttons">
+	///     The buttons being pressed when the mouse event was fired: Left button=1, Right
+	///     button=2, Middle (wheel) button=4, 4th button (typically, "Browser Back" button)=8,
+	///     5th button (typically, "Browser Forward" button)=16. If two or more buttons are
+	///     pressed, returns the logical sum of the values. E.g., if Left button and Right
+	///     button are pressed, returns 3 (=1 | 2).
+	/// </param>
+	/// <param name="ctrlKey">true if the control key was down when the event was fired. false otherwise.</param>
+	/// <param name="shiftKey">true if the shift key was down when the event was fired. false otherwise.</param>
+	/// <param name="altKey">true if the alt key was down when the event was fired. false otherwise.</param>
+	/// <param name="metaKey">true if the meta key was down when the event was fired. false otherwise.</param>
+	/// <param name="type">Gets or sets the type of the event.</param>
+	public static Task MouseUpAsync(this IElement element, long detail = default, double screenX = default, double screenY = default, double clientX = default, double clientY = default, long button = default, long buttons = default, bool ctrlKey = default, bool shiftKey = default, bool altKey = default, bool metaKey = default, string? type = default)
+		=> MouseUpAsync(element, new MouseEventArgs { Detail = detail, ScreenX = screenX, ScreenY = screenY, ClientX = clientX, ClientY = clientY, Button = button, Buttons = buttons, CtrlKey = ctrlKey, ShiftKey = shiftKey, AltKey = altKey, MetaKey = metaKey, Type = type! });
+
+	/// <summary>
 	/// Raises the <c>@onmouseup</c> event on <paramref name="element"/>, passing the provided <paramref name="eventArgs"/>
 	/// to the event handler.
 	/// </summary>
@@ -287,6 +442,41 @@ public static class MouseEventDispatchExtensions
 	/// <param name="type">Gets or sets the type of the event.</param>
 	public static void Click(this IElement element, long detail = 1, double screenX = default, double screenY = default, double clientX = default, double clientY = default, double pageX = 0, double pageY = 0, double offsetX = 0, double offsetY = 0, long button = default, long buttons = default, bool ctrlKey = default, bool shiftKey = default, bool altKey = default, bool metaKey = default, string? type = default)
 		=> _ = ClickAsync(element, new MouseEventArgs { Detail = detail, ScreenX = screenX, ScreenY = screenY, ClientX = clientX, PageX = pageX, PageY = pageY, OffsetX = offsetX, OffsetY = offsetY, ClientY = clientY, Button = button, Buttons = buttons, CtrlKey = ctrlKey, ShiftKey = shiftKey, AltKey = altKey, MetaKey = metaKey, Type = type! });
+
+	/// <summary>
+	/// Raises the <c>@onclick</c> event on <paramref name="element"/>,  passing the provided
+	/// properties to the event handler via a <see cref="MouseEventArgs"/> object.
+	/// </summary>
+	/// <param name="element">The element to raise the event on.</param>
+	/// <param name="detail">A count of consecutive clicks that happened in a short amount of time, incremented by one.</param>
+	/// <param name="screenX">The X coordinate of the mouse pointer in global (screen) coordinates.</param>
+	/// <param name="screenY">The Y coordinate of the mouse pointer in global (screen) coordinates.</param>
+	/// <param name="clientX">The X coordinate of the mouse pointer in local (DOM content) coordinates.</param>
+	/// <param name="clientY">The Y coordinate of the mouse pointer in local (DOM content) coordinates.</param>
+	/// <param name="pageX">The X coordinate of the mouse pointer relative to the whole document.</param>
+	/// <param name="pageY">The Y coordinate of the mouse pointer relative to the whole document.</param>
+	/// <param name="offsetX">The X coordinate of the mouse pointer in relative (Target Element) coordinates.</param>
+	/// <param name="offsetY">The Y coordinate of the mouse pointer in relative (Target Element) coordinates.</param>
+	/// <param name="button">
+	///     The button number that was pressed when the mouse event was fired: Left button=0,
+	///     middle button=1 (if present), right button=2. For mice configured for left handed
+	///     use in which the button actions are reversed the values are instead read from
+	///     right to left.
+	/// </param>
+	/// <param name="buttons">
+	///     The buttons being pressed when the mouse event was fired: Left button=1, Right
+	///     button=2, Middle (wheel) button=4, 4th button (typically, "Browser Back" button)=8,
+	///     5th button (typically, "Browser Forward" button)=16. If two or more buttons are
+	///     pressed, returns the logical sum of the values. E.g., if Left button and Right
+	///     button are pressed, returns 3 (=1 | 2).
+	/// </param>
+	/// <param name="ctrlKey">true if the control key was down when the event was fired. false otherwise.</param>
+	/// <param name="shiftKey">true if the shift key was down when the event was fired. false otherwise.</param>
+	/// <param name="altKey">true if the alt key was down when the event was fired. false otherwise.</param>
+	/// <param name="metaKey">true if the meta key was down when the event was fired. false otherwise.</param>
+	/// <param name="type">Gets or sets the type of the event.</param>
+	public static Task ClickAsync(this IElement element, long detail = 1, double screenX = default, double screenY = default, double clientX = default, double clientY = default, double pageX = 0, double pageY = 0, double offsetX = 0, double offsetY = 0, long button = default, long buttons = default, bool ctrlKey = default, bool shiftKey = default, bool altKey = default, bool metaKey = default, string? type = default)
+		=> ClickAsync(element, new MouseEventArgs { Detail = detail, ScreenX = screenX, ScreenY = screenY, ClientX = clientX, PageX = pageX, PageY = pageY, OffsetX = offsetX, OffsetY = offsetY, ClientY = clientY, Button = button, Buttons = buttons, CtrlKey = ctrlKey, ShiftKey = shiftKey, AltKey = altKey, MetaKey = metaKey, Type = type! });
 #elif NET5_0
 	/// <summary>
 	/// Raises the <c>@onclick</c> event on <paramref name="element"/>,  passing the provided
@@ -320,6 +510,39 @@ public static class MouseEventDispatchExtensions
 	/// <param name="type">Gets or sets the type of the event.</param>
 	public static void Click(this IElement element, long detail = 1, double screenX = default, double screenY = default, double clientX = default, double clientY = default, double offsetX = 0, double offsetY = 0, long button = default, long buttons = default, bool ctrlKey = default, bool shiftKey = default, bool altKey = default, bool metaKey = default, string? type = default)
 		=> _ = ClickAsync(element, new MouseEventArgs { Detail = detail, ScreenX = screenX, ScreenY = screenY, ClientX = clientX, OffsetX = offsetX, OffsetY = offsetY, ClientY = clientY, Button = button, Buttons = buttons, CtrlKey = ctrlKey, ShiftKey = shiftKey, AltKey = altKey, MetaKey = metaKey, Type = type! });
+
+	/// <summary>
+	/// Raises the <c>@onclick</c> event on <paramref name="element"/>,  passing the provided
+	/// properties to the event handler via a <see cref="MouseEventArgs"/> object.
+	/// </summary>
+	/// <param name="element">The element to raise the event on.</param>
+	/// <param name="detail">A count of consecutive clicks that happened in a short amount of time, incremented by one.</param>
+	/// <param name="screenX">The X coordinate of the mouse pointer in global (screen) coordinates.</param>
+	/// <param name="screenY">The Y coordinate of the mouse pointer in global (screen) coordinates.</param>
+	/// <param name="clientX">The X coordinate of the mouse pointer in local (DOM content) coordinates.</param>
+	/// <param name="clientY">The Y coordinate of the mouse pointer in local (DOM content) coordinates.</param>
+	/// <param name="offsetX">The X coordinate of the mouse pointer in relative (Target Element) coordinates.</param>
+	/// <param name="offsetY">The Y coordinate of the mouse pointer in relative (Target Element) coordinates.</param>
+	/// <param name="button">
+	///     The button number that was pressed when the mouse event was fired: Left button=0,
+	///     middle button=1 (if present), right button=2. For mice configured for left handed
+	///     use in which the button actions are reversed the values are instead read from
+	///     right to left.
+	/// </param>
+	/// <param name="buttons">
+	///     The buttons being pressed when the mouse event was fired: Left button=1, Right
+	///     button=2, Middle (wheel) button=4, 4th button (typically, "Browser Back" button)=8,
+	///     5th button (typically, "Browser Forward" button)=16. If two or more buttons are
+	///     pressed, returns the logical sum of the values. E.g., if Left button and Right
+	///     button are pressed, returns 3 (=1 | 2).
+	/// </param>
+	/// <param name="ctrlKey">true if the control key was down when the event was fired. false otherwise.</param>
+	/// <param name="shiftKey">true if the shift key was down when the event was fired. false otherwise.</param>
+	/// <param name="altKey">true if the alt key was down when the event was fired. false otherwise.</param>
+	/// <param name="metaKey">true if the meta key was down when the event was fired. false otherwise.</param>
+	/// <param name="type">Gets or sets the type of the event.</param>
+	public static Task ClickAsync(this IElement element, long detail = 1, double screenX = default, double screenY = default, double clientX = default, double clientY = default, double offsetX = 0, double offsetY = 0, long button = default, long buttons = default, bool ctrlKey = default, bool shiftKey = default, bool altKey = default, bool metaKey = default, string? type = default)
+		=> ClickAsync(element, new MouseEventArgs { Detail = detail, ScreenX = screenX, ScreenY = screenY, ClientX = clientX, OffsetX = offsetX, OffsetY = offsetY, ClientY = clientY, Button = button, Buttons = buttons, CtrlKey = ctrlKey, ShiftKey = shiftKey, AltKey = altKey, MetaKey = metaKey, Type = type! });
 #else
 	/// <summary>
 	/// Raises the <c>@onclick</c> event on <paramref name="element"/>,  passing the provided
@@ -351,6 +574,37 @@ public static class MouseEventDispatchExtensions
 	/// <param name="type">Gets or sets the type of the event.</param>
 	public static void Click(this IElement element, long detail = 1, double screenX = default, double screenY = default, double clientX = default, double clientY = default, long button = default, long buttons = default, bool ctrlKey = default, bool shiftKey = default, bool altKey = default, bool metaKey = default, string? type = default)
 		=> _ = ClickAsync(element, new MouseEventArgs { Detail = detail, ScreenX = screenX, ScreenY = screenY, ClientX = clientX, ClientY = clientY, Button = button, Buttons = buttons, CtrlKey = ctrlKey, ShiftKey = shiftKey, AltKey = altKey, MetaKey = metaKey, Type = type! });
+
+	/// <summary>
+	/// Raises the <c>@onclick</c> event on <paramref name="element"/>,  passing the provided
+	/// properties to the event handler via a <see cref="MouseEventArgs"/> object.
+	/// </summary>
+	/// <param name="element">The element to raise the event on.</param>
+	/// <param name="detail">A count of consecutive clicks that happened in a short amount of time, incremented by one.</param>
+	/// <param name="screenX">The X coordinate of the mouse pointer in global (screen) coordinates.</param>
+	/// <param name="screenY">The Y coordinate of the mouse pointer in global (screen) coordinates.</param>
+	/// <param name="clientX">The X coordinate of the mouse pointer in local (DOM content) coordinates.</param>
+	/// <param name="clientY">The Y coordinate of the mouse pointer in local (DOM content) coordinates.</param>
+	/// <param name="button">
+	///     The button number that was pressed when the mouse event was fired: Left button=0,
+	///     middle button=1 (if present), right button=2. For mice configured for left handed
+	///     use in which the button actions are reversed the values are instead read from
+	///     right to left.
+	/// </param>
+	/// <param name="buttons">
+	///     The buttons being pressed when the mouse event was fired: Left button=1, Right
+	///     button=2, Middle (wheel) button=4, 4th button (typically, "Browser Back" button)=8,
+	///     5th button (typically, "Browser Forward" button)=16. If two or more buttons are
+	///     pressed, returns the logical sum of the values. E.g., if Left button and Right
+	///     button are pressed, returns 3 (=1 | 2).
+	/// </param>
+	/// <param name="ctrlKey">true if the control key was down when the event was fired. false otherwise.</param>
+	/// <param name="shiftKey">true if the shift key was down when the event was fired. false otherwise.</param>
+	/// <param name="altKey">true if the alt key was down when the event was fired. false otherwise.</param>
+	/// <param name="metaKey">true if the meta key was down when the event was fired. false otherwise.</param>
+	/// <param name="type">Gets or sets the type of the event.</param>
+	public static Task ClickAsync(this IElement element, long detail = 1, double screenX = default, double screenY = default, double clientX = default, double clientY = default, long button = default, long buttons = default, bool ctrlKey = default, bool shiftKey = default, bool altKey = default, bool metaKey = default, string? type = default)
+		=> ClickAsync(element, new MouseEventArgs { Detail = detail, ScreenX = screenX, ScreenY = screenY, ClientX = clientX, ClientY = clientY, Button = button, Buttons = buttons, CtrlKey = ctrlKey, ShiftKey = shiftKey, AltKey = altKey, MetaKey = metaKey, Type = type! });
 #endif
 
 
@@ -407,6 +661,41 @@ public static class MouseEventDispatchExtensions
 	/// <param name="type">Gets or sets the type of the event.</param>
 	public static void DoubleClick(this IElement element, long detail = 2, double screenX = default, double screenY = default, double clientX = default, double clientY = default, double pageX = 0, double pageY = 0, double offsetX = 0, double offsetY = 0, long button = default, long buttons = default, bool ctrlKey = default, bool shiftKey = default, bool altKey = default, bool metaKey = default, string? type = default)
 		=> _ = DoubleClickAsync(element, new MouseEventArgs { Detail = detail, ScreenX = screenX, ScreenY = screenY, ClientX = clientX, ClientY = clientY, PageX = pageX, PageY = pageY, OffsetX = offsetX, OffsetY = offsetY, Button = button, Buttons = buttons, CtrlKey = ctrlKey, ShiftKey = shiftKey, AltKey = altKey, MetaKey = metaKey, Type = type! });
+
+	/// <summary>
+	/// Raises the <c>@ondblclick</c> event on <paramref name="element"/>,  passing the provided
+	/// properties to the event handler via a <see cref="MouseEventArgs"/> object.
+	/// </summary>
+	/// <param name="element">The element to raise the event on.</param>
+	/// <param name="detail">A count of consecutive clicks that happened in a short amount of time, incremented by one.</param>
+	/// <param name="screenX">The X coordinate of the mouse pointer in global (screen) coordinates.</param>
+	/// <param name="screenY">The Y coordinate of the mouse pointer in global (screen) coordinates.</param>
+	/// <param name="clientX">The X coordinate of the mouse pointer in local (DOM content) coordinates.</param>
+	/// <param name="clientY">The Y coordinate of the mouse pointer in local (DOM content) coordinates.</param>
+	/// <param name="pageX">The X coordinate of the mouse pointer relative to the whole document.</param>
+	/// <param name="pageY">The Y coordinate of the mouse pointer relative to the whole document.</param>
+	/// <param name="offsetX">The X coordinate of the mouse pointer in relative (Target Element) coordinates.</param>
+	/// <param name="offsetY">The Y coordinate of the mouse pointer in relative (Target Element) coordinates.</param>
+	/// <param name="button">
+	///     The button number that was pressed when the mouse event was fired: Left button=0,
+	///     middle button=1 (if present), right button=2. For mice configured for left handed
+	///     use in which the button actions are reversed the values are instead read from
+	///     right to left.
+	/// </param>
+	/// <param name="buttons">
+	///     The buttons being pressed when the mouse event was fired: Left button=1, Right
+	///     button=2, Middle (wheel) button=4, 4th button (typically, "Browser Back" button)=8,
+	///     5th button (typically, "Browser Forward" button)=16. If two or more buttons are
+	///     pressed, returns the logical sum of the values. E.g., if Left button and Right
+	///     button are pressed, returns 3 (=1 | 2).
+	/// </param>
+	/// <param name="ctrlKey">true if the control key was down when the event was fired. false otherwise.</param>
+	/// <param name="shiftKey">true if the shift key was down when the event was fired. false otherwise.</param>
+	/// <param name="altKey">true if the alt key was down when the event was fired. false otherwise.</param>
+	/// <param name="metaKey">true if the meta key was down when the event was fired. false otherwise.</param>
+	/// <param name="type">Gets or sets the type of the event.</param>
+	public static Task DoubleClickAsync(this IElement element, long detail = 2, double screenX = default, double screenY = default, double clientX = default, double clientY = default, double pageX = 0, double pageY = 0, double offsetX = 0, double offsetY = 0, long button = default, long buttons = default, bool ctrlKey = default, bool shiftKey = default, bool altKey = default, bool metaKey = default, string? type = default)
+		=> DoubleClickAsync(element, new MouseEventArgs { Detail = detail, ScreenX = screenX, ScreenY = screenY, ClientX = clientX, ClientY = clientY, PageX = pageX, PageY = pageY, OffsetX = offsetX, OffsetY = offsetY, Button = button, Buttons = buttons, CtrlKey = ctrlKey, ShiftKey = shiftKey, AltKey = altKey, MetaKey = metaKey, Type = type! });
 #elif NET5_0
 	/// <summary>
 	/// Raises the <c>@ondblclick</c> event on <paramref name="element"/>,  passing the provided
@@ -440,6 +729,39 @@ public static class MouseEventDispatchExtensions
 	/// <param name="type">Gets or sets the type of the event.</param>
 	public static void DoubleClick(this IElement element, long detail = 2, double screenX = default, double screenY = default, double clientX = default, double clientY = default, double offsetX = 0, double offsetY = 0, long button = default, long buttons = default, bool ctrlKey = default, bool shiftKey = default, bool altKey = default, bool metaKey = default, string? type = default)
 		=> _ = DoubleClickAsync(element, new MouseEventArgs { Detail = detail, ScreenX = screenX, ScreenY = screenY, ClientX = clientX, ClientY = clientY, OffsetX = offsetX, OffsetY = offsetY, Button = button, Buttons = buttons, CtrlKey = ctrlKey, ShiftKey = shiftKey, AltKey = altKey, MetaKey = metaKey, Type = type! });
+
+	/// <summary>
+	/// Raises the <c>@ondblclick</c> event on <paramref name="element"/>,  passing the provided
+	/// properties to the event handler via a <see cref="MouseEventArgs"/> object.
+	/// </summary>
+	/// <param name="element">The element to raise the event on.</param>
+	/// <param name="detail">A count of consecutive clicks that happened in a short amount of time, incremented by one.</param>
+	/// <param name="screenX">The X coordinate of the mouse pointer in global (screen) coordinates.</param>
+	/// <param name="screenY">The Y coordinate of the mouse pointer in global (screen) coordinates.</param>
+	/// <param name="clientX">The X coordinate of the mouse pointer in local (DOM content) coordinates.</param>
+	/// <param name="clientY">The Y coordinate of the mouse pointer in local (DOM content) coordinates.</param>
+	/// <param name="offsetX">The X coordinate of the mouse pointer in relative (Target Element) coordinates.</param>
+	/// <param name="offsetY">The Y coordinate of the mouse pointer in relative (Target Element) coordinates.</param>
+	/// <param name="button">
+	///     The button number that was pressed when the mouse event was fired: Left button=0,
+	///     middle button=1 (if present), right button=2. For mice configured for left handed
+	///     use in which the button actions are reversed the values are instead read from
+	///     right to left.
+	/// </param>
+	/// <param name="buttons">
+	///     The buttons being pressed when the mouse event was fired: Left button=1, Right
+	///     button=2, Middle (wheel) button=4, 4th button (typically, "Browser Back" button)=8,
+	///     5th button (typically, "Browser Forward" button)=16. If two or more buttons are
+	///     pressed, returns the logical sum of the values. E.g., if Left button and Right
+	///     button are pressed, returns 3 (=1 | 2).
+	/// </param>
+	/// <param name="ctrlKey">true if the control key was down when the event was fired. false otherwise.</param>
+	/// <param name="shiftKey">true if the shift key was down when the event was fired. false otherwise.</param>
+	/// <param name="altKey">true if the alt key was down when the event was fired. false otherwise.</param>
+	/// <param name="metaKey">true if the meta key was down when the event was fired. false otherwise.</param>
+	/// <param name="type">Gets or sets the type of the event.</param>
+	public static Task DoubleClickAsync(this IElement element, long detail = 2, double screenX = default, double screenY = default, double clientX = default, double clientY = default, double offsetX = 0, double offsetY = 0, long button = default, long buttons = default, bool ctrlKey = default, bool shiftKey = default, bool altKey = default, bool metaKey = default, string? type = default)
+		=> DoubleClickAsync(element, new MouseEventArgs { Detail = detail, ScreenX = screenX, ScreenY = screenY, ClientX = clientX, ClientY = clientY, OffsetX = offsetX, OffsetY = offsetY, Button = button, Buttons = buttons, CtrlKey = ctrlKey, ShiftKey = shiftKey, AltKey = altKey, MetaKey = metaKey, Type = type! });
 #else
 
 	/// <summary>
@@ -472,6 +794,37 @@ public static class MouseEventDispatchExtensions
 	/// <param name="type">Gets or sets the type of the event.</param>
 	public static void DoubleClick(this IElement element, long detail = 2, double screenX = default, double screenY = default, double clientX = default, double clientY = default, long button = default, long buttons = default, bool ctrlKey = default, bool shiftKey = default, bool altKey = default, bool metaKey = default, string? type = default)
 		=> _ = DoubleClickAsync(element, new MouseEventArgs { Detail = detail, ScreenX = screenX, ScreenY = screenY, ClientX = clientX, ClientY = clientY, Button = button, Buttons = buttons, CtrlKey = ctrlKey, ShiftKey = shiftKey, AltKey = altKey, MetaKey = metaKey, Type = type! });
+
+	/// <summary>
+	/// Raises the <c>@ondblclick</c> event on <paramref name="element"/>,  passing the provided
+	/// properties to the event handler via a <see cref="MouseEventArgs"/> object.
+	/// </summary>
+	/// <param name="element">The element to raise the event on.</param>
+	/// <param name="detail">A count of consecutive clicks that happened in a short amount of time, incremented by one.</param>
+	/// <param name="screenX">The X coordinate of the mouse pointer in global (screen) coordinates.</param>
+	/// <param name="screenY">The Y coordinate of the mouse pointer in global (screen) coordinates.</param>
+	/// <param name="clientX">The X coordinate of the mouse pointer in local (DOM content) coordinates.</param>
+	/// <param name="clientY">The Y coordinate of the mouse pointer in local (DOM content) coordinates.</param>
+	/// <param name="button">
+	///     The button number that was pressed when the mouse event was fired: Left button=0,
+	///     middle button=1 (if present), right button=2. For mice configured for left handed
+	///     use in which the button actions are reversed the values are instead read from
+	///     right to left.
+	/// </param>
+	/// <param name="buttons">
+	///     The buttons being pressed when the mouse event was fired: Left button=1, Right
+	///     button=2, Middle (wheel) button=4, 4th button (typically, "Browser Back" button)=8,
+	///     5th button (typically, "Browser Forward" button)=16. If two or more buttons are
+	///     pressed, returns the logical sum of the values. E.g., if Left button and Right
+	///     button are pressed, returns 3 (=1 | 2).
+	/// </param>
+	/// <param name="ctrlKey">true if the control key was down when the event was fired. false otherwise.</param>
+	/// <param name="shiftKey">true if the shift key was down when the event was fired. false otherwise.</param>
+	/// <param name="altKey">true if the alt key was down when the event was fired. false otherwise.</param>
+	/// <param name="metaKey">true if the meta key was down when the event was fired. false otherwise.</param>
+	/// <param name="type">Gets or sets the type of the event.</param>
+	public static Task DoubleClickAsync(this IElement element, long detail = 2, double screenX = default, double screenY = default, double clientX = default, double clientY = default, long button = default, long buttons = default, bool ctrlKey = default, bool shiftKey = default, bool altKey = default, bool metaKey = default, string? type = default)
+		=> DoubleClickAsync(element, new MouseEventArgs { Detail = detail, ScreenX = screenX, ScreenY = screenY, ClientX = clientX, ClientY = clientY, Button = button, Buttons = buttons, CtrlKey = ctrlKey, ShiftKey = shiftKey, AltKey = altKey, MetaKey = metaKey, Type = type! });
 #endif
 	/// <summary>
 	/// Raises the <c>@ondblclick</c> event on <paramref name="element"/>, passing the provided <paramref name="eventArgs"/>
@@ -536,6 +889,41 @@ public static class MouseEventDispatchExtensions
 		=> _ = WheelAsync(element, eventArgs);
 
 	/// <summary>
+	/// Raises the <c>@onwheel</c> event on <paramref name="element"/>,  passing the provided
+	/// properties to the event handler via a <see cref="MouseEventArgs"/> object.
+	/// </summary>
+	/// <param name="element">The element to raise the event on.</param>
+	/// <param name="detail">A count of consecutive clicks that happened in a short amount of time, incremented by one.</param>
+	/// <param name="screenX">The X coordinate of the mouse pointer in global (screen) coordinates.</param>
+	/// <param name="screenY">The Y coordinate of the mouse pointer in global (screen) coordinates.</param>
+	/// <param name="clientX">The X coordinate of the mouse pointer in local (DOM content) coordinates.</param>
+	/// <param name="clientY">The Y coordinate of the mouse pointer in local (DOM content) coordinates.</param>
+	/// <param name="button">
+	///     The button number that was pressed when the mouse event was fired: Left button=0,
+	///     middle button=1 (if present), right button=2. For mice configured for left handed
+	///     use in which the button actions are reversed the values are instead read from
+	///     right to left.
+	/// </param>
+	/// <param name="buttons">
+	///     The buttons being pressed when the mouse event was fired: Left button=1, Right
+	///     button=2, Middle (wheel) button=4, 4th button (typically, "Browser Back" button)=8,
+	///     5th button (typically, "Browser Forward" button)=16. If two or more buttons are
+	///     pressed, returns the logical sum of the values. E.g., if Left button and Right
+	///     button are pressed, returns 3 (=1 | 2).
+	/// </param>
+	/// <param name="ctrlKey">true if the control key was down when the event was fired. false otherwise.</param>
+	/// <param name="shiftKey">true if the shift key was down when the event was fired. false otherwise.</param>
+	/// <param name="altKey">true if the alt key was down when the event was fired. false otherwise.</param>
+	/// <param name="metaKey">true if the meta key was down when the event was fired. false otherwise.</param>
+	/// <param name="type">Gets or sets the type of the event.</param>
+	/// <param name="deltaX">The horizontal scroll amount.</param>
+	/// <param name="deltaY">The vertical scroll amount.</param>
+	/// <param name="deltaZ">The scroll amount for the z-axis.</param>
+	/// <param name="deltaMode">The unit of the delta values scroll amount.</param>
+	public static Task WheelAsync(this IElement element, long detail = default, double screenX = default, double screenY = default, double clientX = default, double clientY = default, long button = default, long buttons = default, bool ctrlKey = default, bool shiftKey = default, bool altKey = default, bool metaKey = default, string? type = default, double deltaX = default, double deltaY = default, double deltaZ = default, long deltaMode = default)
+		=> WheelAsync(element, new WheelEventArgs { Detail = detail, ScreenX = screenX, ScreenY = screenY, ClientX = clientX, ClientY = clientY, Button = button, Buttons = buttons, CtrlKey = ctrlKey, ShiftKey = shiftKey, AltKey = altKey, MetaKey = metaKey, Type = type!, DeltaX = deltaX, DeltaY = deltaY, DeltaZ = deltaZ, DeltaMode = deltaMode });
+
+	/// <summary>
 	/// Raises the <c>@onwheel</c> event on <paramref name="element"/>, passing the provided <paramref name="eventArgs"/>
 	/// to the event handler.
 	/// </summary>
@@ -589,6 +977,41 @@ public static class MouseEventDispatchExtensions
 		=> _ = MouseWheelAsync(element, eventArgs);
 
 	/// <summary>
+	/// Raises the <c>@onmousewheel</c> event on <paramref name="element"/>,  passing the provided
+	/// properties to the event handler via a <see cref="MouseEventArgs"/> object.
+	/// </summary>
+	/// <param name="element">The element to raise the event on.</param>
+	/// <param name="detail">A count of consecutive clicks that happened in a short amount of time, incremented by one.</param>
+	/// <param name="screenX">The X coordinate of the mouse pointer in global (screen) coordinates.</param>
+	/// <param name="screenY">The Y coordinate of the mouse pointer in global (screen) coordinates.</param>
+	/// <param name="clientX">The X coordinate of the mouse pointer in local (DOM content) coordinates.</param>
+	/// <param name="clientY">The Y coordinate of the mouse pointer in local (DOM content) coordinates.</param>
+	/// <param name="button">
+	///     The button number that was pressed when the mouse event was fired: Left button=0,
+	///     middle button=1 (if present), right button=2. For mice configured for left handed
+	///     use in which the button actions are reversed the values are instead read from
+	///     right to left.
+	/// </param>
+	/// <param name="buttons">
+	///     The buttons being pressed when the mouse event was fired: Left button=1, Right
+	///     button=2, Middle (wheel) button=4, 4th button (typically, "Browser Back" button)=8,
+	///     5th button (typically, "Browser Forward" button)=16. If two or more buttons are
+	///     pressed, returns the logical sum of the values. E.g., if Left button and Right
+	///     button are pressed, returns 3 (=1 | 2).
+	/// </param>
+	/// <param name="ctrlKey">true if the control key was down when the event was fired. false otherwise.</param>
+	/// <param name="shiftKey">true if the shift key was down when the event was fired. false otherwise.</param>
+	/// <param name="altKey">true if the alt key was down when the event was fired. false otherwise.</param>
+	/// <param name="metaKey">true if the meta key was down when the event was fired. false otherwise.</param>
+	/// <param name="type">Gets or sets the type of the event.</param>
+	/// <param name="deltaX">The horizontal scroll amount.</param>
+	/// <param name="deltaY">The vertical scroll amount.</param>
+	/// <param name="deltaZ">The scroll amount for the z-axis.</param>
+	/// <param name="deltaMode">The unit of the delta values scroll amount.</param>
+	public static Task MouseWheelAsync(this IElement element, long detail = default, double screenX = default, double screenY = default, double clientX = default, double clientY = default, long button = default, long buttons = default, bool ctrlKey = default, bool shiftKey = default, bool altKey = default, bool metaKey = default, string? type = default, double deltaX = default, double deltaY = default, double deltaZ = default, long deltaMode = default)
+		=> MouseWheelAsync(element, new WheelEventArgs { Detail = detail, ScreenX = screenX, ScreenY = screenY, ClientX = clientX, ClientY = clientY, Button = button, Buttons = buttons, CtrlKey = ctrlKey, ShiftKey = shiftKey, AltKey = altKey, MetaKey = metaKey, Type = type!, DeltaX = deltaX, DeltaY = deltaY, DeltaZ = deltaZ, DeltaMode = deltaMode });
+
+	/// <summary>
 	/// Raises the <c>@onmousewheel</c> event on <paramref name="element"/>, passing the provided <paramref name="eventArgs"/>
 	/// to the event handler.
 	/// </summary>
@@ -636,6 +1059,37 @@ public static class MouseEventDispatchExtensions
 	/// <param name="eventArgs">The event arguments to pass to the event handler.</param>
 	public static void ContextMenu(this IElement element, MouseEventArgs eventArgs)
 		=> _ = ContextMenuAsync(element, eventArgs);
+
+	/// <summary>
+	/// Raises the <c>@oncontextmenu</c> event on <paramref name="element"/>,  passing the provided
+	/// properties to the event handler via a <see cref="MouseEventArgs"/> object.
+	/// </summary>
+	/// <param name="element">The element to raise the event on.</param>
+	/// <param name="detail">A count of consecutive clicks that happened in a short amount of time, incremented by one.</param>
+	/// <param name="screenX">The X coordinate of the mouse pointer in global (screen) coordinates.</param>
+	/// <param name="screenY">The Y coordinate of the mouse pointer in global (screen) coordinates.</param>
+	/// <param name="clientX">The X coordinate of the mouse pointer in local (DOM content) coordinates.</param>
+	/// <param name="clientY">The Y coordinate of the mouse pointer in local (DOM content) coordinates.</param>
+	/// <param name="button">
+	///     The button number that was pressed when the mouse event was fired: Left button=0,
+	///     middle button=1 (if present), right button=2. For mice configured for left handed
+	///     use in which the button actions are reversed the values are instead read from
+	///     right to left.
+	/// </param>
+	/// <param name="buttons">
+	///     The buttons being pressed when the mouse event was fired: Left button=1, Right
+	///     button=2, Middle (wheel) button=4, 4th button (typically, "Browser Back" button)=8,
+	///     5th button (typically, "Browser Forward" button)=16. If two or more buttons are
+	///     pressed, returns the logical sum of the values. E.g., if Left button and Right
+	///     button are pressed, returns 3 (=1 | 2).
+	/// </param>
+	/// <param name="ctrlKey">true if the control key was down when the event was fired. false otherwise.</param>
+	/// <param name="shiftKey">true if the shift key was down when the event was fired. false otherwise.</param>
+	/// <param name="altKey">true if the alt key was down when the event was fired. false otherwise.</param>
+	/// <param name="metaKey">true if the meta key was down when the event was fired. false otherwise.</param>
+	/// <param name="type">Gets or sets the type of the event.</param>
+	public static Task ContextMenuAsync(this IElement element, long detail = default, double screenX = default, double screenY = default, double clientX = default, double clientY = default, long button = default, long buttons = default, bool ctrlKey = default, bool shiftKey = default, bool altKey = default, bool metaKey = default, string? type = default)
+		=> ContextMenuAsync(element, new MouseEventArgs { Detail = detail, ScreenX = screenX, ScreenY = screenY, ClientX = clientX, ClientY = clientY, Button = button, Buttons = buttons, CtrlKey = ctrlKey, ShiftKey = shiftKey, AltKey = altKey, MetaKey = metaKey, Type = type! });
 
 	/// <summary>
 	/// Raises the <c>@oncontextmenu</c> event on <paramref name="element"/>, passing the provided <paramref name="eventArgs"/>

--- a/src/bunit.web/EventDispatchExtensions/MouseEventDispatchExtensions.cs
+++ b/src/bunit.web/EventDispatchExtensions/MouseEventDispatchExtensions.cs
@@ -442,7 +442,83 @@ public static class MouseEventDispatchExtensions
 	/// <param name="type">Gets or sets the type of the event.</param>
 	public static void Click(this IElement element, long detail = 1, double screenX = default, double screenY = default, double clientX = default, double clientY = default, double pageX = 0, double pageY = 0, double offsetX = 0, double offsetY = 0, long button = default, long buttons = default, bool ctrlKey = default, bool shiftKey = default, bool altKey = default, bool metaKey = default, string? type = default)
 		=> _ = ClickAsync(element, new MouseEventArgs { Detail = detail, ScreenX = screenX, ScreenY = screenY, ClientX = clientX, PageX = pageX, PageY = pageY, OffsetX = offsetX, OffsetY = offsetY, ClientY = clientY, Button = button, Buttons = buttons, CtrlKey = ctrlKey, ShiftKey = shiftKey, AltKey = altKey, MetaKey = metaKey, Type = type! });
+#elif NET5_0
+	/// <summary>
+	/// Raises the <c>@onclick</c> event on <paramref name="element"/>,  passing the provided
+	/// properties to the event handler via a <see cref="MouseEventArgs"/> object.
+	/// </summary>
+	/// <param name="element">The element to raise the event on.</param>
+	/// <param name="detail">A count of consecutive clicks that happened in a short amount of time, incremented by one.</param>
+	/// <param name="screenX">The X coordinate of the mouse pointer in global (screen) coordinates.</param>
+	/// <param name="screenY">The Y coordinate of the mouse pointer in global (screen) coordinates.</param>
+	/// <param name="clientX">The X coordinate of the mouse pointer in local (DOM content) coordinates.</param>
+	/// <param name="clientY">The Y coordinate of the mouse pointer in local (DOM content) coordinates.</param>
+	/// <param name="offsetX">The X coordinate of the mouse pointer in relative (Target Element) coordinates.</param>
+	/// <param name="offsetY">The Y coordinate of the mouse pointer in relative (Target Element) coordinates.</param>
+	/// <param name="button">
+	///     The button number that was pressed when the mouse event was fired: Left button=0,
+	///     middle button=1 (if present), right button=2. For mice configured for left handed
+	///     use in which the button actions are reversed the values are instead read from
+	///     right to left.
+	/// </param>
+	/// <param name="buttons">
+	///     The buttons being pressed when the mouse event was fired: Left button=1, Right
+	///     button=2, Middle (wheel) button=4, 4th button (typically, "Browser Back" button)=8,
+	///     5th button (typically, "Browser Forward" button)=16. If two or more buttons are
+	///     pressed, returns the logical sum of the values. E.g., if Left button and Right
+	///     button are pressed, returns 3 (=1 | 2).
+	/// </param>
+	/// <param name="ctrlKey">true if the control key was down when the event was fired. false otherwise.</param>
+	/// <param name="shiftKey">true if the shift key was down when the event was fired. false otherwise.</param>
+	/// <param name="altKey">true if the alt key was down when the event was fired. false otherwise.</param>
+	/// <param name="metaKey">true if the meta key was down when the event was fired. false otherwise.</param>
+	/// <param name="type">Gets or sets the type of the event.</param>
+	public static void Click(this IElement element, long detail = 1, double screenX = default, double screenY = default, double clientX = default, double clientY = default, double offsetX = 0, double offsetY = 0, long button = default, long buttons = default, bool ctrlKey = default, bool shiftKey = default, bool altKey = default, bool metaKey = default, string? type = default)
+		=> _ = ClickAsync(element, new MouseEventArgs { Detail = detail, ScreenX = screenX, ScreenY = screenY, ClientX = clientX, OffsetX = offsetX, OffsetY = offsetY, ClientY = clientY, Button = button, Buttons = buttons, CtrlKey = ctrlKey, ShiftKey = shiftKey, AltKey = altKey, MetaKey = metaKey, Type = type! });
+#else
+	/// <summary>
+	/// Raises the <c>@onclick</c> event on <paramref name="element"/>,  passing the provided
+	/// properties to the event handler via a <see cref="MouseEventArgs"/> object.
+	/// </summary>
+	/// <param name="element">The element to raise the event on.</param>
+	/// <param name="detail">A count of consecutive clicks that happened in a short amount of time, incremented by one.</param>
+	/// <param name="screenX">The X coordinate of the mouse pointer in global (screen) coordinates.</param>
+	/// <param name="screenY">The Y coordinate of the mouse pointer in global (screen) coordinates.</param>
+	/// <param name="clientX">The X coordinate of the mouse pointer in local (DOM content) coordinates.</param>
+	/// <param name="clientY">The Y coordinate of the mouse pointer in local (DOM content) coordinates.</param>
+	/// <param name="button">
+	///     The button number that was pressed when the mouse event was fired: Left button=0,
+	///     middle button=1 (if present), right button=2. For mice configured for left handed
+	///     use in which the button actions are reversed the values are instead read from
+	///     right to left.
+	/// </param>
+	/// <param name="buttons">
+	///     The buttons being pressed when the mouse event was fired: Left button=1, Right
+	///     button=2, Middle (wheel) button=4, 4th button (typically, "Browser Back" button)=8,
+	///     5th button (typically, "Browser Forward" button)=16. If two or more buttons are
+	///     pressed, returns the logical sum of the values. E.g., if Left button and Right
+	///     button are pressed, returns 3 (=1 | 2).
+	/// </param>
+	/// <param name="ctrlKey">true if the control key was down when the event was fired. false otherwise.</param>
+	/// <param name="shiftKey">true if the shift key was down when the event was fired. false otherwise.</param>
+	/// <param name="altKey">true if the alt key was down when the event was fired. false otherwise.</param>
+	/// <param name="metaKey">true if the meta key was down when the event was fired. false otherwise.</param>
+	/// <param name="type">Gets or sets the type of the event.</param>
+	public static void Click(this IElement element, long detail = 1, double screenX = default, double screenY = default, double clientX = default, double clientY = default, long button = default, long buttons = default, bool ctrlKey = default, bool shiftKey = default, bool altKey = default, bool metaKey = default, string? type = default)
+		=> _ = ClickAsync(element, new MouseEventArgs { Detail = detail, ScreenX = screenX, ScreenY = screenY, ClientX = clientX, ClientY = clientY, Button = button, Buttons = buttons, CtrlKey = ctrlKey, ShiftKey = shiftKey, AltKey = altKey, MetaKey = metaKey, Type = type! });
+#endif
 
+
+	/// <summary>
+	/// Raises the <c>@onclick</c> event on <paramref name="element"/>, passing the provided <paramref name="eventArgs"/>
+	/// to the event handler.
+	/// </summary>
+	/// <param name="element">The element to raise the event on.</param>
+	/// <param name="eventArgs">The event arguments to pass to the event handler.</param>
+	public static void Click(this IElement element, MouseEventArgs eventArgs)
+		=> _ = ClickAsync(element, eventArgs);
+
+#if NET6_0_OR_GREATER
 	/// <summary>
 	/// Raises the <c>@onclick</c> event on <paramref name="element"/>,  passing the provided
 	/// properties to the event handler via a <see cref="MouseEventArgs"/> object.
@@ -508,39 +584,6 @@ public static class MouseEventDispatchExtensions
 	/// <param name="altKey">true if the alt key was down when the event was fired. false otherwise.</param>
 	/// <param name="metaKey">true if the meta key was down when the event was fired. false otherwise.</param>
 	/// <param name="type">Gets or sets the type of the event.</param>
-	public static void Click(this IElement element, long detail = 1, double screenX = default, double screenY = default, double clientX = default, double clientY = default, double offsetX = 0, double offsetY = 0, long button = default, long buttons = default, bool ctrlKey = default, bool shiftKey = default, bool altKey = default, bool metaKey = default, string? type = default)
-		=> _ = ClickAsync(element, new MouseEventArgs { Detail = detail, ScreenX = screenX, ScreenY = screenY, ClientX = clientX, OffsetX = offsetX, OffsetY = offsetY, ClientY = clientY, Button = button, Buttons = buttons, CtrlKey = ctrlKey, ShiftKey = shiftKey, AltKey = altKey, MetaKey = metaKey, Type = type! });
-
-	/// <summary>
-	/// Raises the <c>@onclick</c> event on <paramref name="element"/>,  passing the provided
-	/// properties to the event handler via a <see cref="MouseEventArgs"/> object.
-	/// </summary>
-	/// <param name="element">The element to raise the event on.</param>
-	/// <param name="detail">A count of consecutive clicks that happened in a short amount of time, incremented by one.</param>
-	/// <param name="screenX">The X coordinate of the mouse pointer in global (screen) coordinates.</param>
-	/// <param name="screenY">The Y coordinate of the mouse pointer in global (screen) coordinates.</param>
-	/// <param name="clientX">The X coordinate of the mouse pointer in local (DOM content) coordinates.</param>
-	/// <param name="clientY">The Y coordinate of the mouse pointer in local (DOM content) coordinates.</param>
-	/// <param name="offsetX">The X coordinate of the mouse pointer in relative (Target Element) coordinates.</param>
-	/// <param name="offsetY">The Y coordinate of the mouse pointer in relative (Target Element) coordinates.</param>
-	/// <param name="button">
-	///     The button number that was pressed when the mouse event was fired: Left button=0,
-	///     middle button=1 (if present), right button=2. For mice configured for left handed
-	///     use in which the button actions are reversed the values are instead read from
-	///     right to left.
-	/// </param>
-	/// <param name="buttons">
-	///     The buttons being pressed when the mouse event was fired: Left button=1, Right
-	///     button=2, Middle (wheel) button=4, 4th button (typically, "Browser Back" button)=8,
-	///     5th button (typically, "Browser Forward" button)=16. If two or more buttons are
-	///     pressed, returns the logical sum of the values. E.g., if Left button and Right
-	///     button are pressed, returns 3 (=1 | 2).
-	/// </param>
-	/// <param name="ctrlKey">true if the control key was down when the event was fired. false otherwise.</param>
-	/// <param name="shiftKey">true if the shift key was down when the event was fired. false otherwise.</param>
-	/// <param name="altKey">true if the alt key was down when the event was fired. false otherwise.</param>
-	/// <param name="metaKey">true if the meta key was down when the event was fired. false otherwise.</param>
-	/// <param name="type">Gets or sets the type of the event.</param>
 	public static Task ClickAsync(this IElement element, long detail = 1, double screenX = default, double screenY = default, double clientX = default, double clientY = default, double offsetX = 0, double offsetY = 0, long button = default, long buttons = default, bool ctrlKey = default, bool shiftKey = default, bool altKey = default, bool metaKey = default, string? type = default)
 		=> ClickAsync(element, new MouseEventArgs { Detail = detail, ScreenX = screenX, ScreenY = screenY, ClientX = clientX, OffsetX = offsetX, OffsetY = offsetY, ClientY = clientY, Button = button, Buttons = buttons, CtrlKey = ctrlKey, ShiftKey = shiftKey, AltKey = altKey, MetaKey = metaKey, Type = type! });
 #else
@@ -572,50 +615,9 @@ public static class MouseEventDispatchExtensions
 	/// <param name="altKey">true if the alt key was down when the event was fired. false otherwise.</param>
 	/// <param name="metaKey">true if the meta key was down when the event was fired. false otherwise.</param>
 	/// <param name="type">Gets or sets the type of the event.</param>
-	public static void Click(this IElement element, long detail = 1, double screenX = default, double screenY = default, double clientX = default, double clientY = default, long button = default, long buttons = default, bool ctrlKey = default, bool shiftKey = default, bool altKey = default, bool metaKey = default, string? type = default)
-		=> _ = ClickAsync(element, new MouseEventArgs { Detail = detail, ScreenX = screenX, ScreenY = screenY, ClientX = clientX, ClientY = clientY, Button = button, Buttons = buttons, CtrlKey = ctrlKey, ShiftKey = shiftKey, AltKey = altKey, MetaKey = metaKey, Type = type! });
-
-	/// <summary>
-	/// Raises the <c>@onclick</c> event on <paramref name="element"/>,  passing the provided
-	/// properties to the event handler via a <see cref="MouseEventArgs"/> object.
-	/// </summary>
-	/// <param name="element">The element to raise the event on.</param>
-	/// <param name="detail">A count of consecutive clicks that happened in a short amount of time, incremented by one.</param>
-	/// <param name="screenX">The X coordinate of the mouse pointer in global (screen) coordinates.</param>
-	/// <param name="screenY">The Y coordinate of the mouse pointer in global (screen) coordinates.</param>
-	/// <param name="clientX">The X coordinate of the mouse pointer in local (DOM content) coordinates.</param>
-	/// <param name="clientY">The Y coordinate of the mouse pointer in local (DOM content) coordinates.</param>
-	/// <param name="button">
-	///     The button number that was pressed when the mouse event was fired: Left button=0,
-	///     middle button=1 (if present), right button=2. For mice configured for left handed
-	///     use in which the button actions are reversed the values are instead read from
-	///     right to left.
-	/// </param>
-	/// <param name="buttons">
-	///     The buttons being pressed when the mouse event was fired: Left button=1, Right
-	///     button=2, Middle (wheel) button=4, 4th button (typically, "Browser Back" button)=8,
-	///     5th button (typically, "Browser Forward" button)=16. If two or more buttons are
-	///     pressed, returns the logical sum of the values. E.g., if Left button and Right
-	///     button are pressed, returns 3 (=1 | 2).
-	/// </param>
-	/// <param name="ctrlKey">true if the control key was down when the event was fired. false otherwise.</param>
-	/// <param name="shiftKey">true if the shift key was down when the event was fired. false otherwise.</param>
-	/// <param name="altKey">true if the alt key was down when the event was fired. false otherwise.</param>
-	/// <param name="metaKey">true if the meta key was down when the event was fired. false otherwise.</param>
-	/// <param name="type">Gets or sets the type of the event.</param>
 	public static Task ClickAsync(this IElement element, long detail = 1, double screenX = default, double screenY = default, double clientX = default, double clientY = default, long button = default, long buttons = default, bool ctrlKey = default, bool shiftKey = default, bool altKey = default, bool metaKey = default, string? type = default)
 		=> ClickAsync(element, new MouseEventArgs { Detail = detail, ScreenX = screenX, ScreenY = screenY, ClientX = clientX, ClientY = clientY, Button = button, Buttons = buttons, CtrlKey = ctrlKey, ShiftKey = shiftKey, AltKey = altKey, MetaKey = metaKey, Type = type! });
 #endif
-
-
-	/// <summary>
-	/// Raises the <c>@onclick</c> event on <paramref name="element"/>, passing the provided <paramref name="eventArgs"/>
-	/// to the event handler.
-	/// </summary>
-	/// <param name="element">The element to raise the event on.</param>
-	/// <param name="eventArgs">The event arguments to pass to the event handler.</param>
-	public static void Click(this IElement element, MouseEventArgs eventArgs)
-		=> _ = ClickAsync(element, eventArgs);
 
 	/// <summary>
 	/// Raises the <c>@onclick</c> event on <paramref name="element"/>, passing the provided <paramref name="eventArgs"/>
@@ -661,7 +663,83 @@ public static class MouseEventDispatchExtensions
 	/// <param name="type">Gets or sets the type of the event.</param>
 	public static void DoubleClick(this IElement element, long detail = 2, double screenX = default, double screenY = default, double clientX = default, double clientY = default, double pageX = 0, double pageY = 0, double offsetX = 0, double offsetY = 0, long button = default, long buttons = default, bool ctrlKey = default, bool shiftKey = default, bool altKey = default, bool metaKey = default, string? type = default)
 		=> _ = DoubleClickAsync(element, new MouseEventArgs { Detail = detail, ScreenX = screenX, ScreenY = screenY, ClientX = clientX, ClientY = clientY, PageX = pageX, PageY = pageY, OffsetX = offsetX, OffsetY = offsetY, Button = button, Buttons = buttons, CtrlKey = ctrlKey, ShiftKey = shiftKey, AltKey = altKey, MetaKey = metaKey, Type = type! });
+#elif NET5_0
+	/// <summary>
+	/// Raises the <c>@ondblclick</c> event on <paramref name="element"/>,  passing the provided
+	/// properties to the event handler via a <see cref="MouseEventArgs"/> object.
+	/// </summary>
+	/// <param name="element">The element to raise the event on.</param>
+	/// <param name="detail">A count of consecutive clicks that happened in a short amount of time, incremented by one.</param>
+	/// <param name="screenX">The X coordinate of the mouse pointer in global (screen) coordinates.</param>
+	/// <param name="screenY">The Y coordinate of the mouse pointer in global (screen) coordinates.</param>
+	/// <param name="clientX">The X coordinate of the mouse pointer in local (DOM content) coordinates.</param>
+	/// <param name="clientY">The Y coordinate of the mouse pointer in local (DOM content) coordinates.</param>
+	/// <param name="offsetX">The X coordinate of the mouse pointer in relative (Target Element) coordinates.</param>
+	/// <param name="offsetY">The Y coordinate of the mouse pointer in relative (Target Element) coordinates.</param>
+	/// <param name="button">
+	///     The button number that was pressed when the mouse event was fired: Left button=0,
+	///     middle button=1 (if present), right button=2. For mice configured for left handed
+	///     use in which the button actions are reversed the values are instead read from
+	///     right to left.
+	/// </param>
+	/// <param name="buttons">
+	///     The buttons being pressed when the mouse event was fired: Left button=1, Right
+	///     button=2, Middle (wheel) button=4, 4th button (typically, "Browser Back" button)=8,
+	///     5th button (typically, "Browser Forward" button)=16. If two or more buttons are
+	///     pressed, returns the logical sum of the values. E.g., if Left button and Right
+	///     button are pressed, returns 3 (=1 | 2).
+	/// </param>
+	/// <param name="ctrlKey">true if the control key was down when the event was fired. false otherwise.</param>
+	/// <param name="shiftKey">true if the shift key was down when the event was fired. false otherwise.</param>
+	/// <param name="altKey">true if the alt key was down when the event was fired. false otherwise.</param>
+	/// <param name="metaKey">true if the meta key was down when the event was fired. false otherwise.</param>
+	/// <param name="type">Gets or sets the type of the event.</param>
+	public static void DoubleClick(this IElement element, long detail = 2, double screenX = default, double screenY = default, double clientX = default, double clientY = default, double offsetX = 0, double offsetY = 0, long button = default, long buttons = default, bool ctrlKey = default, bool shiftKey = default, bool altKey = default, bool metaKey = default, string? type = default)
+		=> _ = DoubleClickAsync(element, new MouseEventArgs { Detail = detail, ScreenX = screenX, ScreenY = screenY, ClientX = clientX, ClientY = clientY, OffsetX = offsetX, OffsetY = offsetY, Button = button, Buttons = buttons, CtrlKey = ctrlKey, ShiftKey = shiftKey, AltKey = altKey, MetaKey = metaKey, Type = type! });
+#else
 
+	/// <summary>
+	/// Raises the <c>@ondblclick</c> event on <paramref name="element"/>,  passing the provided
+	/// properties to the event handler via a <see cref="MouseEventArgs"/> object.
+	/// </summary>
+	/// <param name="element">The element to raise the event on.</param>
+	/// <param name="detail">A count of consecutive clicks that happened in a short amount of time, incremented by one.</param>
+	/// <param name="screenX">The X coordinate of the mouse pointer in global (screen) coordinates.</param>
+	/// <param name="screenY">The Y coordinate of the mouse pointer in global (screen) coordinates.</param>
+	/// <param name="clientX">The X coordinate of the mouse pointer in local (DOM content) coordinates.</param>
+	/// <param name="clientY">The Y coordinate of the mouse pointer in local (DOM content) coordinates.</param>
+	/// <param name="button">
+	///     The button number that was pressed when the mouse event was fired: Left button=0,
+	///     middle button=1 (if present), right button=2. For mice configured for left handed
+	///     use in which the button actions are reversed the values are instead read from
+	///     right to left.
+	/// </param>
+	/// <param name="buttons">
+	///     The buttons being pressed when the mouse event was fired: Left button=1, Right
+	///     button=2, Middle (wheel) button=4, 4th button (typically, "Browser Back" button)=8,
+	///     5th button (typically, "Browser Forward" button)=16. If two or more buttons are
+	///     pressed, returns the logical sum of the values. E.g., if Left button and Right
+	///     button are pressed, returns 3 (=1 | 2).
+	/// </param>
+	/// <param name="ctrlKey">true if the control key was down when the event was fired. false otherwise.</param>
+	/// <param name="shiftKey">true if the shift key was down when the event was fired. false otherwise.</param>
+	/// <param name="altKey">true if the alt key was down when the event was fired. false otherwise.</param>
+	/// <param name="metaKey">true if the meta key was down when the event was fired. false otherwise.</param>
+	/// <param name="type">Gets or sets the type of the event.</param>
+	public static void DoubleClick(this IElement element, long detail = 2, double screenX = default, double screenY = default, double clientX = default, double clientY = default, long button = default, long buttons = default, bool ctrlKey = default, bool shiftKey = default, bool altKey = default, bool metaKey = default, string? type = default)
+		=> _ = DoubleClickAsync(element, new MouseEventArgs { Detail = detail, ScreenX = screenX, ScreenY = screenY, ClientX = clientX, ClientY = clientY, Button = button, Buttons = buttons, CtrlKey = ctrlKey, ShiftKey = shiftKey, AltKey = altKey, MetaKey = metaKey, Type = type! });
+#endif
+
+	/// <summary>
+	/// Raises the <c>@ondblclick</c> event on <paramref name="element"/>, passing the provided <paramref name="eventArgs"/>
+	/// to the event handler.
+	/// </summary>
+	/// <param name="element">The element to raise the event on.</param>
+	/// <param name="eventArgs">The event arguments to pass to the event handler.</param>
+	public static void DoubleClick(this IElement element, MouseEventArgs eventArgs)
+		=> _ = DoubleClickAsync(element, eventArgs);
+
+#if NET6_0_OR_GREATER
 	/// <summary>
 	/// Raises the <c>@ondblclick</c> event on <paramref name="element"/>,  passing the provided
 	/// properties to the event handler via a <see cref="MouseEventArgs"/> object.
@@ -727,39 +805,6 @@ public static class MouseEventDispatchExtensions
 	/// <param name="altKey">true if the alt key was down when the event was fired. false otherwise.</param>
 	/// <param name="metaKey">true if the meta key was down when the event was fired. false otherwise.</param>
 	/// <param name="type">Gets or sets the type of the event.</param>
-	public static void DoubleClick(this IElement element, long detail = 2, double screenX = default, double screenY = default, double clientX = default, double clientY = default, double offsetX = 0, double offsetY = 0, long button = default, long buttons = default, bool ctrlKey = default, bool shiftKey = default, bool altKey = default, bool metaKey = default, string? type = default)
-		=> _ = DoubleClickAsync(element, new MouseEventArgs { Detail = detail, ScreenX = screenX, ScreenY = screenY, ClientX = clientX, ClientY = clientY, OffsetX = offsetX, OffsetY = offsetY, Button = button, Buttons = buttons, CtrlKey = ctrlKey, ShiftKey = shiftKey, AltKey = altKey, MetaKey = metaKey, Type = type! });
-
-	/// <summary>
-	/// Raises the <c>@ondblclick</c> event on <paramref name="element"/>,  passing the provided
-	/// properties to the event handler via a <see cref="MouseEventArgs"/> object.
-	/// </summary>
-	/// <param name="element">The element to raise the event on.</param>
-	/// <param name="detail">A count of consecutive clicks that happened in a short amount of time, incremented by one.</param>
-	/// <param name="screenX">The X coordinate of the mouse pointer in global (screen) coordinates.</param>
-	/// <param name="screenY">The Y coordinate of the mouse pointer in global (screen) coordinates.</param>
-	/// <param name="clientX">The X coordinate of the mouse pointer in local (DOM content) coordinates.</param>
-	/// <param name="clientY">The Y coordinate of the mouse pointer in local (DOM content) coordinates.</param>
-	/// <param name="offsetX">The X coordinate of the mouse pointer in relative (Target Element) coordinates.</param>
-	/// <param name="offsetY">The Y coordinate of the mouse pointer in relative (Target Element) coordinates.</param>
-	/// <param name="button">
-	///     The button number that was pressed when the mouse event was fired: Left button=0,
-	///     middle button=1 (if present), right button=2. For mice configured for left handed
-	///     use in which the button actions are reversed the values are instead read from
-	///     right to left.
-	/// </param>
-	/// <param name="buttons">
-	///     The buttons being pressed when the mouse event was fired: Left button=1, Right
-	///     button=2, Middle (wheel) button=4, 4th button (typically, "Browser Back" button)=8,
-	///     5th button (typically, "Browser Forward" button)=16. If two or more buttons are
-	///     pressed, returns the logical sum of the values. E.g., if Left button and Right
-	///     button are pressed, returns 3 (=1 | 2).
-	/// </param>
-	/// <param name="ctrlKey">true if the control key was down when the event was fired. false otherwise.</param>
-	/// <param name="shiftKey">true if the shift key was down when the event was fired. false otherwise.</param>
-	/// <param name="altKey">true if the alt key was down when the event was fired. false otherwise.</param>
-	/// <param name="metaKey">true if the meta key was down when the event was fired. false otherwise.</param>
-	/// <param name="type">Gets or sets the type of the event.</param>
 	public static Task DoubleClickAsync(this IElement element, long detail = 2, double screenX = default, double screenY = default, double clientX = default, double clientY = default, double offsetX = 0, double offsetY = 0, long button = default, long buttons = default, bool ctrlKey = default, bool shiftKey = default, bool altKey = default, bool metaKey = default, string? type = default)
 		=> DoubleClickAsync(element, new MouseEventArgs { Detail = detail, ScreenX = screenX, ScreenY = screenY, ClientX = clientX, ClientY = clientY, OffsetX = offsetX, OffsetY = offsetY, Button = button, Buttons = buttons, CtrlKey = ctrlKey, ShiftKey = shiftKey, AltKey = altKey, MetaKey = metaKey, Type = type! });
 #else
@@ -792,48 +837,9 @@ public static class MouseEventDispatchExtensions
 	/// <param name="altKey">true if the alt key was down when the event was fired. false otherwise.</param>
 	/// <param name="metaKey">true if the meta key was down when the event was fired. false otherwise.</param>
 	/// <param name="type">Gets or sets the type of the event.</param>
-	public static void DoubleClick(this IElement element, long detail = 2, double screenX = default, double screenY = default, double clientX = default, double clientY = default, long button = default, long buttons = default, bool ctrlKey = default, bool shiftKey = default, bool altKey = default, bool metaKey = default, string? type = default)
-		=> _ = DoubleClickAsync(element, new MouseEventArgs { Detail = detail, ScreenX = screenX, ScreenY = screenY, ClientX = clientX, ClientY = clientY, Button = button, Buttons = buttons, CtrlKey = ctrlKey, ShiftKey = shiftKey, AltKey = altKey, MetaKey = metaKey, Type = type! });
-
-	/// <summary>
-	/// Raises the <c>@ondblclick</c> event on <paramref name="element"/>,  passing the provided
-	/// properties to the event handler via a <see cref="MouseEventArgs"/> object.
-	/// </summary>
-	/// <param name="element">The element to raise the event on.</param>
-	/// <param name="detail">A count of consecutive clicks that happened in a short amount of time, incremented by one.</param>
-	/// <param name="screenX">The X coordinate of the mouse pointer in global (screen) coordinates.</param>
-	/// <param name="screenY">The Y coordinate of the mouse pointer in global (screen) coordinates.</param>
-	/// <param name="clientX">The X coordinate of the mouse pointer in local (DOM content) coordinates.</param>
-	/// <param name="clientY">The Y coordinate of the mouse pointer in local (DOM content) coordinates.</param>
-	/// <param name="button">
-	///     The button number that was pressed when the mouse event was fired: Left button=0,
-	///     middle button=1 (if present), right button=2. For mice configured for left handed
-	///     use in which the button actions are reversed the values are instead read from
-	///     right to left.
-	/// </param>
-	/// <param name="buttons">
-	///     The buttons being pressed when the mouse event was fired: Left button=1, Right
-	///     button=2, Middle (wheel) button=4, 4th button (typically, "Browser Back" button)=8,
-	///     5th button (typically, "Browser Forward" button)=16. If two or more buttons are
-	///     pressed, returns the logical sum of the values. E.g., if Left button and Right
-	///     button are pressed, returns 3 (=1 | 2).
-	/// </param>
-	/// <param name="ctrlKey">true if the control key was down when the event was fired. false otherwise.</param>
-	/// <param name="shiftKey">true if the shift key was down when the event was fired. false otherwise.</param>
-	/// <param name="altKey">true if the alt key was down when the event was fired. false otherwise.</param>
-	/// <param name="metaKey">true if the meta key was down when the event was fired. false otherwise.</param>
-	/// <param name="type">Gets or sets the type of the event.</param>
 	public static Task DoubleClickAsync(this IElement element, long detail = 2, double screenX = default, double screenY = default, double clientX = default, double clientY = default, long button = default, long buttons = default, bool ctrlKey = default, bool shiftKey = default, bool altKey = default, bool metaKey = default, string? type = default)
 		=> DoubleClickAsync(element, new MouseEventArgs { Detail = detail, ScreenX = screenX, ScreenY = screenY, ClientX = clientX, ClientY = clientY, Button = button, Buttons = buttons, CtrlKey = ctrlKey, ShiftKey = shiftKey, AltKey = altKey, MetaKey = metaKey, Type = type! });
 #endif
-	/// <summary>
-	/// Raises the <c>@ondblclick</c> event on <paramref name="element"/>, passing the provided <paramref name="eventArgs"/>
-	/// to the event handler.
-	/// </summary>
-	/// <param name="element">The element to raise the event on.</param>
-	/// <param name="eventArgs">The event arguments to pass to the event handler.</param>
-	public static void DoubleClick(this IElement element, MouseEventArgs eventArgs)
-		=> _ = DoubleClickAsync(element, eventArgs);
 
 	/// <summary>
 	/// Raises the <c>@ondblclick</c> event on <paramref name="element"/>, passing the provided <paramref name="eventArgs"/>


### PR DESCRIPTION
## Pull request description
Adds more Mouse Events extension methods.
Currently, it's impossible to call asynchronous overloads of mouse events without having to provide a `MouseEventArgs` parameter. In this PR, I've introduced a way to do so.

### PR meta checklist
- [x] Pull request is targeted at `main` branch for code   
  or targeted at `stable` branch for documentation that is live on bunit.dev.
- [ ] Pull request is linked to all related issues, if any.
- [x] I have read the _CONTRIBUTING.md_ document.

### Code PR specific checklist
- [x] My code follows the code style of this project and AspNetCore coding guidelines.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] I have updated the appropriate sub section in the _CHANGELOG.md_.
- [ ] I have added, updated or removed tests to according to my changes.
  - [x] All tests passed.
