### PR TITLE
Smarter rendering in v2

### DIFF
--- a/src/bunit/Rendering/IRenderedComponent.cs
+++ b/src/bunit/Rendering/IRenderedComponent.cs
@@ -11,9 +11,17 @@ internal interface IRenderedComponent : IDisposable
 	int ComponentId { get; }
 
 	/// <summary>
-	/// Called by the owning <see cref="BunitRenderer"/> when it finishes a render.
+	/// Gets the total number times the fragment has been through its render life-cycle.
 	/// </summary>
-	void UpdateState(bool hasRendered, bool isMarkupGenerationRequired);
+	int RenderCount { get; set; }
+
+	void UpdateMarkup();
+
+	void SetMarkupIndices(int start, int end);
+
+	bool IsDirty { get; set; }
+
+	IRenderedComponent? Root { get; }
 }
 
 /// <summary>

--- a/tests/bunit.tests/BunitContextTest.cs
+++ b/tests/bunit.tests/BunitContextTest.cs
@@ -93,7 +93,7 @@ public class BunitContextTest : BunitContext
 			.ShouldBe("FOO");
 	}
 
-	[Fact(DisplayName = "Render<TComponent>(builder) renders TComponent inside RenderTreee")]
+	[Fact(DisplayName = "Render<TComponent>(builder) renders TComponent inside RenderTree")]
 	public void Test032()
 	{
 		RenderTree.Add<CascadingValue<string>>(ps => ps.Add(p => p.Value, "FOO"));
@@ -104,7 +104,7 @@ public class BunitContextTest : BunitContext
 			.ShouldBe("FOO");
 	}
 
-	[Fact(DisplayName = "Render<TComponent>(factories) renders TComponent inside RenderTreee")]
+	[Fact(DisplayName = "Render<TComponent>(factories) renders TComponent inside RenderTree")]
 	public void Test033()
 	{
 		RenderTree.Add<CascadingValue<string>>(ps => ps.Add(p => p.Value, "FOO"));

--- a/tests/bunit.tests/Rendering/BunitRendererTest.cs
+++ b/tests/bunit.tests/Rendering/BunitRendererTest.cs
@@ -3,11 +3,11 @@ using Bunit.TestAssets.RenderModes;
 
 namespace Bunit.Rendering;
 
-public class BunitRendererBunits : BunitContext
+public class BunitRendererTest : BunitContext
 {
-	public BunitRendererBunits(ITestOutputHelper outputHelper)
+	public BunitRendererTest(ITestOutputHelper outputHelper)
 	{
-		DefaultWaitTimeout = TimeSpan.FromSeconds(30);
+		//DefaultWaitTimeout = TimeSpan.FromSeconds(30);
 		Services.AddXunitLogger(outputHelper);
 	}
 
@@ -159,7 +159,7 @@ public class BunitRendererBunits : BunitContext
 			.AddChildContent<HasParams>(pps => pps
 				.Add(p => p.Value, PARENT_VALUE)
 				.AddChildContent<HasParams>(ppps => ppps
-					.Add(p=>p.Value, CHILD_VALUE))));
+					.Add(p => p.Value, CHILD_VALUE))));
 
 		// act
 		var childCuts = Renderer.FindComponents<HasParams>(cut)
@@ -226,22 +226,6 @@ public class BunitRendererBunits : BunitContext
 
 		await cut.Instance.TriggerWithValue("X");
 
-		cut.RenderCount.ShouldBe(2);
-		cut.Markup.ShouldBe("X");
-	}
-
-	[Fact(DisplayName = "Rendered component updates on re-renders from child components with changes in render tree")]
-	public async Task Test050()
-	{
-		// arrange
-		var cut = Renderer.Render<HasParams>(ps => ps
-			.AddChildContent<RenderTrigger>());
-		var child = Renderer.FindComponent<RenderTrigger>(cut);
-
-		// act
-		await child.Instance.TriggerWithValue("X");
-
-		// assert
 		cut.RenderCount.ShouldBe(2);
 		cut.Markup.ShouldBe("X");
 	}
@@ -506,6 +490,9 @@ public class BunitRendererBunits : BunitContext
 	{
 		[Parameter] public string? Value { get; set; }
 		[Parameter] public RenderFragment? ChildContent { get; set; }
+
+		public override Task SetParametersAsync(ParameterView parameters)
+			=> base.SetParametersAsync(parameters);
 
 		protected override void BuildRenderTree(RenderTreeBuilder builder)
 		{

--- a/tests/bunit.tests/Rendering/RenderedComponentTest.cs
+++ b/tests/bunit.tests/Rendering/RenderedComponentTest.cs
@@ -57,7 +57,7 @@ public class RenderedComponentTest : BunitContext
 
 		Should.Throw<ComponentDisposedException>(() => target.Instance);
 	}
-	
+
 	[Fact(DisplayName = "Find throws an exception if no element matches the css selector")]
 	public void Test021()
 	{
@@ -197,13 +197,13 @@ public class RenderedComponentTest : BunitContext
 
 		first.Render();
 
-		wrapper.RenderCount.ShouldBe(2);
+		wrapper.RenderCount.ShouldBe(1);
 		first.RenderCount.ShouldBe(2);
 		second.RenderCount.ShouldBe(1);
 
 		second.Render();
 
-		wrapper.RenderCount.ShouldBe(3);
+		wrapper.RenderCount.ShouldBe(1);
 		first.RenderCount.ShouldBe(2);
 		second.RenderCount.ShouldBe(2);
 	}


### PR DESCRIPTION
- [ ] Only (re)create markup root component
- [ ] Reference root components markup using child indices
- [ ] Only (re)create nodes in root component
- [ ] Split rendered component type into two, root and child nodes
