### PR TITLE
ci: only target net8 when validating docs/running docs tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,10 +228,10 @@ jobs:
           RELEASE_NOTES: ${{ steps.changelog_reader.outputs.changes }}
 
       - name: 📄 Build bUnit
-        run: dotnet build -c release
+        run: dotnet build docs/samples/samples.sln -c release
 
       - name: 🧪 Run sample unit tests
-        run: dotnet test docs/samples/samples.sln -c release -p:VSTestUseMSBuildOutput=false
+        run: dotnet test docs/samples/samples.sln -c release -p:VSTestUseMSBuildOutput=false -f net8.0
 
       - name: 📄 Build docs
         working-directory: ./docs/site


### PR DESCRIPTION
## Pull request description
<!--- 
    Describe the changes and motivation behind them here, if it is not obvious
    from the related issues. Does it have new features, breaking changes, etc. 
-->

### PR meta checklist
- [ ] Pull request is targeted at `main` branch for code   
  or targeted at `stable` branch for documentation that is live on bunit.dev.
- [ ] Pull request is linked to all related issues, if any.
- [ ] I have read the _CONTRIBUTING.md_ document.

### Code PR specific checklist
- [ ] My code follows the code style of this project and AspNetCore coding guidelines.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] I have updated the appropriate sub section in the _CHANGELOG.md_.
- [ ] I have added, updated or removed tests to according to my changes.
  - [ ] All tests passed.
