### PR TITLE
feat: add devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,33 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/dotnet
+{
+	"name": "Full",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/dotnet/sdk:9.0-preview",
+	"features": {
+		"ghcr.io/devcontainers/features/dotnet:2": {
+			"version": "latest",
+			"additionalVersions": "6.0,5.0,3.1"
+		}
+	},
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Configure tool-specific properties.
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"ms-dotnettools.csdevkit",
+        		"yzhang.markdown-all-in-one",
+				"vscode-icons-team.vscode-icons",
+				"me-dutour-mathieu.vscode-github-actions"
+			]
+		}
+	},
+
+	"postCreateCommand": "bash .devcontainer/post-install.sh"
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/.devcontainer/post-install.sh
+++ b/.devcontainer/post-install.sh
@@ -1,0 +1,7 @@
+#/bin/bash
+
+# Install docfx (should be aligned with docs-deploy.yml)
+dotnet tool install --global docfx --version 2.74.1
+
+# Trust dotnet developer certs
+dotnet dev-certs https --check --trust

--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,6 @@ bld/
 
 # Visual Studio 2015/2017 cache/options directory
 .vs/
-.vscode/
 # Uncomment if you have tasks that create the project's static files in wwwroot
 #wwwroot/
 

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,22 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Serve Docs (Without Build)",
+            "type": "shell",
+            "command": "docfx metadata docs/site/docfx.json && docfx docs/site/docfx.json --serve"
+        },
+        {
+            "label": "Serve Docs (With Build for API Documentation)",
+            "type": "shell",
+            "command": "dotnet build -c Release && docfx metadata docs/site/docfx.json && docfx docs/site/docfx.json --serve"
+        },
+        {
+            "label": "Run all tests (Release Mode)",
+            "type": "shell",
+            "command": "dotnet test -c Release"
+        }
+    ]
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,13 @@ Here are some resources to help you get started on how to contribute code or new
 * ["Help wanted" issues](https://github.com/egil/bunit/labels/help%20wanted) - these issues are up for grabs if you want to create a fix. To do this, simply comment on the issue you want to fix.
 * ["Good first issue" issues](https://github.com/egil/bunit/labels/good%20first%20issue) - these are good for newcomers. Good first issues are small, usually require just a few hours of work, and do not require a deep technical knowledge of bUnit. This is a good place to start if you want to become familiar with bUnit’s inner workings and maybe take on bigger issues later.
 
+### Using Codespaces
+
+bUnit offers predefined Codespaces to enable contributing to the project without having to set up a local development environment. 
+The Codespace is pre-configured with the necessary tools and dependencies to build and run the project including the .NET SDK but also serves the documentation site.
+
+[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/bUnit-dev/bUnit?quickstart=1)
+
 ### Identifying the Scale of a Contribution
 
 If you would like to contribute to bUnit, first identify the scale of what you would like to contribute. If it is small (grammar/spelling or a bug fix), feel free to start working on a fix. If you are submitting a feature or substantial code contribution, please discuss it with us first. 


### PR DESCRIPTION
This PR enables devcontainer support so that folks can easily contribute to bUnit. Every GitHub user automatically has 120 CPU hours for free, which allows most people to contribute easily (even when using higher-tier machines). 

Especially updating docs means installing/configuring docfx, which is automatically done.
There are also three pre-defined tasks:
 * Serve Docs without building bUnit - for just smaller things where API references aren't important
 * Serve Docs with building - to enable the "full" documentation, especially linking
 * Running all unit tests in release mode

Many things like building or even running tests, does work out of the box (even though you can unfortunately only run all tests or none - MS please fix that!)

Here some nice screenshots to convince you!

![image](https://github.com/bUnit-dev/bUnit/assets/26365461/943cb839-8c49-4206-8ac8-edf2bd563f57)
![image](https://github.com/bUnit-dev/bUnit/assets/26365461/1001c533-248e-4993-985a-89db4bc1e578)
<img width="925" alt="image" src="https://github.com/bUnit-dev/bUnit/assets/26365461/0311546d-138d-4eeb-a1a3-5acb56b50211">
<img width="709" alt="image" src="https://github.com/bUnit-dev/bUnit/assets/26365461/97db27ed-9aba-4528-bfc7-ac9e8d362bd4">


