### PR TITLE
Update emulating-ijsruntime.md

### DIFF
--- a/docs/site/docs/test-doubles/emulating-ijsruntime.md
+++ b/docs/site/docs/test-doubles/emulating-ijsruntime.md
@@ -88,7 +88,7 @@ var moduleInterop = JSInterop.SetupModule("hello.js");
 moduleInterop.SetupVoid("world");
 ```
 
-If you are testing methods that themselves return a `IJSObjectReference`, such as `await JsRuntime.InvokeAsync<IJSObjectReference>("SomeModule.GetInstance")` you can use the same process with the identifier assocaited with the interoperation and configure the `IJSObjectRefernce` the same way you would a module.
+When testing methods that return an `IJSObjectReference`, such as `await JsRuntime.InvokeAsync<IJSObjectReference>("SomeModule.GetInstance")`, the same process can be used with the identifier associated with the interoperation, configuring the `IJSObjectReference` in the same manner as a module.
 
 ```csharp
 var objectReference = JSInterop.SetupModule(matcher => matcher.Identifier == "SomeModule.GetInstance");

--- a/docs/site/docs/test-doubles/emulating-ijsruntime.md
+++ b/docs/site/docs/test-doubles/emulating-ijsruntime.md
@@ -88,6 +88,13 @@ var moduleInterop = JSInterop.SetupModule("hello.js");
 moduleInterop.SetupVoid("world");
 ```
 
+If you are testing methods that themselves return a `IJSObjectReference`, such as `await JsRuntime.InvokeAsync<IJSObjectReference>("SomeModule.GetInstance")` you can use the same process with the identifier assocaited with the interoperation and configure the `IJSObjectRefernce` the same way you would a module.
+
+```csharp
+var objectReference = JSInterop.SetupModule(matcher => matcher.Identifier == "SomeModule.GetInstance");
+objectReference.SetupVoid("world");
+```
+
 ### Module Interop Mode
 
 By default, a module Interop inherits the `Mode` setting from the root JSInterop in bUnit. However, you can override it explicitly and have it in a different mode from another module's Interop or the root JSInterop. Just set the `Mode` property, e.g.:


### PR DESCRIPTION
Adding doc for what I think is likely to be a common use case for testing methods that return `IJSObjectReference` instances.

It took me quite a while to figure out the right approach to this specific scenario, and I felt it might warrant sparing someone else the lost time.

