### PR TITLE
chore: Align package versions

### DIFF
--- a/docs/samples/tests/Directory.Build.props
+++ b/docs/samples/tests/Directory.Build.props
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net7.0' OR '$(TargetFramework)' == 'net8.0'">
-    <PackageReference Include="System.Text.Json" Version="8.0.0" />
+    <PackageReference Include="System.Text.Json" Version="8.0.4" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">

--- a/docs/samples/tests/razor/bunit.docs.razor.samples.csproj
+++ b/docs/samples/tests/razor/bunit.docs.razor.samples.csproj
@@ -9,7 +9,7 @@
     <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
-		<PackageReference Include="xunit" Version="2.8.1" />
+		<PackageReference Include="xunit" Version="2.9.0" />
 		<!-- DO NOT UPGRADE TO versions > 2.4.5 as they do not support .net5 or older -->
 		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
 			<PrivateAssets>all</PrivateAssets>

--- a/docs/samples/tests/xunit/bunit.docs.xunit.samples.csproj
+++ b/docs/samples/tests/xunit/bunit.docs.xunit.samples.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
-		<PackageReference Include="xunit" Version="2.8.1" />
+		<PackageReference Include="xunit" Version="2.9.0" />
 		<!-- DO NOT UPGRADE TO versions > 2.4.5 as they do not support .net5 or older -->
 		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
 			<PrivateAssets>all</PrivateAssets>

--- a/src/bunit.template/template/Company.BlazorTests1.csproj
+++ b/src/bunit.template/template/Company.BlazorTests1.csproj
@@ -25,7 +25,7 @@
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(testFramework_xunit)' == 'true'">
-		<PackageReference Include="xunit" Version="2.8.1" />
+		<PackageReference Include="xunit" Version="2.9.0" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="2.5.4">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/tests/bunit.core.tests/bunit.core.tests.csproj
+++ b/tests/bunit.core.tests/bunit.core.tests.csproj
@@ -13,7 +13,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="xunit" Version="2.8.1" />
+		<PackageReference Include="xunit" Version="2.9.0" />
 		<!-- DO NOT UPGRADE TO versions > 2.4.5 as they do not support .net5 or older -->
 		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
 			<PrivateAssets>all</PrivateAssets>

--- a/tests/bunit.generators.tests/bunit.generators.tests.csproj
+++ b/tests/bunit.generators.tests/bunit.generators.tests.csproj
@@ -14,7 +14,6 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-		<PackageReference Include="System.Net.Http" Version="4.3.4" />
 		<PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
 		<PackageReference Include="Verify.SourceGenerators" Version="2.2.0" />
 		<PackageReference Include="Verify.Xunit" Version="25.3.0" />
@@ -25,8 +24,8 @@
 		<PackageReference Update="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.9.2" />
 		<PackageReference Update="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing.XUnit" Version="1.1.1" />
 
-		<PackageReference Include="xunit" Version="2.8.1" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
+		<PackageReference Include="xunit" Version="2.9.0" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 		</PackageReference>

--- a/tests/bunit.testassets/_Imports.razor
+++ b/tests/bunit.testassets/_Imports.razor
@@ -1,4 +1,3 @@
-@using System.Net.Http
 @using Microsoft.AspNetCore.Components.Forms
 @using Microsoft.AspNetCore.Components.Routing
 @using Microsoft.AspNetCore.Components.Web

--- a/tests/bunit.testassets/bunit.testassets.csproj
+++ b/tests/bunit.testassets/bunit.testassets.csproj
@@ -25,7 +25,7 @@
 		<PackageReference Include="Microsoft.Extensions.Localization.Abstractions" Version="$(DotNet3Version)" />
 		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="3.2.1" />
 		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="3.2.1" />
-		<PackageReference Include="System.Text.Json" Version="8.0.3" />
+		<PackageReference Include="System.Text.Json" Version="8.0.4" />
 		<PackageReference Include="Serilog.Extensions.Logging" Version="8.0.0" />
 	</ItemGroup>
 	<ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">

--- a/tests/bunit.web.query.tests/bunit.web.query.tests.csproj
+++ b/tests/bunit.web.query.tests/bunit.web.query.tests.csproj
@@ -14,7 +14,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="xunit" Version="2.8.1" />
+		<PackageReference Include="xunit" Version="2.9.0" />
 		<!-- DO NOT UPGRADE TO versions > 2.4.5 as they do not support .net5 or older -->
 		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
 			<PrivateAssets>all</PrivateAssets>

--- a/tests/bunit.web.tests/bunit.web.tests.csproj
+++ b/tests/bunit.web.tests/bunit.web.tests.csproj
@@ -13,7 +13,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="xunit" Version="2.8.1" />
+		<PackageReference Include="xunit" Version="2.9.0" />
 		<!-- DO NOT UPGRADE TO versions > 2.4.5 as they do not support .net5 or older -->
 		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
 			<PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
Fix the current CVE with `System.Text.Json` and align versions to get rid of the build error.