### PR TITLE
docs: Added Limitation for UploadFiles

### DIFF
--- a/docs/site/docs/test-doubles/input-file.md
+++ b/docs/site/docs/test-doubles/input-file.md
@@ -26,3 +26,44 @@ inputFile.UploadFile(fileToUpload);
 ```
 
 To upload binary content, create an `InputFileContent` with the `InputFileContent.CreateFromBinary()` method.
+
+## Known limitations
+bUnit's support for the `InputFile` component is limited when uploading and resizing images (using the provided stream).
+
+```razor
+<InputFile OnChange="Upload" />
+<img src="@imageBase64">
+
+@code {
+  private string imageBase64 = string.Empty;
+
+  private async Task Upload(InputFileChangeEventArgs args)
+  {
+    var file = args.File;
+    var preview = await file.RequestImageFileAsync("image/png", 100, 100);
+    await using var stream = preview.OpenReadStream();
+    var buffer = new byte[stream.Length];
+    await using var memoryStream = new MemoryStream(buffer);
+    await stream.CopyToAsync(memoryStream);
+    var base64 = Convert.ToBase64String(buffer);
+    imageBase64 = $"data:image/png;base64,{base64}";
+  }
+}
+```
+
+When using the `RequestImageFileAsync` method, the `UploadFiles` method will not be able to upload the file inside a test. Blazor has some internal checks, bUnit can not overcome easily. So the following test will fail:
+
+```csharp
+[Fact]
+public void UploadFileTest()
+{
+  var cut = Render<ComponentThatUsesInputFile>();
+    
+  cut.FindComponent<InputFile>().UploadFiles(InputFileContent.CreateFromBinary([1,2], "test.png"));
+
+  cut.Find("img").GetAttribute("src").Should().NotBeNullOrEmpty(); // Will fail
+  Renderer.UnhandledException.Should().BeNull(); // Will fail
+}
+```
+
+To work around this limitation, refactoring the logic into a service that is injected into the component and then mocking the service in the test is a possible solution.


### PR DESCRIPTION
Added section about limitations for `UploadFiles`.
Closes #1521 