### PR TITLE
fix: Use docfx.json as replacement target

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -60,10 +60,10 @@ jobs:
         with:
           path: ./CHANGELOG.md
 
-      - name: 🛠️ Update tokens in project files
+      - name: 🛠️ Update tokens in files
         uses: cschleiden/replace-tokens@v1
         with:
-          files: '["docs/site/*.md", "docs/**/*.md", "docs/**/*.tmpl.partial", "*.csproj", "**/*.csproj", "src/Directory.Build.props"]'
+          files: '["docs/site/*.md", "docs/**/*.md", "docs/**/docfx.json", "*.csproj", "**/*.csproj", "src/Directory.Build.props"]'
         env:
           RELEASE_VERSION: ${{ steps.changelog_reader.outputs.version }}
           RELEASE_NOTES: ${{ steps.changelog_reader.outputs.changes }}

--- a/tests/bunit.generators.tests/bunit.generators.tests.csproj
+++ b/tests/bunit.generators.tests/bunit.generators.tests.csproj
@@ -17,7 +17,6 @@
 		<PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
 		<PackageReference Include="Verify.SourceGenerators" Version="2.3.0" />
 		<PackageReference Include="Verify.Xunit" Version="26.2.0" />
-		<PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="8.0.2" />
 		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.10.0" />
 		<PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.10.0" />
 		<PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="4.10.0" />


### PR DESCRIPTION
At some point in the past we moved the footer from the template file (`footer.temp.partial`) to inside the docfx.json due to their updated master template file.

Fixes #1546 