### PR TITLE
fix: Use one central version for System.Text.Json

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -28,6 +28,11 @@
 		<PackageVersion Include="Nerdbank.GitVersioning" Version="3.6.143" />
 	</ItemGroup>
 
+	<ItemGroup Label="System.Text.Json Vulnerability">
+		<!-- Due to a CVE in System.Text.Json we explicitly reference the latest version of System.Text.Json -->
+		<PackageVersion Include="System.Text.Json" Version="8.0.5"/>
+	</ItemGroup>
+
 	<ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
 		<PackageVersion Include="Microsoft.Extensions.Logging" Version="3.1.32"/>
 		<PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.32"/>
@@ -40,9 +45,6 @@
 		<PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="3.1.32"/>
 		<PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="3.2.1"/>
 		<PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="3.2.1"/>
-
-		<!-- Due to a CVE in System.Text.Json we explicitly reference the latest version of System.Text.Json -->
-		<PackageVersion Include="System.Text.Json" Version="6.0.10"/>
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
@@ -57,9 +59,6 @@
 		<PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="5.0.0"/>
 		<PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="5.0.17"/>
 		<PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="5.0.17"/>
-
-		<!-- Due to a CVE in System.Text.Json we explicitly reference the latest version of System.Text.Json -->
-		<PackageVersion Include="System.Text.Json" Version="6.0.10"/>
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
@@ -73,9 +72,6 @@
 		<PackageVersion Include="Microsoft.AspNetCore.Components.Web" Version="6.0.33"/>
 		<PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="6.0.33"/>
 		<PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="6.0.33"/>
-
-		<!-- Due to a CVE in System.Text.Json we explicitly reference the latest version of System.Text.Json -->
-		<PackageVersion Include="System.Text.Json" Version="6.0.10"/>
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
@@ -89,9 +85,6 @@
 		<PackageVersion Include="Microsoft.AspNetCore.Components.Web" Version="7.0.20"/>
 		<PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="7.0.20"/>
 		<PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="7.0.20"/>
-
-		<!-- Due to a CVE in System.Text.Json we explicitly reference the latest version of System.Text.Json -->
-		<PackageVersion Include="System.Text.Json" Version="8.0.5"/>
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
@@ -105,9 +98,6 @@
 		<PackageVersion Include="Microsoft.AspNetCore.Components.Web" Version="8.0.8"/>
 		<PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.8"/>
 		<PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="8.0.8"/>
-
-		<!-- Due to a CVE in System.Text.Json we explicitly reference the latest version of System.Text.Json -->
-		<PackageVersion Include="System.Text.Json" Version="8.0.5"/>
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
@@ -121,8 +111,6 @@
 		<PackageVersion Include="Microsoft.AspNetCore.Components.Web" Version="9.0.0-rc.1.24452.1"/>
 		<PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.0-rc.1.24452.1"/>
 		<PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="9.0.0-rc.1.24452.1"/>
-
-		<PackageVersion Include="System.Text.Json" Version="8.0.5" />
 	</ItemGroup>
 
 	<ItemGroup Label="Test Dependencies">


### PR DESCRIPTION
`System.Text.Json` in Version `8.0.x` supports `netstandard2.1` - therefore there is no need to manage different version across target frameworks.