### PR TITLE
chore: Update templates for .net9 and make .net9 default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,8 +163,11 @@ jobs:
         with:
           fetch-depth: 0 # Get all history to allow automatic versioning using MinVer
 
-      - name: Setup .NET
+      - name: ⚙️ Setup dotnet
         uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            9.0.x
 
       - uses: actions/download-artifact@v4
         with:

--- a/src/bunit.template/template/.template.config/template.json
+++ b/src/bunit.template/template/.template.config/template.json
@@ -82,7 +82,7 @@
 			"description": "The target framework sdk for the project.",
 			"displayName": "Target framework sdk",
 			"datatype": "choice",
-			"defaultValue": "net7.0",
+			"defaultValue": "net9.0",
 			"replaces": "targetSdk",
 			"choices": [
 				{
@@ -99,6 +99,11 @@
 					"choice": "net8.0",
 					"description": ".net 8.0",
 					"displayName": ".net 8.0"
+				},
+				{
+					"choice": "net9.0",
+					"description": ".net 9.0",
+					"displayName": ".net 9.0"
 				}
 			]
 		}

--- a/src/bunit.template/template/Company.BlazorTests1.csproj
+++ b/src/bunit.template/template/Company.BlazorTests1.csproj
@@ -25,21 +25,21 @@
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(testFramework_xunit)' == 'true'">
-		<PackageReference Include="xunit" Version="2.9.0" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="2.5.4">
+		<PackageReference Include="xunit" Version="2.9.2" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 		  </PackageReference>
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(testFramework_nunit)' == 'true'">
-		<PackageReference Include="NUnit" Version="3.14.0" />
-		<PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+		<PackageReference Include="NUnit" Version="4.2.2" />
+		<PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(testFramework_mstest)' == 'true'">
-		<PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
-		<PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
+		<PackageReference Include="MSTest.TestAdapter" Version="3.6.2" />
+		<PackageReference Include="MSTest.TestFramework" Version="3.6.2" />
 	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
Update our templates to support `net9.0` and make net9.0 the default too.