### PR TITLE
remove source link package reference not necessary

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -23,7 +23,6 @@
 	</ItemGroup>
 
 	<ItemGroup Label="Package Versioning">
-		<PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
 		<PackageVersion Include="Nerdbank.GitVersioning" Version="3.6.146" />
 	</ItemGroup>
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -60,10 +60,6 @@ See the full changelog at https://github.com/bUnit-dev/bUnit/releases
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.SourceLink.GitHub">
-			<PrivateAssets>all</PrivateAssets>
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
 		<PackageReference Include="Nerdbank.GitVersioning">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
> Starting with .NET 8, Source Link for the following source control providers is included in the .NET SDK and enabled by default:
> 
> [GitHub](http://github.com/) or [GitHub Enterprise](https://enterprise.github.com/home)
> [Azure Repos](https://azure.microsoft.com/en-us/services/devops/repos) git repositories (formerly known as Visual Studio Team Services)
> [GitLab](https://gitlab.com/) 12.0+ (for older versions see [GitLab settings](https://github.com/dotnet/sourcelink?tab=readme-ov-file#gitlab))
> [Bitbucket](https://bitbucket.org/) 4.7+ (for older versions see [Bitbucket settings](https://github.com/dotnet/sourcelink?tab=readme-ov-file#bitbucket))
> If your project uses .NET SDK 8+ and is hosted by the above providers it does not need to reference any Source Link packages or set any build properties.
> 

see https://github.com/dotnet/sourcelink?tab=readme-ov-file#using-source-link-in-net-projects