### PR TITLE
Update main with changes in stable after v1.37.7 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,10 @@ All notable changes to **bUnit** will be documented in this file. The project ad
 
 ## [Unreleased]
 
+## [1.37.7] - 2024-12-13
+
 ### Added
+
 - Added support for `RendererInfo` and `AssignedRenderMode` (`.net9.0`).
 
 ## [1.36.0] - 2024-11-12
@@ -1426,7 +1429,8 @@ The latest version of the library is availble on NuGet:
 - **Wrong casing on keyboard event dispatch helpers.**
           The helper methods for the keyboard events was not probably cased, so that has been updated. E.g. from `Keypress(...)` to `KeyPress(...)`.
 
-[unreleased]: https://github.com/bUnit-dev/bUnit/compare/v1.36.0...HEAD
+[unreleased]: https://github.com/bUnit-dev/bUnit/compare/v1.37.7...HEAD
+[1.37.7]: https://github.com/bUnit-dev/bUnit/compare/v1.36.0...1.37.7
 [1.36.0]: https://github.com/bUnit-dev/bUnit/compare/v1.35.3...v1.36.0
 [1.35.3]: https://github.com/bUnit-dev/bUnit/compare/v1.34.0...1.35.3
 [1.34.0]: https://github.com/bUnit-dev/bUnit/compare/v1.33.3...v1.34.0


### PR DESCRIPTION
Hi @egil

This PR was created because the [release workflow](https://github.com/bUnit-dev/bUnit/actions/runs/12319083236) failed to automatically merge stable into main.