### PR TITLE
fix(FakeNavigationManager): Do Not set Uri if navigation is prevented…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to **bUnit** will be documented in this file. The project ad
 
 ## [Unreleased]
 
+### Fixed
+
+- Do not set the `Uri` property on the `FakeNavigationManager` if navigation is prevented by a handler on `net7.0` or greater.
+
 ## [1.38.5] - 2025-01-12
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to **bUnit** will be documented in this file. The project ad
 
 ### Fixed
 
-- Do not set the `Uri` property on the `FakeNavigationManager` if navigation is prevented by a handler on `net7.0` or greater.
+- Do not set the `Uri` or `BaseUri` property on the `FakeNavigationManager` if navigation is prevented by a handler on `net7.0` or greater.
 
 ## [1.38.5] - 2025-01-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to **bUnit** will be documented in this file. The project ad
 
 ### Fixed
 
-- Do not set the `Uri` or `BaseUri` property on the `FakeNavigationManager` if navigation is prevented by a handler on `net7.0` or greater.
+- Do not set the `Uri` or `BaseUri` property on the `FakeNavigationManager` if navigation is prevented by a handler on `net7.0` or greater. Reported and fixed by [@ayyron-dev](https://github.com/ayyron-dev) in [#1647](https://github.com/bUnit-dev/bUnit/issues/1647)
 
 ## [1.38.5] - 2025-01-12
 

--- a/src/bunit.web/TestDoubles/NavigationManager/FakeNavigationManager.cs
+++ b/src/bunit.web/TestDoubles/NavigationManager/FakeNavigationManager.cs
@@ -75,11 +75,6 @@ public sealed class FakeNavigationManager : NavigationManager
 		var absoluteUri = GetNewAbsoluteUri(uri);
 		var changedBaseUri = HasDifferentBaseUri(absoluteUri);
 
-		if (changedBaseUri)
-		{
-			BaseUri = GetBaseUri(absoluteUri);
-		}
-
 		if (options.ReplaceHistoryEntry && history.Count > 0)
 			history.Pop();
 
@@ -109,15 +104,16 @@ public sealed class FakeNavigationManager : NavigationManager
 			{
 				return;
 			}
-			else
-			{
-				Uri = ToAbsoluteUri(uri).OriginalString;
-			}
 #else
 			history.Push(new NavigationHistory(uri, options));
-			Uri = absoluteUri.OriginalString;
 #endif
 
+			if (changedBaseUri)
+			{
+				BaseUri = GetBaseUri(absoluteUri);
+			}
+
+			Uri = absoluteUri.OriginalString;
 
 			// Only notify of changes if user navigates within the same
 			// base url (domain). Otherwise, the user navigated away
@@ -126,10 +122,6 @@ public sealed class FakeNavigationManager : NavigationManager
 			if (!changedBaseUri)
 			{
 				NotifyLocationChanged(isInterceptedLink: false);
-			}
-			else
-			{
-				BaseUri = GetBaseUri(absoluteUri);
 			}
 		});
 	}

--- a/src/bunit.web/TestDoubles/NavigationManager/FakeNavigationManager.cs
+++ b/src/bunit.web/TestDoubles/NavigationManager/FakeNavigationManager.cs
@@ -80,8 +80,6 @@ public sealed class FakeNavigationManager : NavigationManager
 			BaseUri = GetBaseUri(absoluteUri);
 		}
 
-		Uri = ToAbsoluteUri(uri).OriginalString;
-
 		if (options.ReplaceHistoryEntry && history.Count > 0)
 			history.Pop();
 
@@ -92,7 +90,6 @@ public sealed class FakeNavigationManager : NavigationManager
 		testContextBase.Renderer.Dispatcher.InvokeAsync(() =>
 #endif
 		{
-			Uri = absoluteUri.OriginalString;
 
 #if NET7_0_OR_GREATER
 			var shouldContinueNavigation = false;
@@ -112,8 +109,13 @@ public sealed class FakeNavigationManager : NavigationManager
 			{
 				return;
 			}
+			else
+			{
+				Uri = ToAbsoluteUri(uri).OriginalString;
+			}
 #else
 			history.Push(new NavigationHistory(uri, options));
+			Uri = absoluteUri.OriginalString;
 #endif
 
 
@@ -135,7 +137,7 @@ public sealed class FakeNavigationManager : NavigationManager
 
 #if NET7_0_OR_GREATER
 	/// <inheritdoc/>
-	protected override void SetNavigationLockState(bool value) {}
+	protected override void SetNavigationLockState(bool value) { }
 
 	/// <inheritdoc/>
 	protected override void HandleLocationChangingHandlerException(Exception ex, LocationChangingContext context)

--- a/tests/bunit.web.tests/TestDoubles/NavigationManager/FakeNavigationManagerTest.cs
+++ b/tests/bunit.web.tests/TestDoubles/NavigationManager/FakeNavigationManagerTest.cs
@@ -107,18 +107,18 @@ public class FakeNavigationManagerTest : TestContext
 	}
 
 #if !NET6_0_OR_GREATER
-		[Theory(DisplayName = "NavigateTo(uri, forceLoad) is saved in history")]
-		[InlineData("/uri", false)]
-		[InlineData("/anotherUri", true)]
-		public void Test100(string uri, bool forceLoad)
-		{
-			var sut = CreateFakeNavigationManager();
+	[Theory(DisplayName = "NavigateTo(uri, forceLoad) is saved in history")]
+	[InlineData("/uri", false)]
+	[InlineData("/anotherUri", true)]
+	public void Test100(string uri, bool forceLoad)
+	{
+		var sut = CreateFakeNavigationManager();
 
-			sut.NavigateTo(uri, forceLoad);
+		sut.NavigateTo(uri, forceLoad);
 
-			sut.History.ShouldHaveSingleItem()
-				.ShouldBeEquivalentTo(new NavigationHistory(uri, new NavigationOptions(forceLoad)));
-		}
+		sut.History.ShouldHaveSingleItem()
+			.ShouldBeEquivalentTo(new NavigationHistory(uri, new NavigationOptions(forceLoad)));
+	}
 #endif
 #if NET6_0_OR_GREATER
 	[Theory(DisplayName = "NavigateTo(uri, forceLoad, replaceHistoryEntry) is saved in history")]
@@ -297,18 +297,22 @@ public class FakeNavigationManagerTest : TestContext
 		sut.HistoryEntryState.ShouldBe(null);
 	}
 
-	[Fact(DisplayName = "Preventing Navigation does not change Uri")]
-	public void Test018()
+	[Theory(DisplayName = "Preventing Navigation does not change Uri or BaseUri")]
+	[InlineData("/prevented-path")]
+	[InlineData("https://bunit.dev/uri")]
+	public void Test018(string navToUri)
 	{
 		var sut = CreateFakeNavigationManager();
-		string expectedUri = new Uri(new Uri(sut.BaseUri, UriKind.Absolute), new Uri("/expected-path", UriKind.Relative)).AbsoluteUri;
+		Uri expectedUri = new Uri(new Uri(sut.BaseUri, UriKind.Absolute), new Uri("/expected-path", UriKind.Relative));
+		string expectedBaseUri = sut.BaseUri;
 
-		sut.NavigateTo("/expected-path");
+		sut.NavigateTo(expectedUri.AbsoluteUri);
 		using var handler = sut.RegisterLocationChangingHandler(LocationChangingHandler);
-		sut.NavigateTo("/prevented-path");
+		sut.NavigateTo(navToUri);
 
 		sut.History.First().State.ShouldBe(NavigationState.Prevented);
-		sut.Uri.ShouldBe(expectedUri);
+		sut.BaseUri.ShouldBe(expectedBaseUri);
+		sut.Uri.ShouldBe(expectedUri.AbsoluteUri);
 
 		ValueTask LocationChangingHandler(LocationChangingContext arg)
 		{

--- a/tests/bunit.web.tests/TestDoubles/NavigationManager/FakeNavigationManagerTest.cs
+++ b/tests/bunit.web.tests/TestDoubles/NavigationManager/FakeNavigationManagerTest.cs
@@ -303,16 +303,13 @@ public class FakeNavigationManagerTest : TestContext
 	public void Test018(string navToUri)
 	{
 		var sut = CreateFakeNavigationManager();
-		Uri expectedUri = new Uri(new Uri(sut.BaseUri, UriKind.Absolute), new Uri("/expected-path", UriKind.Relative));
-		string expectedBaseUri = sut.BaseUri;
-
-		sut.NavigateTo(expectedUri.AbsoluteUri);
 		using var handler = sut.RegisterLocationChangingHandler(LocationChangingHandler);
+		
 		sut.NavigateTo(navToUri);
 
 		sut.History.First().State.ShouldBe(NavigationState.Prevented);
-		sut.BaseUri.ShouldBe(expectedBaseUri);
-		sut.Uri.ShouldBe(expectedUri.AbsoluteUri);
+		sut.BaseUri.ShouldBe("http://localhost/");
+		sut.Uri.ShouldBe("http://localhost/");
 
 		ValueTask LocationChangingHandler(LocationChangingContext arg)
 		{


### PR DESCRIPTION
… on net7.0 or greater

## Pull request description
This PR is meant to address issue #1647 

NavigationManager has added functionality to support preventing navigation in net7.0 and later so this PR updates teh FakeNavigationManager to not set the Uri property with the target uri if navigation was prevented by the user.

### PR meta checklist
- [x] Pull request is targeted at `main` branch for code   
  or targeted at `stable` branch for documentation that is live on bunit.dev.
- [x] Pull request is linked to all related issues, if any.
- [x] I have read the _CONTRIBUTING.md_ document.

### Code PR specific checklist
- [x] My code follows the code style of this project and AspNetCore coding guidelines.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] I have updated the appropriate sub section in the _CHANGELOG.md_.
- [x] I have added, updated or removed tests to according to my changes.
  - [x] All tests passed.
