### PR TITLE
API review

### DIFF
--- a/src/bunit/Diffing/DiffMarkupFormatter.cs
+++ b/src/bunit/Diffing/DiffMarkupFormatter.cs
@@ -7,7 +7,7 @@ namespace Bunit.Diffing;
 /// <summary>
 /// A markup formatter, that skips any special Blazor attributes added by the <see cref="Htmlizer"/>.
 /// </summary>
-public class DiffMarkupFormatter : PrettyMarkupFormatter, IMarkupFormatter
+internal class DiffMarkupFormatter : PrettyMarkupFormatter, IMarkupFormatter
 {
 	/// <summary>
 	/// Initializes a new instance of the <see cref="DiffMarkupFormatter"/> class.

--- a/src/bunit/Extensions/NodePrintExtensions.cs
+++ b/src/bunit/Extensions/NodePrintExtensions.cs
@@ -10,7 +10,7 @@ namespace Bunit;
 /// <summary>
 /// Helper methods for pretty printing markup from <see cref="INode"/> and <see cref="INodeList"/>.
 /// </summary>
-public static class NodePrintExtensions
+internal static class NodePrintExtensions
 {
 	/// <summary>
 	/// Writes the serialization of the node guided by the formatter.
@@ -30,21 +30,6 @@ public static class NodePrintExtensions
 
 	/// <summary>
 	/// Uses the <see cref="DiffMarkupFormatter"/> to generate a HTML markup string
-	/// from a <see cref="IEnumerable{INode}"/> <paramref name="nodes"/>.
-	/// The generated HTML markup will NOT include the internal Blazor attributes
-	/// added to elements.
-	/// </summary>
-	public static string ToDiffMarkup(this IEnumerable<INode> nodes)
-	{
-		ArgumentNullException.ThrowIfNull(nodes);
-
-		using var sw = new StringWriter();
-		nodes.ToHtml(sw, new DiffMarkupFormatter());
-		return sw.ToString();
-	}
-
-	/// <summary>
-	/// Uses the <see cref="DiffMarkupFormatter"/> to generate a HTML markup string
 	/// from a <see cref="IMarkupFormattable"/> <paramref name="markupFormattable"/>.
 	/// The generated HTML markup will NOT include the internal Blazor attributes
 	/// added to elements.
@@ -55,42 +40,6 @@ public static class NodePrintExtensions
 
 		using var sw = new StringWriter();
 		markupFormattable.ToHtml(sw, new DiffMarkupFormatter());
-		return sw.ToString();
-	}
-
-	/// <summary>
-	/// Uses the <see cref="PrettyMarkupFormatter"/> to generate a HTML markup string
-	/// from a <see cref="IEnumerable{INode}"/> <paramref name="nodes"/>.
-	/// </summary>
-	public static string ToMarkup(this IEnumerable<INode> nodes)
-	{
-		ArgumentNullException.ThrowIfNull(nodes);
-
-		using var sw = new StringWriter();
-		var formatter = new PrettyMarkupFormatter
-		{
-			NewLine = Environment.NewLine,
-			Indentation = "  ",
-		};
-		nodes.ToHtml(sw, formatter);
-		return sw.ToString();
-	}
-
-	/// <summary>
-	/// Uses the <see cref="PrettyMarkupFormatter"/> to generate a HTML markup
-	/// from a <see cref="IMarkupFormattable"/> <paramref name="markupFormattable"/>.
-	/// </summary>
-	public static string ToMarkup(this IMarkupFormattable markupFormattable)
-	{
-		ArgumentNullException.ThrowIfNull(markupFormattable);
-
-		using var sw = new StringWriter();
-		var formatter = new PrettyMarkupFormatter
-		{
-			NewLine = Environment.NewLine,
-			Indentation = "  ",
-		};
-		markupFormattable.ToHtml(sw, formatter);
 		return sw.ToString();
 	}
 


### PR DESCRIPTION
The target is to have a clean and maintainable public API surface.

What we did so far (21th of February):
 * Used the following regex to identify public API: `public [\w|\s]*(interface|class|record|struct)`
 * `DiffMarkupFormatter`is internal
 * `NodePrintExtensions`is internal and we removed some methods that weren't used anymore