### PR TITLE
fix: bUnit can handle relative units in Markup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to **bUnit** will be documented in this file. The project ad
 ### Fixed
 
 - Do not set the `Uri` or `BaseUri` property on the `FakeNavigationManager` if navigation is prevented by a handler on `net7.0` or greater. Reported and fixed by [@ayyron-dev](https://github.com/ayyron-dev) in [#1647](https://github.com/bUnit-dev/bUnit/issues/1647)
+- Use default renderer properties for AngleSharp. Reported by [@jtleaming](https://github.com/jtleaming) in [#1692].
 
 ## [1.38.5] - 2025-01-12
 

--- a/src/bunit.web/Rendering/BunitHtmlParser.cs
+++ b/src/bunit.web/Rendering/BunitHtmlParser.cs
@@ -1,6 +1,7 @@
 using System.Collections;
 using System.Diagnostics;
 using AngleSharp;
+using AngleSharp.Css;
 using AngleSharp.Dom;
 using AngleSharp.Html.Parser;
 using Bunit.Diffing;
@@ -28,7 +29,8 @@ public sealed class BunitHtmlParser : IDisposable
 	/// with a AngleSharp context without a <see cref="TestRenderer"/> registered.
 	/// </summary>
 	public BunitHtmlParser()
-		: this(Configuration.Default.WithCss().With(new HtmlComparer())) { }
+		: this(Configuration.Default.WithCss()
+			.With(new HtmlComparer())) { }
 
 	/// <summary>
 	/// Initializes a new instance of the <see cref="BunitHtmlParser"/> class
@@ -43,7 +45,13 @@ public sealed class BunitHtmlParser : IDisposable
 
 	private BunitHtmlParser(IConfiguration angleSharpConfiguration)
 	{
-		var config = angleSharpConfiguration.With(this);
+		var config = angleSharpConfiguration
+			.With(this)
+			.WithRenderDevice(new DefaultRenderDevice
+			{
+				ViewPortWidth = 1920,
+				ViewPortHeight = 1080,
+			});
 		context = BrowsingContext.New(config);
 		var parseOptions = new HtmlParserOptions
 		{

--- a/tests/bunit.testassets/SampleComponents/ComponentWithRelativeUnitAsWidth.razor
+++ b/tests/bunit.testassets/SampleComponents/ComponentWithRelativeUnitAsWidth.razor
@@ -1,0 +1,2 @@
+<div class="my-component" style="width: 5%">
+</div>

--- a/tests/bunit.web.tests/Rendering/RenderedComponentTest.cs
+++ b/tests/bunit.web.tests/Rendering/RenderedComponentTest.cs
@@ -1,3 +1,6 @@
+using AngleSharp;
+using AngleSharp.Css;
+using AngleSharp.Dom;
 using Bunit.Rendering;
 
 namespace Bunit;
@@ -67,4 +70,14 @@ public class RenderedComponentTest : TestContext
 		cut.Instance.JSRuntime.ShouldNotBeNull();
 	}
 	#endif
+
+	[Fact(DisplayName = "Using relative units in style attribute can be retrieved")]
+	public void Test022()
+	{
+		var cut = RenderComponent<ComponentWithRelativeUnitAsWidth>();
+		
+		var text = cut.Find(".my-component").GetInnerText();
+
+		text.ShouldNotBeNull();
+	}
 }


### PR DESCRIPTION
Fixes #1692