### PR TITLE
V2 migration docs

### DIFF
--- a/docs/serve-docs.cmd
+++ b/docs/serve-docs.cmd
@@ -1,2 +1,0 @@
-@echo off
-dotnet-serve -d "site/_site" -h "Cache-Control: no-cache"

--- a/docs/serve-docs.sh
+++ b/docs/serve-docs.sh
@@ -1,2 +1,0 @@
-#!/bin/bash
-dotnet-serve -d "site/_site" -h "Cache-Control: no-cache"

--- a/docs/site/docs/migrations/1to2.md
+++ b/docs/site/docs/migrations/1to2.md
@@ -1,0 +1,67 @@
+---
+uid: migrating-from-1-to-2
+title: Migrating from 1.x to 2.x
+---
+
+# Migrating from bUnit 1.x to 2.x
+This document describes the changes made in bUnit 2.x that may affect  existing tests written for bUnit 1.x. The old documentation for bUnit 1.x is available at: https://v1.bunit.dev.
+
+## One package to rule them all
+`bunit.core` and `bunit.web` have be merged into a single package called `bunit`. The seperation was used to allow for extensibitlity, which isn't used anymore. Therefore `bunit.core` and `bunit.web` will stay on version 1.x, while `bunit` will be the only package going forward. To migrate, simply remove the `bunit.core` and `bunit.web` packages and add the `bunit` package. We don't expect many users to have used the `bunit.core` or `bunit.web`  package directly, but may hit 3rd party packages that depend on them. 
+
+## `TestContext` renamed to `BunitContext`
+
+The `TestContext` class has been renamed to `BunitContext`. To migrate tests, rename all instances of `TestContext` to `BunitContext`:
+
+```diff
+- public class MyTestClass : TestContext
++ public class MyTestClass : BunitContext
+```
+
+## `BunitContext` offers `Dispose` and `DisposeAsync` methods
+In version 1, the `TestContext` class only implemented `IDisposable`, but in version 2, it also implements `IAsyncDisposable`. Therefore, if there are asynchronous disposable inside the container for example, the asynchronous version should be used.
+
+## The `Fake` prefix was renamed to `Bunit` (e.g. `FakeNavigationManager` to `BunitNavigationManager`)
+The `Fake` prefix used for various fake implementations has been renamed to `Bunit`. This includes the following types:
+ * `FakeNavigationManager` to `BunitNavigationManager`
+ * `FakeJSRuntime` to `BunitJSRuntime`
+ * `FakeAuthenticationStateProvider` to `BunitAuthenticationStateProvider`
+ * `FakeAuthrozitationContext` to `BunitAuthorizationContext`
+ * `FakeuthorizationPolicyProvider` to `BunitAuthorizationPolicyProvider`
+  
+## Unified the `Render` methods
+In v1 there were multiple `RenderXXX`methods (like `RenderComponent`, `Render` and `SetParametersAndRender`) that were used to render components and markup. In v2, these methods have been unified into a single `Render` method that can handle both components and markup) via the simple `Render` method:
+
+```diff
+- var cut = RenderComponent<MyComponent>();
++ var cut = Render<MyComponent>();
+```
+
+## Removed some abstraction
+Many types were removed in favor of one public type:
+ * `IRenderedComponent<TComponent>` - where `TComponent` is the type of the component rendered (or the a `ContainerFragment` if markup was rendered).
+
+The removed types were:
+ * `IRenderedFragment`
+ * `IRenderedComponent`
+ * `IRenderedMarkup`
+ * `IRenderedComponentBase`
+
+If any of the types were used (for example in extensions methods), they should be replaced with `IRenderedComponent`.
+
+## Removed of `IsNullOrEmpty` extension method on `IEnumerable<T>` and `CreateLogger` on `IServiceProvider`
+The `IsNullOrEmpty` extension method on `IEnumerable<T>` has been removed, as well as the `CreateLogger` extension method on `IServiceProvider`. These extension methods are pretty common and conflict with other libraries. These methods can be recreated like this:
+
+```csharp
+public static class Extensions
+{
+    public static bool IsNullOrEmpty<T>(this IEnumerable<T> enumerable)
+        => enumerable == null || !enumerable.Any();
+    
+    public static ILogger<T> CreateLogger<T>(this IServiceProvider serviceProvider)
+    {
+        var loggerFactory = serviceProvider.GetRequiredService<ILoggerFactory>() ?? NullLoggerFactory.Instance;
+        return loggerFactory.CreateLogger<T>();
+    }
+}
+```

--- a/docs/site/docs/migrations/index.md
+++ b/docs/site/docs/migrations/index.md
@@ -1,0 +1,10 @@
+---
+uid: migrations
+title: Migrations
+---
+
+# Migrations
+
+This section covers the migration across major versions of bUnit. The mirations themselves also list the link to the old version of the documentation (including the old API documentation).
+
+ - <xref:migrating-from-1-to-2>

--- a/docs/site/docs/toc.md
+++ b/docs/site/docs/toc.md
@@ -35,6 +35,9 @@
 # [Extensions](xref:extensions)
 ## [bunit.generators](xref:bunit-generators)
 
+# [Migrations](xref:migrations)
+## [1.x to 2.x](xref:migrating-from-1-to-2)
+
 # [Miscellaneous testing tips](xref:misc-test-tips)
 # [External resources](xref:external-resources)
 # [Contribute](xref:contribute)

--- a/docs/site/index.md
+++ b/docs/site/index.md
@@ -42,8 +42,6 @@ bUnit is available on NuGet in various incarnations. Most users should just pick
 | Name | Description | NuGet Download Link |
 | ----- | ----- | ---- |
 | [bUnit](https://www.nuget.org/packages/bunit/) | Includes the bUnit.core and bUnit.web packages. | [![Nuget](https://img.shields.io/nuget/dt/bunit?logo=nuget&style=flat-square)](https://www.nuget.org/packages/bunit/) |
-| [bUnit.core](https://www.nuget.org/packages/bunit.core/) | Core library that enables rendering a Blazor component in a test context. | [![Nuget](https://img.shields.io/nuget/dt/bunit.core?logo=nuget&style=flat-square)](https://www.nuget.org/packages/bunit.core/) |
-| [bUnit.web](https://www.nuget.org/packages/bunit.web/) | Adds support for testing Blazor components for the web. This includes bUnit.core. | [![Nuget](https://img.shields.io/nuget/dt/bunit.web?logo=nuget&style=flat-square)](https://www.nuget.org/packages/bunit.web/) |
 | [bUnit.template](https://www.nuget.org/packages/bunit.template/) | Template for bUnit test projects based on xUnit, NUnit or MSTest | [![Nuget](https://img.shields.io/nuget/dt/bunit.template?logo=nuget&style=flat-square)](https://www.nuget.org/packages/bunit.template/) |
 | [bUnit.generators](https://www.nuget.org/packages/bunit.generators/)|Source code generators to minimize code setup in various situations.|[![Nuget](https://img.shields.io/nuget/dt/bunit.generators?logo=nuget&style=flat-square)](https://www.nuget.org/packages/bunit.generators/)|
 | [bUnit.web.query](https://www.nuget.org/packages/bunit.web.query/)|bUnit implementation of testing-library.com's query APIs.|[![Nuget](https://img.shields.io/nuget/dt/bunit.web.query?logo=nuget&style=flat-square)](https://www.nuget.org/packages/bunit.web.query/)|


### PR DESCRIPTION
This adds some very basic documentation for the migration from v1 to v2.

Just something so we can go out and prerelease v2 to the public.