### PR TITLE
refactor: use xunit.v3 for test suite

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -73,7 +73,7 @@
 
 	<ItemGroup Label="Test Dependencies">
 		<PackageVersion Include="AutoFixture" Version="4.18.1"/>
-		<PackageVersion Include="AutoFixture.Xunit2" Version="4.18.1"/>
+		<PackageVersion Include="AutoFixture.Xunit3" Version="4.19.0"/>
 		<PackageVersion Include="MSTest.TestAdapter" Version="3.6.0" />
 		<PackageVersion Include="MSTest.TestFramework" Version="3.6.0" />
 		<PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1"/>
@@ -84,20 +84,16 @@
 		<PackageVersion Include="Serilog.Extensions.Logging" Version="9.0.2" />
 		<PackageVersion Include="Shouldly" Version="4.3.0"/>
 		<PackageVersion Include="Verify.SourceGenerators" Version="2.5.0"/>
-		<PackageVersion Include="Verify.Xunit" Version="30.12.0"/>
-		<PackageVersion Include="Xunit.Combinatorial" Version="1.6.24"/>
+		<PackageVersion Include="Verify.XunitV3" Version="30.13.0"/>
+		<PackageVersion Include="Xunit.Combinatorial" Version="2.0.24"/>
 		<PackageVersion Include="coverlet.collector" Version="6.0.4" />
 		<PackageVersion Include="coverlet.msbuild" Version="6.0.4" />
 		<PackageVersion Include="nunit" Version="4.2.2" />
 		<PackageVersion Include="xunit" Version="2.9.3"/>
-		<PackageVersion Include="xunit.abstractions" Version="2.0.3"/>
-		<PackageVersion Include="xunit.assert" Version="2.9.3"/>
-		<PackageVersion Include="xunit.extensibility.execution" Version="2.9.3"/>
+		<PackageVersion Include="xunit.v3" Version="3.0.1"/>
+		<PackageVersion Include="xunit.v3.extensibility.core" Version="3.0.1" />
+		<PackageVersion Include="xunit.v3.assert" Version="3.0.1"/>
 		<PackageVersion Include="xunit.runner.visualstudio" Version="3.1.4"/>
-	</ItemGroup>
-
-	<ItemGroup Label="Test Dependencies - Legacy" Condition="'$(TargetFramework)' == 'netcoreapp3.1' Or '$(TargetFramework)' == 'net5.0'">
-		<PackageVersion Update="xunit.runner.visualstudio" Version="2.4.5"/>
 	</ItemGroup>
 
 	<ItemGroup Label="Source Code Generators">
@@ -105,6 +101,6 @@
 		<PackageVersion Include="Microsoft.CodeAnalysis.Common" Version="4.14.0"/>
 		<PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="4.14.0"/>
 		<PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.14.0"/>
-		<PackageVersion Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing.XUnit" Version="1.1.2" />
+		<PackageVersion Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing" Version="1.1.2" />
 	</ItemGroup>
 </Project>

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -12,6 +12,7 @@
 		<IsPackable>false</IsPackable>
 		<IsTestProject>true</IsTestProject>
 		<SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
+        <OutputType>Exe</OutputType>
 	</PropertyGroup>
 	
 	<PropertyGroup>
@@ -24,19 +25,19 @@
 
 	<ItemGroup Condition="$(MSBuildProjectName) != 'bunit.testassets'">
 		<PackageReference Include="AutoFixture" />
-		<PackageReference Include="AutoFixture.Xunit2" />
+		<PackageReference Include="AutoFixture.Xunit3" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk"/>
 		<PackageReference Include="NSubstitute" />
 		<PackageReference Include="Shouldly"/>
 		<PackageReference Include="coverlet.msbuild" />
 		<PackageReference Include="Xunit.Combinatorial" />
-		<PackageReference Include="xunit" />
+		<PackageReference Include="xunit.v3" />
 		<PackageReference Include="xunit.runner.visualstudio" PrivateAssets="All" IncludeAssets="Runtime;Build;Native;contentFiles;Analyzers" />
 	</ItemGroup>
 
 	<ItemGroup Label="Implicit usings" Condition="$(MSBuildProjectName) != 'bunit.testassets' AND $(MSBuildProjectName) != 'bunit.generators.tests'">
 		<Using Include="AutoFixture" />
-		<Using Include="AutoFixture.Xunit2" />
+		<Using Include="AutoFixture.Xunit3" />
 		<Using Include="Bunit.TestAssets.SampleComponents" />
 		<Using Include="Bunit.TestAssets.SampleComponents.Data" />
 		<Using Include="Microsoft.JSInterop" />
@@ -46,7 +47,6 @@
 		<Using Include="NSubstitute" />
 		<Using Include="Shouldly" />
 		<Using Include="Xunit" />
-		<Using Include="Xunit.Abstractions" />
 	</ItemGroup>
 
 </Project>

--- a/tests/bunit.generators.tests/Web.AngleSharp/WrapperElementsGeneratorTest.cs
+++ b/tests/bunit.generators.tests/Web.AngleSharp/WrapperElementsGeneratorTest.cs
@@ -14,7 +14,7 @@ public class WrapperElementsGeneratorTest
 		var generator = new WrapperElementsGenerator();
 
 		GeneratorDriver driver = CSharpGeneratorDriver.Create(generator);
-		driver = driver.RunGenerators(inputCompilation);
+		driver = driver.RunGenerators(inputCompilation, Xunit.TestContext.Current.CancellationToken);
 
 		var settings = new VerifySettings();
 		settings.AutoVerify();

--- a/tests/bunit.generators.tests/bunit.generators.tests.csproj
+++ b/tests/bunit.generators.tests/bunit.generators.tests.csproj
@@ -15,12 +15,12 @@
 
 	<ItemGroup>
 		<PackageReference Include="Verify.SourceGenerators" />
-		<PackageReference Include="Verify.Xunit" />
+		<PackageReference Include="Verify.XunitV3" />
 		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
 		<PackageReference Include="Microsoft.CodeAnalysis.Common" />
 		<PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" />
 		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" />
-		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing.XUnit" />
+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/tests/bunit.testassets/DumpCapture.cs
+++ b/tests/bunit.testassets/DumpCapture.cs
@@ -1,6 +1,6 @@
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
-using Xunit.Abstractions;
+using Xunit;
 
 namespace Bunit.TestAssets;
 

--- a/tests/bunit.testassets/Serilog.Sinks.XUnit/TestOutputSink.cs
+++ b/tests/bunit.testassets/Serilog.Sinks.XUnit/TestOutputSink.cs
@@ -1,8 +1,9 @@
 using Serilog.Core;
 using Serilog.Events;
 using Serilog.Formatting;
-using Xunit.Abstractions;
+using Xunit;
 using Xunit.Sdk;
+using Xunit.v3;
 
 namespace Serilog.Sinks.XUnit;
 

--- a/tests/bunit.testassets/Serilog.Sinks.XUnit/XUnitLoggerConfigurationExtensions.cs
+++ b/tests/bunit.testassets/Serilog.Sinks.XUnit/XUnitLoggerConfigurationExtensions.cs
@@ -4,7 +4,8 @@ using Serilog.Events;
 using Serilog.Formatting;
 using Serilog.Formatting.Display;
 using Serilog.Sinks.XUnit;
-using Xunit.Abstractions;
+using Xunit;
+using Xunit.Sdk;
 
 namespace Serilog;
 

--- a/tests/bunit.testassets/ServiceCollectionLoggingExtensions.cs
+++ b/tests/bunit.testassets/ServiceCollectionLoggingExtensions.cs
@@ -2,7 +2,6 @@ using Microsoft.Extensions.Logging;
 using Serilog;
 using Serilog.Events;
 using Serilog.Templates;
-using Xunit.Abstractions;
 
 namespace Xunit;
 

--- a/tests/bunit.testassets/XunitExtensions/RepeatAttribute.cs
+++ b/tests/bunit.testassets/XunitExtensions/RepeatAttribute.cs
@@ -1,5 +1,6 @@
 using System.Reflection;
 using Xunit.Sdk;
+using Xunit.v3;
 
 namespace Xunit;
 
@@ -20,11 +21,12 @@ public sealed class RepeatAttribute : DataAttribute
 		Count = count;
 	}
 
-	public override IEnumerable<object[]> GetData(MethodInfo testMethod)
+	public override ValueTask<IReadOnlyCollection<ITheoryDataRow>> GetData(MethodInfo testMethod,
+		DisposalTracker disposalTracker)
 	{
-		for (int count = 1; count <= Count; count++)
-		{
-			yield return new object[] { count };
-		}
+		var rows = Enumerable.Range(1, Count).Select(i => new TheoryDataRow(new object[] { i })).ToArray();
+		return new ValueTask<IReadOnlyCollection<ITheoryDataRow>>(rows);
 	}
+
+	public override bool SupportsDiscoveryEnumeration() => false;
 }

--- a/tests/bunit.testassets/XunitExtensions/UseCultureAttribute.cs
+++ b/tests/bunit.testassets/XunitExtensions/UseCultureAttribute.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 using System.Reflection;
 using Xunit.Sdk;
+using Xunit.v3;
 
 namespace Xunit;
 
@@ -62,7 +63,7 @@ public sealed class UseCultureAttribute : BeforeAfterTestAttribute
 	/// and replaces them with the new cultures defined in the constructor.
 	/// </summary>
 	/// <param name="methodUnderTest">The method under test</param>
-	public override void Before(MethodInfo methodUnderTest)
+	public override void Before(MethodInfo methodUnderTest, IXunitTest test)
 	{
 		originalCulture = Thread.CurrentThread.CurrentCulture;
 		originalUICulture = Thread.CurrentThread.CurrentUICulture;
@@ -79,7 +80,7 @@ public sealed class UseCultureAttribute : BeforeAfterTestAttribute
 	/// <see cref="CultureInfo.CurrentUICulture" /> to <see cref="Thread.CurrentPrincipal" />
 	/// </summary>
 	/// <param name="methodUnderTest">The method under test</param>
-	public override void After(MethodInfo methodUnderTest)
+	public override void After(MethodInfo methodUnderTest, IXunitTest test)
 	{
 		Thread.CurrentThread.CurrentCulture = originalCulture;
 		Thread.CurrentThread.CurrentUICulture = originalUICulture;

--- a/tests/bunit.testassets/bunit.testassets.csproj
+++ b/tests/bunit.testassets/bunit.testassets.csproj
@@ -16,9 +16,8 @@
 	<ItemGroup>
 		<PackageReference Include="Serilog" />
 		<PackageReference Include="Serilog.Expressions" />
-		<PackageReference Include="xunit.extensibility.execution" />
-		<PackageReference Include="xunit.abstractions" />		
-		<PackageReference Include="xunit.assert"  />
+		<PackageReference Include="xunit.v3.extensibility.core" />
+		<PackageReference Include="xunit.v3.assert"  />
 		<PackageReference Include="Microsoft.Extensions.Localization.Abstractions" />
 		<PackageReference Include="Microsoft.AspNetCore.Components" />
 		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" />

--- a/tests/bunit.tests/Rendering/BunitHtmlParserTest.cs
+++ b/tests/bunit.tests/Rendering/BunitHtmlParserTest.cs
@@ -31,7 +31,8 @@ public class BunitHtmlParserTest
 	};
 
 	public static readonly IEnumerable<object[]> BodyHtmlAndSpecialElements =
-		TheoryDataExtensions.AddRange(BodyHtmlElements.Clone(), "html", "head", "body");
+		TheoryDataExtensions.AddRange(BodyHtmlElements.Clone(), "html", "head", "body")
+			.Select(data => new object[] { data });
 
 	public static readonly TheoryData<string> SvgElements = new TheoryData<string>
 	{


### PR DESCRIPTION
Move our whole test suite from `xunit` to `xunit.v3` (incl. all its dependencies)