### PR TITLE
feat: Shared DOM

### DIFF
--- a/src/bunit/Extensions/RenderedComponentExtensions.cs
+++ b/src/bunit/Extensions/RenderedComponentExtensions.cs
@@ -92,7 +92,9 @@ public static class RenderedComponentExtensions
 		ArgumentNullException.ThrowIfNull(renderedComponent);
 
 		var renderer = renderedComponent.Services.GetRequiredService<BunitContext>().Renderer;
-		return renderer.FindComponent<TChildComponent>(renderedComponent);
+		var found = renderer.FindComponent<TChildComponent>(renderedComponent);
+		SetupSharedDom(renderedComponent, found);
+		return found;
 	}
 
 	/// <summary>
@@ -109,6 +111,11 @@ public static class RenderedComponentExtensions
 		var renderer = renderedComponent.Services.GetRequiredService<BunitContext>().Renderer;
 		var components = renderer.FindComponents<TChildComponent>(renderedComponent);
 
+		foreach (var component in components)
+		{
+			SetupSharedDom(renderedComponent, component);
+		}
+
 		return components.ToArray();
 	}
 
@@ -121,4 +128,13 @@ public static class RenderedComponentExtensions
 	/// <returns>True if the <paramref name="renderedComponent"/> contains the <typeparamref name="TChildComponent"/>; otherwise false.</returns>
 	public static bool HasComponent<TChildComponent>(this IRenderedComponent<IComponent> renderedComponent)
 		where TChildComponent : IComponent => FindComponents<TChildComponent>(renderedComponent).Count > 0;
+
+	private static void SetupSharedDom<TChildComponent>(IRenderedComponent<IComponent> parentComponent, IRenderedComponent<TChildComponent> childComponent)
+		where TChildComponent : IComponent
+	{
+		var parent = (IRenderedComponent)parentComponent;
+		var child = (IRenderedComponent)childComponent;
+		var effectiveRootId = parent.RootComponentId ?? parentComponent.ComponentId;
+		child.SetRootComponentId(effectiveRootId);
+	}
 }

--- a/src/bunit/Rendering/BunitRenderer.cs
+++ b/src/bunit/Rendering/BunitRenderer.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Logging;
+using AngleSharp.Dom;
 using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Reflection;
@@ -538,6 +539,25 @@ public sealed class BunitRenderer : Renderer
 	internal new ArrayRange<RenderTreeFrame> GetCurrentRenderTreeFrames(int componentId)
 		=> base.GetCurrentRenderTreeFrames(componentId);
 
+	private readonly Dictionary<int, INodeList> boundaryNodesCache = new();
+
+	internal INodeList GetBoundaryNodesForComponent(int componentId)
+	{
+		if (boundaryNodesCache.TryGetValue(componentId, out var cached))
+		{
+			return cached;
+		}
+
+		var htmlParser = services.GetRequiredService<BunitHtmlParser>();
+		var boundaryHtml = Htmlizer.GetHtmlWithComponentBoundaries(componentId, this);
+		var nodes = htmlParser.Parse(boundaryHtml);
+		boundaryNodesCache[componentId] = nodes;
+		return nodes;
+	}
+
+	internal void InvalidateBoundaryNodesCache(int componentId)
+		=> boundaryNodesCache.Remove(componentId);
+
 	/// <inheritdoc/>
 	protected override void Dispose(bool disposing)
 	{
@@ -615,6 +635,7 @@ public sealed class BunitRenderer : Renderer
 		{
 			ObjectDisposedException.ThrowIf(disposed, this);
 			FindComponentsInRenderTree(parentComponent.ComponentId);
+
 			foreach (var rc in result)
 			{
 				((IRenderedComponent)rc).UpdateState(hasRendered: false, isMarkupGenerationRequired: true);

--- a/src/bunit/Rendering/IRenderedComponent.cs
+++ b/src/bunit/Rendering/IRenderedComponent.cs
@@ -10,7 +10,17 @@ internal interface IRenderedComponent : IDisposable
 	int ComponentId { get; }
 
 	/// <summary>
+	/// Gets the root component ID for shared DOM resolution, or <c>null</c> if this is a root component.
+	/// </summary>
+	int? RootComponentId { get; }
+
+	/// <summary>
 	/// Called by the owning <see cref="BunitRenderer"/> when it finishes a render.
 	/// </summary>
 	void UpdateState(bool hasRendered, bool isMarkupGenerationRequired);
+
+	/// <summary>
+	/// Sets the root component ID for shared DOM resolution.
+	/// </summary>
+	void SetRootComponentId(int rootComponentId);
 }

--- a/src/bunit/Rendering/Internal/ComponentBoundaryNodeExtractor.cs
+++ b/src/bunit/Rendering/Internal/ComponentBoundaryNodeExtractor.cs
@@ -1,0 +1,69 @@
+using AngleSharp.Dom;
+
+namespace Bunit.Rendering;
+
+internal static class ComponentBoundaryNodeExtractor
+{
+	private const string BoundaryStartPrefix = "bl:";
+	private const string BoundaryEndPrefix = "/bl:";
+
+	internal static string StartMarkerFor(int componentId) => $"{BoundaryStartPrefix}{componentId}";
+
+	internal static string EndMarkerFor(int componentId) => $"{BoundaryEndPrefix}{componentId}";
+
+	internal static INodeList Extract(INodeList rootNodes, int componentId)
+	{
+		var startMarker = StartMarkerFor(componentId);
+		var endMarker = EndMarkerFor(componentId);
+		var result = new List<INode>();
+
+		CollectNodesBetweenMarkers(rootNodes, startMarker, endMarker, result);
+
+		return new ReadOnlyNodeList(result);
+	}
+
+	private static bool CollectNodesBetweenMarkers(
+		INodeList nodes,
+		string startMarker,
+		string endMarker,
+		List<INode> result)
+	{
+		for (var i = 0; i < nodes.Length; i++)
+		{
+			var node = nodes[i];
+
+			if (node is IComment comment && string.Equals(comment.Data, startMarker, StringComparison.Ordinal))
+			{
+				for (var j = i + 1; j < nodes.Length; j++)
+				{
+					var sibling = nodes[j];
+					if (sibling is IComment endComment && string.Equals(endComment.Data, endMarker, StringComparison.Ordinal))
+					{
+						return true;
+					}
+
+					if (sibling is IComment nestedMarker && IsBoundaryComment(nestedMarker))
+					{
+						continue;
+					}
+
+					result.Add(sibling);
+				}
+
+				return true;
+			}
+
+			if (node.HasChildNodes
+				&& CollectNodesBetweenMarkers(node.ChildNodes, startMarker, endMarker, result))
+			{
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	private static bool IsBoundaryComment(IComment comment) =>
+		comment.Data.StartsWith(BoundaryStartPrefix, StringComparison.Ordinal)
+		|| comment.Data.StartsWith(BoundaryEndPrefix, StringComparison.Ordinal);
+}

--- a/src/bunit/Rendering/Internal/Htmlizer.cs
+++ b/src/bunit/Rendering/Internal/Htmlizer.cs
@@ -61,6 +61,15 @@ internal static class Htmlizer
 		return context.Result.ToString();
 	}
 
+	public static string GetHtmlWithComponentBoundaries(int componentId, BunitRenderer renderer)
+	{
+		var context = new HtmlRenderingContext(renderer) { IncludeComponentBoundaries = true };
+		var frames = context.GetRenderTreeFrames(componentId);
+		var newPosition = RenderFrames(context, frames, 0, frames.Count);
+		Debug.Assert(newPosition == frames.Count);
+		return context.Result.ToString();
+	}
+
 	private static int RenderFrames(
 		HtmlRenderingContext context,
 		ArrayRange<RenderTreeFrame> frames,
@@ -131,8 +140,26 @@ internal static class Htmlizer
 	)
 	{
 		var frame = frames.Array[position];
+
+		if (context.IncludeComponentBoundaries)
+		{
+			context.Result
+				.Append("<!--")
+				.Append(ComponentBoundaryNodeExtractor.StartMarkerFor(frame.ComponentId))
+				.Append("-->");
+		}
+
 		var childFrames = context.GetRenderTreeFrames(frame.ComponentId);
 		RenderFrames(context, childFrames, 0, childFrames.Count);
+
+		if (context.IncludeComponentBoundaries)
+		{
+			context.Result
+				.Append("<!--")
+				.Append(ComponentBoundaryNodeExtractor.EndMarkerFor(frame.ComponentId))
+				.Append("-->");
+		}
+
 		return position + frame.ComponentSubtreeLength;
 	}
 
@@ -402,5 +429,7 @@ internal static class Htmlizer
 		public StringBuilder Result { get; } = new();
 
 		public string? ClosestSelectValueAsString { get; set; }
+
+		public bool IncludeComponentBoundaries { get; init; }
 	}
 }

--- a/src/bunit/Rendering/Internal/ReadOnlyNodeList.cs
+++ b/src/bunit/Rendering/Internal/ReadOnlyNodeList.cs
@@ -1,0 +1,30 @@
+using System.Collections;
+using AngleSharp;
+using AngleSharp.Dom;
+
+namespace Bunit.Rendering;
+
+internal sealed class ReadOnlyNodeList : INodeList, IReadOnlyList<INode>
+{
+	private readonly List<INode> nodes;
+
+	public ReadOnlyNodeList(List<INode> nodes) => this.nodes = nodes;
+
+	public INode this[int index] => nodes[index];
+
+	public int Length => nodes.Count;
+
+	public int Count => nodes.Count;
+
+	public IEnumerator<INode> GetEnumerator() => nodes.GetEnumerator();
+
+	IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+	public void ToHtml(TextWriter writer, IMarkupFormatter formatter)
+	{
+		foreach (var node in nodes)
+		{
+			node.ToHtml(writer, formatter);
+		}
+	}
+}

--- a/src/bunit/Rendering/RenderedComponent.cs
+++ b/src/bunit/Rendering/RenderedComponent.cs
@@ -19,6 +19,7 @@ internal sealed class RenderedComponent<TComponent> : ComponentState, IRenderedC
 
 	private string markup = string.Empty;
 	private INodeList? latestRenderNodes;
+	private int? rootComponentId;
 
 	/// <summary>
 	/// Gets the component under test.
@@ -68,6 +69,12 @@ internal sealed class RenderedComponent<TComponent> : ComponentState, IRenderedC
 		get
 		{
 			EnsureComponentNotDisposed();
+
+			if (rootComponentId.HasValue)
+			{
+				return latestRenderNodes ??= ResolveNodesFromRootDom();
+			}
+
 			return latestRenderNodes ??= htmlParser.Parse(Markup);
 		}
 	}
@@ -133,6 +140,7 @@ internal sealed class RenderedComponent<TComponent> : ComponentState, IRenderedC
 	private void UpdateMarkup()
 	{
 		latestRenderNodes = null;
+		renderer.InvalidateBoundaryNodesCache(ComponentId);
 		var newMarkup = Htmlizer.GetHtml(ComponentId, renderer);
 
 		// Volatile write is necessary to ensure the updated markup
@@ -140,6 +148,20 @@ internal sealed class RenderedComponent<TComponent> : ComponentState, IRenderedC
 		// markup string can be stored in a CPUs register and not
 		// get updated when another CPU changes the string.
 		Volatile.Write(ref markup, newMarkup);
+	}
+
+	public int? RootComponentId => rootComponentId;
+
+	public void SetRootComponentId(int rootComponentId)
+	{
+		this.rootComponentId = rootComponentId;
+		latestRenderNodes = null;
+	}
+
+	private INodeList ResolveNodesFromRootDom()
+	{
+		var fullDom = renderer.GetBoundaryNodesForComponent(rootComponentId!.Value);
+		return ComponentBoundaryNodeExtractor.Extract(fullDom, ComponentId);
 	}
 
 	/// <summary>

--- a/tests/bunit.testassets/SampleComponents/ChildSubmitButton.razor
+++ b/tests/bunit.testassets/SampleComponents/ChildSubmitButton.razor
@@ -1,0 +1,8 @@
+@namespace Bunit.TestAssets.SampleComponents
+
+<button type="submit" id="child-submit-button">Submit</button>
+
+@code {
+	[Parameter]
+	public bool ShowExtraContent { get; set; }
+}

--- a/tests/bunit.testassets/SampleComponents/FormWrapperWithChildSubmitButton.razor
+++ b/tests/bunit.testassets/SampleComponents/FormWrapperWithChildSubmitButton.razor
@@ -1,0 +1,14 @@
+@namespace Bunit.TestAssets.SampleComponents
+
+<form @onsubmit="OnFormSubmit">
+	<ChildSubmitButton />
+</form>
+
+@code {
+	public bool FormSubmitted { get; private set; }
+
+	private void OnFormSubmit()
+	{
+		FormSubmitted = true;
+	}
+}

--- a/tests/bunit.tests/Rendering/RenderedComponentTest.cs
+++ b/tests/bunit.tests/Rendering/RenderedComponentTest.cs
@@ -312,4 +312,127 @@ public class RenderedComponentTest : BunitContext
 			builder.AddContent(0, "derived");
 		}
 	}
+
+	[Fact(DisplayName = "FindComponent child button click triggers parent form onsubmit (#983)")]
+	public void Test030()
+	{
+		var cut = Render<FormWrapperWithChildSubmitButton>();
+		var child = cut.FindComponent<ChildSubmitButton>();
+
+		child.Find("#child-submit-button").Click();
+
+		cut.Instance.FormSubmitted.ShouldBeTrue();
+	}
+
+	[Fact(DisplayName = "FindComponent child nodes have correct parent form element (#983)")]
+	public void Test031()
+	{
+		var cut = Render<FormWrapperWithChildSubmitButton>();
+		var child = cut.FindComponent<ChildSubmitButton>();
+
+		var button = child.Find("#child-submit-button");
+		var parentForm = button.Closest("form");
+
+		parentForm.ShouldNotBeNull();
+		parentForm.ShouldBeAssignableTo<IHtmlFormElement>();
+	}
+
+	[Fact(DisplayName = "FindComponent child Markup only contains child own HTML")]
+	public void Test032()
+	{
+		var cut = Render<FormWrapperWithChildSubmitButton>();
+		var child = cut.FindComponent<ChildSubmitButton>();
+
+		child.Markup.ShouldNotContain("<form");
+		child.Markup.ShouldContain("child-submit-button");
+	}
+
+	[Fact(DisplayName = "FindComponent root Nodes still work correctly")]
+	public void Test033()
+	{
+		var cut = Render<FormWrapperWithChildSubmitButton>();
+
+		var form = cut.Find("form");
+
+		form.ShouldNotBeNull();
+		form.ShouldBeAssignableTo<IHtmlFormElement>();
+	}
+
+	[Fact(DisplayName = "FindComponent child nodes have parent context after parent re-render")]
+	public void Test034()
+	{
+		var cut = Render<FormWrapperWithChildSubmitButton>();
+		var child = cut.FindComponent<ChildSubmitButton>();
+
+		child.Find("#child-submit-button").Click();
+		cut.Instance.FormSubmitted.ShouldBeTrue();
+
+		var button = child.Find("#child-submit-button");
+		button.Closest("form").ShouldNotBeNull();
+	}
+
+	[Fact(DisplayName = "FindComponent direct Find on parent still triggers form submit")]
+	public void Test035()
+	{
+		var cut = Render<FormWrapperWithChildSubmitButton>();
+
+		cut.Find("#child-submit-button").Click();
+
+		cut.Instance.FormSubmitted.ShouldBeTrue();
+	}
+
+	[Fact(DisplayName = "Nested FindComponent preserves root DOM context")]
+	public void Test036()
+	{
+		var wrapper = Render<TwoComponentWrapper>(builder => builder
+			.Add<Wrapper>(p => p.First, wrapper => wrapper
+				.AddChildContent<Simple1>(simple1 => simple1
+					.Add(p => p.Header, "nested")))
+			.Add<Simple1>(p => p.Second, simple1 => simple1
+				.Add(p => p.Header, "Second")));
+
+		var wrapperComponent = wrapper.FindComponent<Wrapper>();
+		var simple1 = wrapperComponent.FindComponent<Simple1>();
+
+		simple1.Instance.Header.ShouldBe("nested");
+		simple1.Find("h1").TextContent.ShouldBe("nested");
+	}
+
+	[Fact(DisplayName = "FindComponent child Nodes length matches isolated rendering")]
+	public void Test037()
+	{
+		var cut = Render<FormWrapperWithChildSubmitButton>();
+		var child = cut.FindComponent<ChildSubmitButton>();
+
+		child.Nodes.Length.ShouldBeGreaterThan(0);
+		child.Find("#child-submit-button").ShouldNotBeNull();
+	}
+
+	[Fact(DisplayName = "Multiple FindComponent calls return components with correct shared DOM")]
+	public void Test038()
+	{
+		var wrapper = Render<TwoComponentWrapper>(builder => builder
+			.Add<Simple1>(p => p.First, s => s.Add(p => p.Header, "First"))
+			.Add<Simple1>(p => p.Second, s => s.Add(p => p.Header, "Second")));
+
+		var components = wrapper.FindComponents<Simple1>();
+
+		components.Count.ShouldBe(2);
+		components[0].Find("h1").TextContent.ShouldBe("First");
+		components[1].Find("h1").TextContent.ShouldBe("Second");
+	}
+
+	[Fact(DisplayName = "FindComponent child has parent element from root DOM tree")]
+	public void Test039()
+	{
+		var wrapper = Render<TwoComponentWrapper>(builder => builder
+			.Add<Simple1>(p => p.First, s => s.Add(p => p.Header, "InDiv"))
+			.Add<Simple1>(p => p.Second));
+
+		var child = wrapper.FindComponent<Simple1>();
+		var heading = child.Find("h1");
+
+		heading.ParentElement.ShouldNotBeNull();
+		heading.ParentElement!.LocalName.ShouldBe("div");
+	}
 }


### PR DESCRIPTION
## Pull request description
This PR tackles mainly #983 - where we try to have a shared dom. This approach works as follows:
 1. When creating the HTML, we add additional comments with the component id in the markup (that might break tests!! that rely on string comparison not utilizing anglesharp)
 2. We keep a map of componentId -> NodeList (basically where are the boundaries per component)
 3. When using Nodes from `IRenderedComponent<T>` we try to find the root and return it's nodelist! Therefore all children share basically the same node list

This basically "fixes" the issue in 983. More of an idea / play than something we have to go forward with.