### PR TITLE
fix: guard BunitHtmlParser.documents against concurrent access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to **bUnit** will be documented in this file. The project ad
 
 ## [Unreleased]
 
+### Fixed
+
+- `BunitHtmlParser.Dispose()` no longer throws `InvalidOperationException: Collection was modified` when a parse is in flight on another thread, which surfaced as an intermittent failure during test teardown against a random test. Reported and fixed by [@thimobuchheister](https://github.com/thimobuchheister) in #1892.
+
 ## [2.9.0] - 2026-08-03
 
 ### Changed

--- a/src/bunit/Rendering/BunitHtmlParser.cs
+++ b/src/bunit/Rendering/BunitHtmlParser.cs
@@ -23,6 +23,7 @@ internal sealed class BunitHtmlParser : IDisposable
 	private readonly IBrowsingContext context;
 	private readonly HtmlParser htmlParser;
 	private readonly List<IDocument> documents = new();
+	private readonly object documentsLock = new();
 
 	/// <summary>
 	/// Initializes a new instance of the <see cref="BunitHtmlParser"/> class
@@ -151,7 +152,12 @@ internal sealed class BunitHtmlParser : IDisposable
 	private async Task<IDocument> GetNewDocumentAsync()
 	{
 		var result = await context.OpenNewAsync().ConfigureAwait(false);
-		documents.Add(result);
+
+		lock (documentsLock)
+		{
+			documents.Add(result);
+		}
+
 		return result;
 	}
 
@@ -159,7 +165,21 @@ internal sealed class BunitHtmlParser : IDisposable
 	public void Dispose()
 	{
 		context.Dispose();
-		foreach (var doc in documents)
+
+		// Parse() can be running on another thread while this executes, e.g. a
+		// WaitForAssertion/WaitForState condition being evaluated on the
+		// renderer's dispatcher while the test's BunitContext is being
+		// disposed. Take a snapshot under the lock instead of enumerating the
+		// live list, which would otherwise throw "Collection was modified" if a
+		// parse completed mid-loop.
+		IDocument[] documentsToDispose;
+		lock (documentsLock)
+		{
+			documentsToDispose = documents.ToArray();
+			documents.Clear();
+		}
+
+		foreach (var doc in documentsToDispose)
 		{
 			doc.Dispose();
 		}

--- a/tests/bunit.tests/Rendering/BunitHtmlParserTest.cs
+++ b/tests/bunit.tests/Rendering/BunitHtmlParserTest.cs
@@ -1,4 +1,7 @@
 using System;
+using System.Collections.Concurrent;
+using System.Threading;
+using System.Threading.Tasks;
 using AngleSharp.Dom;
 using AngleSharp.Html.Dom;
 using Xunit;
@@ -168,6 +171,51 @@ public class BunitHtmlParserTest
 		actual.Length.ShouldBe(2);
 		actual[0].ShouldBeAssignableTo<IDocumentType>();
 		actual[1].ShouldBeAssignableTo<IHtmlHtmlElement>();
+	}
+
+	[Fact]
+	public async Task Dispose_does_not_throw_while_another_thread_is_parsing()
+	{
+		var disposeExceptions = new ConcurrentBag<Exception>();
+
+		for (var i = 0; i < 100; i++)
+		{
+			using var cts = new CancellationTokenSource();
+			using var parser = new BunitHtmlParser();
+
+			var parsing = Task.Run(
+				() =>
+				{
+					while (!cts.IsCancellationRequested)
+					{
+						try
+						{
+							parser.Parse("<p>Hello world</p>");
+						}
+						catch (Exception)
+						{
+							// This loop deliberately races Dispose(), so its own
+							// failures are expected and are not what is under test.
+							// Only Dispose() itself is asserted on below.
+						}
+					}
+				},
+				Xunit.TestContext.Current.CancellationToken);
+
+			// Give the parsing loop a moment to get into Parse().
+			await Task.Delay(1, Xunit.TestContext.Current.CancellationToken);
+
+			var exception = Record.Exception(parser.Dispose);
+			if (exception is not null)
+			{
+				disposeExceptions.Add(exception);
+			}
+
+			await cts.CancelAsync();
+			await parsing;
+		}
+
+		disposeExceptions.ShouldBeEmpty();
 	}
 
 	private static void VerifyElementParsedWithId(string expectedElementName, List<INode> actual)


### PR DESCRIPTION
## Pull request description

Fixes #1892.

`BunitHtmlParser` keeps its parsed documents in a plain `List<IDocument>`. `Parse()` adds to it and `Dispose()` enumerates it, and the two can run on different threads, producing an intermittent teardown failure that names an innocent test:

```text
System.InvalidOperationException : Collection was modified; enumeration operation may not execute.
   at System.Collections.Generic.List`1.Enumerator.MoveNext()
   at Bunit.Rendering.BunitHtmlParser.Dispose() in /_/src/bunit/Rendering/BunitHtmlParser.cs:line 162
   at Microsoft.Extensions.DependencyInjection.ServiceLookup.ServiceProviderEngineScope.Dispose()
```

**Why the two sides overlap:** `WaitForHelper` evaluates its condition on the renderer's dispatcher (`OnAfterRender` calls `completeChecker()` directly), so `cut.Find(…)` inside a `WaitForAssertion` parses on the dispatcher thread. `BunitContext.Dispose(bool)` meanwhile runs `bunitRenderer?.Dispose()` then `Services.Dispose()` on the test thread — and its "ensure the renderer is disposed before all others" comment does not hold in practice, because `BunitRenderer.Dispose(bool)` ends with `Dispatcher.InvokeAsync(() => base.Dispose(disposing));` and drops the returned task. Renderer disposal is asynchronous and unawaited, so the parser can be disposed mid-parse. Full trace in the issue.

**The change** is deliberately minimal — a dedicated lock object guarding `documents`, and `Dispose()` disposing a snapshot rather than the live list:

```csharp
IDocument[] documentsToDispose;
lock (documentsLock)
{
    documentsToDispose = documents.ToArray();
    documents.Clear();
}

foreach (var doc in documentsToDispose)
{
    doc.Dispose();
}
```

I deliberately did **not** try to fix the unawaited `Dispatcher.InvokeAsync` in `BunitRenderer.Dispose()`, even though it is the reason the two sides overlap at all. That is a behavioural change to teardown ordering with a much wider blast radius, and making the parser thread-safe fixes the reported crash on its own. Happy to look at it separately if you would like.

One residual worth naming: a document whose parse completes *after* `Dispose()` has taken its snapshot will not be disposed by the parser. That was already true before this change (it would have been added to a list nobody reads again), and closing it properly means deciding what `Parse()` should do on a disposed parser — out of scope here, but I can follow up.

### Verification

New test `Dispose_does_not_throw_while_another_thread_is_parsing` in `BunitHtmlParserTest`. It reaches the race through the parser directly, so it needs no renderer. Measured on net10.0, 100 iterations per run:

| | Result |
|---|---|
| Without the fix | **0/5 runs passed** |
| With the fix | **5/5 runs passed** (and 10/10 on an earlier shape of the test) |

`dotnet test tests/bunit.tests -c Release` — **2266/2266 passing**, no new warnings (checked in Release, where `TreatWarningsAsErrors` is on).

Caveat on my local verification: my SDK is 10.0.400-preview, which cannot target `net11.0`, so I built and ran against `net10.0` only. The change uses nothing version-specific (`lock` + `List<T>.ToArray()`), so I would expect the other TFMs to be unaffected, but CI will be the real check.

### PR meta checklist
- [x] Pull request is targeted at `main` branch for code   
  or targeted at `stable` branch for documentation that is live on bunit.dev.
- [x] Pull request is linked to all related issues, if any.
- [x] I have read the _CONTRIBUTING.md_ document.

### Code PR specific checklist
- [x] My code follows the code style of this project and AspNetCore coding guidelines.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] I have updated the appropriate sub section in the _CHANGELOG.md_.
- [x] I have added, updated or removed tests to according to my changes.
  - [x] All tests passed.
